### PR TITLE
chore(console): use AGT Container for panel layout

### DIFF
--- a/console/src/AgentStatus.tsx
+++ b/console/src/AgentStatus.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useEffect, useState } from "react";
+import { Container } from "automated-gameplay-transmitter";
 import type { ReactNode } from "react";
+import { useCallback, useEffect, useState } from "react";
+import { cloneAgentStateResponseMockFixture } from "../../tests/fixtures/agentStateResponseMock";
+import type { AgentStatusRow } from "./agentStatusSections/AgentStatusSectionCard";
 import { GAME_SECTION_TITLE, GameStatusSection } from "./agentStatusSections/GameStatusSection";
 import { LIVE_DELIVERY_SECTION_TITLE, LiveDeliveryStatusSection } from "./agentStatusSections/LiveDeliveryStatusSection";
 import { MARKOV_MODEL_SECTION_TITLE, MarkovModelStatusSection } from "./agentStatusSections/MarkovModelStatusSection";
-import type { AgentStatusRow } from "./agentStatusSections/AgentStatusSectionCard";
-import { cloneAgentStateResponseMockFixture } from "../../tests/fixtures/agentStateResponseMock";
 
 /**
  * Response schema returned by `/console/api/agent-state`.
@@ -493,12 +494,14 @@ export function AgentStatus() {
           </button>
         </div>
         {isShowingMockAgentState ? (
-          <div
-            data-testid="agent-status-mock-notice"
-            className="w-full bg-emerald-950/70 border-2 border-emerald-300 rounded-xl p-3 text-emerald-50"
-          >
-            {AGENT_STATE_MOCK_NOTICE_MESSAGE}
-          </div>
+          <Container>
+            <div
+              data-testid="agent-status-mock-notice"
+              className="w-full bg-emerald-950/70 border-2 border-emerald-300 rounded-xl p-3 text-emerald-50"
+            >
+              {AGENT_STATE_MOCK_NOTICE_MESSAGE}
+            </div>
+          </Container>
         ) : null}
         {agentStatusError ? (
           <div
@@ -510,12 +513,14 @@ export function AgentStatus() {
         ) : null}
       </div>
       {agentStatusSections.length === 0 ? (
-        <div
-          data-testid="agent-status-empty"
-          className="w-full min-h-[80px] bg-emerald-950/70 border-2 border-emerald-300 rounded-xl p-3 text-emerald-50"
-        >
-          {isLoadingAgentState ? "読み込み中..." : "配信情報はありません。"}
-        </div>
+        <Container>
+          <div
+            data-testid="agent-status-empty"
+            className="w-full min-h-[80px] bg-emerald-950/70 border-2 border-emerald-300 rounded-xl p-3 text-emerald-50"
+          >
+            {isLoadingAgentState ? "読み込み中..." : "配信情報はありません。"}
+          </div>
+        </Container>
       ) : (
         <div
           data-testid="agent-status-details"

--- a/console/src/agentStatusSections/AgentStatusSectionCard.tsx
+++ b/console/src/agentStatusSections/AgentStatusSectionCard.tsx
@@ -1,3 +1,4 @@
+import { Container } from "automated-gameplay-transmitter";
 import type { ReactNode } from "react";
 
 export type AgentStatusRow = {
@@ -22,27 +23,29 @@ type AgentStatusSectionCardProps = {
 
 export const AgentStatusSectionCard = ({ title, rows }: AgentStatusSectionCardProps) => {
   return (
-    <section className="bg-emerald-950/70 border-2 border-emerald-300 rounded-xl p-3 text-emerald-50 min-w-0 h-full overflow-hidden flex flex-col">
-      <h3 className="text-lg font-bold mb-2">{title}</h3>
-      <dl className="min-h-0 flex-1 grid content-start items-start grid-cols-[10rem_minmax(0,1fr)] gap-x-4 gap-y-2 overflow-y-auto pr-1">
-        {rows.map((row) => (
-          <div
-            key={`${title}:${row.label}:${"value" in row ? row.value : "value-component"}:${row.href ?? "-"}`}
-            className="contents"
-          >
-            <dt className={row.hideLabel ? "hidden" : "font-bold whitespace-nowrap"}>{row.label}</dt>
-            <dd className={[row.valueComponent ? "break-words" : "break-all", row.hideLabel ? "col-span-2" : ""].join(" ").trim()}>
-              {row.valueComponent ?? (row.href ? (
-                <a className="underline" href={row.href} target="_blank" rel="noreferrer">
-                  {row.value}
-                </a>
-              ) : (
-                row.value
-              ))}
-            </dd>
-          </div>
-        ))}
-      </dl>
-    </section>
+    <Container>
+      <section className="bg-emerald-950/70 border-2 border-emerald-300 rounded-xl p-3 text-emerald-50 min-w-0 h-full overflow-hidden flex flex-col">
+        <h3 className="text-lg font-bold mb-2">{title}</h3>
+        <dl className="min-h-0 flex-1 grid content-start items-start grid-cols-[10rem_minmax(0,1fr)] gap-x-4 gap-y-2 overflow-y-auto pr-1">
+          {rows.map((row) => (
+            <div
+              key={`${title}:${row.label}:${"value" in row ? row.value : "value-component"}:${row.href ?? "-"}`}
+              className="contents"
+            >
+              <dt className={row.hideLabel ? "hidden" : "font-bold whitespace-nowrap"}>{row.label}</dt>
+              <dd className={[row.valueComponent ? "break-words" : "break-all", row.hideLabel ? "col-span-2" : ""].join(" ").trim()}>
+                {row.valueComponent ?? (row.href ? (
+                  <a className="underline" href={row.href} target="_blank" rel="noreferrer">
+                    {row.value}
+                  </a>
+                ) : (
+                  row.value
+                ))}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      </section>
+    </Container>
   );
 };


### PR DESCRIPTION
Replace local Container with AGT's Container and centralize panel layout.

Changes:
- Remove local console/src/components/Container.tsx
- Use automated-gameplay-transmitter's Container in AgentStatus and AgentStatusSectionCard
- Organize imports

Tests:
- Typecheck: passed
- Unit/Integration tests: passed
- Playwright E2E: some environment-dependent failures observed locally (not caused by UI import changes)

Please review.