### PR TITLE
fix(agent): call prompt TTS out-of-band when viewers increase during silence (#202)

### DIFF
--- a/lib/Agent/index.test.ts
+++ b/lib/Agent/index.test.ts
@@ -200,6 +200,60 @@ describe('speechable', () => {
     expect(agent.speechable).toBeTrue();
   });
 
+  it('prompts immediately even when main speech is blocked', async () => {
+    jest.spyOn(Date, 'now').mockReturnValue(0);
+    const called = jest.fn(async (text: string) => {
+      if (text === 'main-block') {
+        return new Promise<void>(() => {});
+      }
+      return;
+    });
+    const spyTts: TTS = { speech: called as any };
+    const agent = new MakaMujo(stubTalkModel, spyTts);
+    agent.onAir(niconamaLive(10));
+    agent.listen([viewerComment]);
+
+    jest.spyOn(Date, 'now').mockReturnValue(SILENCE_THRESHOLD_MS);
+    expect(agent.speechable).toBeFalse();
+
+    // Start a long-running main speech without awaiting it
+    agent.speech('main-block');
+    // viewer count changes — should prompt immediately even while main speech is pending
+    agent.onAir(niconamaLive(11));
+    // allow scheduled tasks to run
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(called).toHaveBeenCalledWith('コメントしていってね〜');
+    expect(agent.speechable).toBeFalse();
+  });
+
+  it('clears prompt-flag if prompt playback fails while main speech blocked', async () => {
+    jest.spyOn(Date, 'now').mockReturnValue(0);
+    const fail = jest.fn(async (text: string) => {
+      if (text === 'main-block') {
+        return new Promise<void>(() => {});
+      }
+      if (text === 'コメントしていってね〜') {
+        return Promise.reject(new Error('boom'));
+      }
+      return;
+    });
+    const failTts: TTS = { speech: fail as any };
+    const agent = new MakaMujo(stubTalkModel, failTts);
+    agent.onAir(niconamaLive(10));
+    agent.listen([viewerComment]);
+
+    jest.spyOn(Date, 'now').mockReturnValue(SILENCE_THRESHOLD_MS);
+    expect(agent.speechable).toBeFalse();
+
+    agent.speech('main-block');
+    agent.onAir(niconamaLive(11));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(fail).toHaveBeenCalledWith('コメントしていってね〜');
+    expect(agent.speechable).toBeTrue();
+  });
+
   it('should be true again after stream goes offline following silence', () => {
     jest.spyOn(Date, 'now').mockReturnValue(0);
     const agent = new MakaMujo(stubTalkModel, stubTts);

--- a/lib/Agent/index.ts
+++ b/lib/Agent/index.ts
@@ -266,17 +266,14 @@ export class MakaMujo {
             if (hadCommentBefore && commentsStale) {
               if (!this.#hasPromptedCommentForViewerIncrease) {
                 this.#hasPromptedCommentForViewerIncrease = true;
-                // Queue the prompt by chaining a direct TTS call onto the
-                // internal speech promise. This ensures the prompt runs in
-                // order with other queued speech, but lets us catch
-                // failures specifically for this prompt so we can reset the
-                // prompted flag when playback fails.
-                const ttsTask = this.#speechPromise.then(() => this.#tts.speech('コメントしていってね〜'));
-                this.#speechPromise = ttsTask.catch(() => Promise.resolve());
-                void ttsTask.catch((err) => {
+                // Call the prompt playback out-of-band so it doesn't wait on
+                // the main speech queue. If the prompt playback fails, clear
+                // the prompted flag so the agent can try again later.
+                const ttsTask = this.#tts.speech('コメントしていってね〜').catch((err) => {
                   console.error('[ERROR]', 'prompting comment failed', err);
                   this.#hasPromptedCommentForViewerIncrease = false;
                 });
+                void ttsTask;
               }
             }
           }


### PR DESCRIPTION
Fixes: ensure the viewer-increase comment prompt is attempted immediately even when the main speech queue is blocked.

Changes:
- Call `TTS.speech('コメントしていってね〜')` out-of-band instead of chaining on the internal `#speechPromise` to avoid the prompt waiting for a blocked main speech task.
- Add unit tests reproducing the blocked-main-speech scenario and verifying prompt behavior:
  - `prompts immediately even when main speech is blocked`
  - `clears prompt-flag if prompt playback fails while main speech blocked`

This addresses https://github.com/nahcnuj/makamujo/issues/202.