### PR TITLE
fix: prevent TSX parse error in embedded browsers (#218)

### DIFF
--- a/lib/Agent/index.ts
+++ b/lib/Agent/index.ts
@@ -300,7 +300,8 @@ export class MakaMujo {
                 // handler to clear the prompted flag if playback fails.
                 const clearOnError = (text: string, err: unknown) => {
                   if (text === promptText) {
-                    console.error('[ERROR]', 'prompting comment failed', err);
+                    const msg = err instanceof Error ? err.message : String(err);
+                    console.error('[ERROR]', 'prompting comment failed', msg);
                     this.#hasPromptedCommentForViewerIncrease = false;
                     this.#ttsErrorHandlers = this.#ttsErrorHandlers.filter(h => h !== clearOnError);
                   }

--- a/src/catchAll.ts
+++ b/src/catchAll.ts
@@ -69,8 +69,12 @@ export function handleCatchAll(req: Request): Response {
           const lines = out.split('\n');
           let insertAt = 0;
           for (let i = 0; i < lines.length; i++) {
+<<<<<<< HEAD
             const line = lines[i] ?? '';
             if (/^import\s/.test(line)) insertAt = i + 1;
+=======
+            if (/^import\s/.test(lines[i])) insertAt = i + 1;
+>>>>>>> 03251b5 (fix: prevent TSX parse error in embedded browsers (#218))
           }
           lines.splice(insertAt, 0, "import React from 'react';");
           out = lines.join('\n');

--- a/src/catchAll.ts
+++ b/src/catchAll.ts
@@ -1,5 +1,63 @@
-import { readFileSync } from "node:fs";
+export function handleCatchAll(req: Request): Response {
+  const url = new URL(req.url);
+  const path = url.pathname;
+  const accept = req.headers.get('accept') ?? '';
+  try { console.log('[TRACE] catch-all matched path=', path, 'accept=', accept); } catch {}
 
+  // If the client explicitly accepts HTML (browser navigation) or
+  // this is the root path, serve the SPA entrypoint.
+  if (accept.includes('text/html') || path === '/') {
+    try {
+      return new Response(Bun.file('./src/index.html'), {
+        headers: { 'Content-Type': 'text/html; charset=utf-8' },
+      });
+    } catch (err) {
+      try { console.error('[ERROR] failed to serve index.html', err); } catch {}
+      return Response.json({}, { status: 500 });
+    }
+  }
+
+  // Try to resolve static/module files from ./src and ./src/public.
+  const candidates = [
+    `./src${path}`,
+    `./src${path}.tsx`,
+    `./src${path}.ts`,
+    `./src${path}.jsx`,
+    `./src${path}.js`,
+    `./src${path}.mjs`,
+    `./src${path}.css`,
+    `./src${path}.html`,
+    `./src/public${path}`,
+    `./src/public${path}.png`,
+    `./src/public${path}.svg`,
+  ];
+
+  for (const p of candidates) {
+    try {
+      const file = Bun.file(p);
+      const ct = p.endsWith('.css') ? 'text/css; charset=utf-8'
+        : p.match(/\.tsx$|\.ts$|\.jsx$|\.js$|\.mjs$/) ? 'application/javascript; charset=utf-8'
+        : p.endsWith('.html') ? 'text/html; charset=utf-8'
+        : p.endsWith('.png') ? 'image/png'
+        : p.endsWith('.svg') ? 'image/svg+xml'
+        : undefined;
+      return new Response(file, ct ? { headers: { 'Content-Type': ct } } : undefined);
+    } catch (err) {
+      // File not found or unreadable; try next candidate.
+    }
+  }
+
+  // If nothing matched, fall back to serving index.html to keep SPA
+  // navigation working for unknown routes.
+  try {
+    return new Response(Bun.file('./src/index.html'), {
+      headers: { 'Content-Type': 'text/html; charset=utf-8' },
+    });
+  } catch (err) {
+    try { console.error('[ERROR] failed to serve index.html', err); } catch {}
+    return Response.json({}, { status: 500 });
+  }
+}
 export function handleCatchAll(req: Request): Response {
   const url = new URL(req.url);
   const path = url.pathname;
@@ -15,6 +73,7 @@ export function handleCatchAll(req: Request): Response {
       const accept = req.headers.get('accept') ?? '';
       try { console.log('[TRACE] catch-all matched path=', path, 'accept=', accept); } catch {}
 
+<<<<<<< HEAD
       // If the client explicitly accepts HTML (browser navigation) or
       // this is the root path, serve the SPA entrypoint.
       if (accept.includes('text/html') || path === '/') {
@@ -42,6 +101,37 @@ export function handleCatchAll(req: Request): Response {
         `./src/public${path}.png`,
         `./src/public${path}.svg`,
       ];
+=======
+  // Try to resolve static/module files from ./src and ./src/public.
+  const candidates = [
+    `./src${path}`,
+    `./src${path}.tsx`,
+    `./src${path}.ts`,
+    `./src${path}.jsx`,
+    `./src${path}.js`,
+    `./src${path}.mjs`,
+    `./src${path}.css`,
+    `./src${path}.html`,
+    `./src/public${path}`,
+    `./src/public${path}.png`,
+    `./src/public${path}.svg`,
+  ];
+
+  for (const p of candidates) {
+    try {
+      const file = Bun.file(p);
+      const ct = p.endsWith('.css') ? 'text/css; charset=utf-8'
+        : p.match(/\.tsx$|\.ts$|\.jsx$|\.js$|\.mjs$/) ? 'application/javascript; charset=utf-8'
+        : p.endsWith('.html') ? 'text/html; charset=utf-8'
+        : p.endsWith('.png') ? 'image/png'
+        : p.endsWith('.svg') ? 'image/svg+xml'
+        : undefined;
+      return new Response(file, ct ? { headers: { 'Content-Type': ct } } : undefined);
+    } catch (err) {
+      // File not found or unreadable; try next candidate.
+    }
+  }
+>>>>>>> da70749 (chore: rely on Bun.serve/native asset handling (revert custom TSX transform))
 
       for (const p of candidates) {
         try {

--- a/src/catchAll.ts
+++ b/src/catchAll.ts
@@ -67,6 +67,66 @@ export function handleCatchAll(req: Request): Response {
   // If the client explicitly accepts HTML (browser navigation) or
   // this is the root path, serve the SPA entrypoint.
   if (accept.includes('text/html') || path === '/') {
+    try {
+      return new Response(Bun.file('./src/index.html'), {
+        headers: { 'Content-Type': 'text/html; charset=utf-8' },
+      });
+    } catch (err) {
+      try { console.error('[ERROR] failed to serve index.html', err); } catch {}
+      return Response.json({}, { status: 500 });
+    }
+  }
+
+  // Try to resolve static/module files from ./src and ./src/public.
+  const candidates = [
+    `./src${path}`,
+    `./src${path}.tsx`,
+    `./src${path}.ts`,
+    `./src${path}.jsx`,
+    `./src${path}.js`,
+    `./src${path}.mjs`,
+    `./src${path}.css`,
+    `./src${path}.html`,
+    `./src/public${path}`,
+    `./src/public${path}.png`,
+    `./src/public${path}.svg`,
+  ];
+
+  for (const p of candidates) {
+    try {
+      const file = Bun.file(p);
+      const ct = p.endsWith('.css') ? 'text/css; charset=utf-8'
+        : p.match(/\.tsx$|\.ts$|\.jsx$|\.js$|\.mjs$/) ? 'application/javascript; charset=utf-8'
+        : p.endsWith('.html') ? 'text/html; charset=utf-8'
+        : p.endsWith('.png') ? 'image/png'
+        : p.endsWith('.svg') ? 'image/svg+xml'
+        : undefined;
+      return new Response(file, ct ? { headers: { 'Content-Type': ct } } : undefined);
+    } catch (err) {
+      // File not found or unreadable; try next candidate.
+    }
+  }
+
+  // If nothing matched, fall back to serving index.html to keep SPA
+  // navigation working for unknown routes.
+  try {
+    return new Response(Bun.file('./src/index.html'), {
+      headers: { 'Content-Type': 'text/html; charset=utf-8' },
+    });
+  } catch (err) {
+    try { console.error('[ERROR] failed to serve index.html', err); } catch {}
+    return Response.json({}, { status: 500 });
+  }
+}
+export function handleCatchAll(req: Request): Response {
+  const url = new URL(req.url);
+  const path = url.pathname;
+  const accept = req.headers.get('accept') ?? '';
+  try { console.log('[TRACE] catch-all matched path=', path, 'accept=', accept); } catch {}
+
+  // If the client explicitly accepts HTML (browser navigation) or
+  // this is the root path, serve the SPA entrypoint.
+  if (accept.includes('text/html') || path === '/') {
     export function handleCatchAll(req: Request): Response {
       const url = new URL(req.url);
       const path = url.pathname;

--- a/src/catchAll.ts
+++ b/src/catchAll.ts
@@ -1,11 +1,10 @@
+// FIXED: single implementation of handleCatchAll
 export function handleCatchAll(req: Request): Response {
   const url = new URL(req.url);
   const path = url.pathname;
   const accept = req.headers.get('accept') ?? '';
   try { console.log('[TRACE] catch-all matched path=', path, 'accept=', accept); } catch {}
 
-  // If the client explicitly accepts HTML (browser navigation) or
-  // this is the root path, serve the SPA entrypoint.
   if (accept.includes('text/html') || path === '/') {
     try {
       return new Response(Bun.file('./src/index.html'), {
@@ -17,7 +16,6 @@ export function handleCatchAll(req: Request): Response {
     }
   }
 
-  // Try to resolve static/module files from ./src and ./src/public.
   const candidates = [
     `./src${path}`,
     `./src${path}.tsx`,
@@ -43,12 +41,10 @@ export function handleCatchAll(req: Request): Response {
         : undefined;
       return new Response(file, ct ? { headers: { 'Content-Type': ct } } : undefined);
     } catch (err) {
-      // File not found or unreadable; try next candidate.
+      // try next
     }
   }
 
-  // If nothing matched, fall back to serving index.html to keep SPA
-  // navigation working for unknown routes.
   try {
     return new Response(Bun.file('./src/index.html'), {
       headers: { 'Content-Type': 'text/html; charset=utf-8' },
@@ -58,165 +54,3 @@ export function handleCatchAll(req: Request): Response {
     return Response.json({}, { status: 500 });
   }
 }
-export function handleCatchAll(req: Request): Response {
-  const url = new URL(req.url);
-  const path = url.pathname;
-  const accept = req.headers.get('accept') ?? '';
-  try { console.log('[TRACE] catch-all matched path=', path, 'accept=', accept); } catch {}
-
-  // If the client explicitly accepts HTML (browser navigation) or
-  // this is the root path, serve the SPA entrypoint.
-  if (accept.includes('text/html') || path === '/') {
-    try {
-      return new Response(Bun.file('./src/index.html'), {
-        headers: { 'Content-Type': 'text/html; charset=utf-8' },
-      });
-    } catch (err) {
-      try { console.error('[ERROR] failed to serve index.html', err); } catch {}
-      return Response.json({}, { status: 500 });
-    }
-  }
-
-  // Try to resolve static/module files from ./src and ./src/public.
-  const candidates = [
-    `./src${path}`,
-    `./src${path}.tsx`,
-    `./src${path}.ts`,
-    `./src${path}.jsx`,
-    `./src${path}.js`,
-    `./src${path}.mjs`,
-    `./src${path}.css`,
-    `./src${path}.html`,
-    `./src/public${path}`,
-    `./src/public${path}.png`,
-    `./src/public${path}.svg`,
-  ];
-
-  for (const p of candidates) {
-    try {
-      const file = Bun.file(p);
-      const ct = p.endsWith('.css') ? 'text/css; charset=utf-8'
-        : p.match(/\.tsx$|\.ts$|\.jsx$|\.js$|\.mjs$/) ? 'application/javascript; charset=utf-8'
-        : p.endsWith('.html') ? 'text/html; charset=utf-8'
-        : p.endsWith('.png') ? 'image/png'
-        : p.endsWith('.svg') ? 'image/svg+xml'
-        : undefined;
-      return new Response(file, ct ? { headers: { 'Content-Type': ct } } : undefined);
-    } catch (err) {
-      // File not found or unreadable; try next candidate.
-    }
-  }
-
-  // If nothing matched, fall back to serving index.html to keep SPA
-  // navigation working for unknown routes.
-  try {
-    return new Response(Bun.file('./src/index.html'), {
-      headers: { 'Content-Type': 'text/html; charset=utf-8' },
-    });
-  } catch (err) {
-    try { console.error('[ERROR] failed to serve index.html', err); } catch {}
-    return Response.json({}, { status: 500 });
-  }
-}
-export function handleCatchAll(req: Request): Response {
-  const url = new URL(req.url);
-  const path = url.pathname;
-  const accept = req.headers.get('accept') ?? '';
-  try { console.log('[TRACE] catch-all matched path=', path, 'accept=', accept); } catch {}
-
-  // If the client explicitly accepts HTML (browser navigation) or
-  // this is the root path, serve the SPA entrypoint.
-  if (accept.includes('text/html') || path === '/') {
-    export function handleCatchAll(req: Request): Response {
-      const url = new URL(req.url);
-      const path = url.pathname;
-      const accept = req.headers.get('accept') ?? '';
-      try { console.log('[TRACE] catch-all matched path=', path, 'accept=', accept); } catch {}
-
-<<<<<<< HEAD
-      // If the client explicitly accepts HTML (browser navigation) or
-      // this is the root path, serve the SPA entrypoint.
-      if (accept.includes('text/html') || path === '/') {
-        try {
-          return new Response(Bun.file('./src/index.html'), {
-            headers: { 'Content-Type': 'text/html; charset=utf-8' },
-          });
-        } catch (err) {
-          try { console.error('[ERROR] failed to serve index.html', err); } catch {}
-          return Response.json({}, { status: 500 });
-        }
-      }
-
-      // Try to resolve static/module files from ./src and ./src/public.
-      const candidates = [
-        `./src${path}`,
-        `./src${path}.tsx`,
-        `./src${path}.ts`,
-        `./src${path}.jsx`,
-        `./src${path}.js`,
-        `./src${path}.mjs`,
-        `./src${path}.css`,
-        `./src${path}.html`,
-        `./src/public${path}`,
-        `./src/public${path}.png`,
-        `./src/public${path}.svg`,
-      ];
-=======
-  // Try to resolve static/module files from ./src and ./src/public.
-  const candidates = [
-    `./src${path}`,
-    `./src${path}.tsx`,
-    `./src${path}.ts`,
-    `./src${path}.jsx`,
-    `./src${path}.js`,
-    `./src${path}.mjs`,
-    `./src${path}.css`,
-    `./src${path}.html`,
-    `./src/public${path}`,
-    `./src/public${path}.png`,
-    `./src/public${path}.svg`,
-  ];
-
-  for (const p of candidates) {
-    try {
-      const file = Bun.file(p);
-      const ct = p.endsWith('.css') ? 'text/css; charset=utf-8'
-        : p.match(/\.tsx$|\.ts$|\.jsx$|\.js$|\.mjs$/) ? 'application/javascript; charset=utf-8'
-        : p.endsWith('.html') ? 'text/html; charset=utf-8'
-        : p.endsWith('.png') ? 'image/png'
-        : p.endsWith('.svg') ? 'image/svg+xml'
-        : undefined;
-      return new Response(file, ct ? { headers: { 'Content-Type': ct } } : undefined);
-    } catch (err) {
-      // File not found or unreadable; try next candidate.
-    }
-  }
->>>>>>> da70749 (chore: rely on Bun.serve/native asset handling (revert custom TSX transform))
-
-      for (const p of candidates) {
-        try {
-          const file = Bun.file(p);
-          const ct = p.endsWith('.css') ? 'text/css; charset=utf-8'
-            : p.match(/\.tsx$|\.ts$|\.jsx$|\.js$|\.mjs$/) ? 'application/javascript; charset=utf-8'
-            : p.endsWith('.html') ? 'text/html; charset=utf-8'
-            : p.endsWith('.png') ? 'image/png'
-            : p.endsWith('.svg') ? 'image/svg+xml'
-            : undefined;
-          return new Response(file, ct ? { headers: { 'Content-Type': ct } } : undefined);
-        } catch (err) {
-          // File not found or unreadable; try next candidate.
-        }
-      }
-
-      // If nothing matched, fall back to serving index.html to keep SPA
-      // navigation working for unknown routes.
-      try {
-        return new Response(Bun.file('./src/index.html'), {
-          headers: { 'Content-Type': 'text/html; charset=utf-8' },
-        });
-      } catch (err) {
-        try { console.error('[ERROR] failed to serve index.html', err); } catch {}
-        return Response.json({}, { status: 500 });
-      }
-    }
-<<<<<<< HEAD

--- a/src/catchAll.ts
+++ b/src/catchAll.ts
@@ -9,100 +9,64 @@ export function handleCatchAll(req: Request): Response {
   // If the client explicitly accepts HTML (browser navigation) or
   // this is the root path, serve the SPA entrypoint.
   if (accept.includes('text/html') || path === '/') {
-    try {
-      return new Response(Bun.file('./src/index.html'), {
-        headers: { 'Content-Type': 'text/html; charset=utf-8' },
-      });
-    } catch (err) {
-      try { console.error('[ERROR] failed to serve index.html', err); } catch {}
-      return Response.json({}, { status: 500 });
-    }
-  }
+    export function handleCatchAll(req: Request): Response {
+      const url = new URL(req.url);
+      const path = url.pathname;
+      const accept = req.headers.get('accept') ?? '';
+      try { console.log('[TRACE] catch-all matched path=', path, 'accept=', accept); } catch {}
 
-  // Try to resolve static/module files from ./src and ./src/public.
-  const candidates = [
-    `./src${path}`,
-    `./src${path}.tsx`,
-    `./src${path}.ts`,
-    `./src${path}.jsx`,
-    `./src${path}.js`,
-    `./src${path}.mjs`,
-    `./src${path}.css`,
-    `./src${path}.html`,
-    `./src/public${path}`,
-    `./src/public${path}.png`,
-    `./src/public${path}.svg`,
-  ];
-
-  for (const p of candidates) {
-    try {
-      // For TS/TSX/JSX files, read and serve as JavaScript. Some clients
-      // (embedded browsers like OBS' browser) cannot parse raw TSX. To
-      // avoid syntax errors we perform minimal, safe transformations for
-      // common patterns used in our entrypoints (remove non-null `!`
-      // assertions and convert simple JSX to `React.createElement`). This
-      // keeps fast refresh/tests working while preventing runtime parse
-      // errors in non-transpiling clients.
-      if (p.match(/\.tsx$|\.ts$|\.jsx$/)) {
-        const text = readFileSync(p, { encoding: 'utf-8' });
-        let out = text;
-
-        // Remove TypeScript non-null assertion after calls like
-        // document.getElementById("root")!. These are invalid in
-        // browsers when served as-is.
-        out = out.replace(/\)\s*!/g, ')');
-
-        // Simple JSX -> React.createElement conversions for our entry
-        // points. This is intentionally conservative and only handles
-        // the patterns present in `frontend.tsx` files.
-        if (out.includes('<App')) {
-          out = out.replace(/<App\s*\/?>/g, 'React.createElement(App, null)');
+      // If the client explicitly accepts HTML (browser navigation) or
+      // this is the root path, serve the SPA entrypoint.
+      if (accept.includes('text/html') || path === '/') {
+        try {
+          return new Response(Bun.file('./src/index.html'), {
+            headers: { 'Content-Type': 'text/html; charset=utf-8' },
+          });
+        } catch (err) {
+          try { console.error('[ERROR] failed to serve index.html', err); } catch {}
+          return Response.json({}, { status: 500 });
         }
-        if (out.includes('<StrictMode')) {
-          out = out.replace(/<StrictMode>/g, 'React.createElement(StrictMode, null, ');
-          out = out.replace(/<\/StrictMode>/g, ')');
-        }
-
-        // Ensure `React` default import exists since we converted JSX.
-        if (out.match(/React\.createElement/) && !out.match(/import\s+React\s+from\s+['"]react['"]/)) {
-          // Insert after the last import statement.
-          const lines = out.split('\n');
-          let insertAt = 0;
-          for (let i = 0; i < lines.length; i++) {
-<<<<<<< HEAD
-            const line = lines[i] ?? '';
-            if (/^import\s/.test(line)) insertAt = i + 1;
-=======
-            if (/^import\s/.test(lines[i])) insertAt = i + 1;
->>>>>>> 03251b5 (fix: prevent TSX parse error in embedded browsers (#218))
-          }
-          lines.splice(insertAt, 0, "import React from 'react';");
-          out = lines.join('\n');
-        }
-
-        return new Response(out, { headers: { 'Content-Type': 'application/javascript; charset=utf-8' } });
       }
 
-      const file = Bun.file(p);
-      const ct = p.endsWith('.css') ? 'text/css; charset=utf-8'
-        : p.endsWith('.html') ? 'text/html; charset=utf-8'
-        : p.endsWith('.png') ? 'image/png'
-        : p.endsWith('.svg') ? 'image/svg+xml'
-        : undefined;
-      return new Response(file, ct ? { headers: { 'Content-Type': ct } } : undefined);
-    } catch (err) {
-      // File not found or unreadable; try next candidate.
-    }
-  }
+      // Try to resolve static/module files from ./src and ./src/public.
+      const candidates = [
+        `./src${path}`,
+        `./src${path}.tsx`,
+        `./src${path}.ts`,
+        `./src${path}.jsx`,
+        `./src${path}.js`,
+        `./src${path}.mjs`,
+        `./src${path}.css`,
+        `./src${path}.html`,
+        `./src/public${path}`,
+        `./src/public${path}.png`,
+        `./src/public${path}.svg`,
+      ];
 
-  // If nothing matched, fall back to serving index.html to keep SPA
-  // navigation working for unknown routes.
-  try {
-    return new Response(Bun.file('./src/index.html'), {
-      headers: { 'Content-Type': 'text/html; charset=utf-8' },
-    });
-  } catch (err) {
-    try { console.error('[ERROR] failed to serve index.html', err); } catch {}
-    return Response.json({}, { status: 500 });
-  }
-}
+      for (const p of candidates) {
+        try {
+          const file = Bun.file(p);
+          const ct = p.endsWith('.css') ? 'text/css; charset=utf-8'
+            : p.match(/\.tsx$|\.ts$|\.jsx$|\.js$|\.mjs$/) ? 'application/javascript; charset=utf-8'
+            : p.endsWith('.html') ? 'text/html; charset=utf-8'
+            : p.endsWith('.png') ? 'image/png'
+            : p.endsWith('.svg') ? 'image/svg+xml'
+            : undefined;
+          return new Response(file, ct ? { headers: { 'Content-Type': ct } } : undefined);
+        } catch (err) {
+          // File not found or unreadable; try next candidate.
+        }
+      }
+
+      // If nothing matched, fall back to serving index.html to keep SPA
+      // navigation working for unknown routes.
+      try {
+        return new Response(Bun.file('./src/index.html'), {
+          headers: { 'Content-Type': 'text/html; charset=utf-8' },
+        });
+      } catch (err) {
+        try { console.error('[ERROR] failed to serve index.html', err); } catch {}
+        return Response.json({}, { status: 500 });
+      }
+    }
+<<<<<<< HEAD


### PR DESCRIPTION
Rebased onto main and reverted fragile on-the-fly TSX transform; rely on Bun's native asset handling. See issue #218.