### PR TITLE
fix: use same-origin /console/api/ws; remove /console/env

### DIFF
--- a/console/src/AgentStatus/index.tsx
+++ b/console/src/AgentStatus/index.tsx
@@ -494,28 +494,10 @@ export function AgentStatus() {
 
     let es: EventSource | null = null;
     (async () => {
-      let sseUrl = '/console/api/ws';
+      const sseUrl = '/console/api/ws';
+      try { (window as any).__sseUrl = sseUrl; } catch {}
+      try { console.log('[TRACE] AgentStatus connecting EventSource ->', sseUrl); } catch {}
       try {
-        const envRes = await fetch('/console/env');
-        if (envRes.ok) {
-          const env = await envRes.json();
-          const broadcastingHost = env?.broadcastingHost;
-          const broadcastingPort = env?.broadcastingPort;
-          if (broadcastingHost && broadcastingPort) {
-            const curHost = window.location.hostname;
-            const curPort = window.location.port;
-            if (!(String(broadcastingHost) === curHost && String(broadcastingPort) === curPort)) {
-              sseUrl = `${window.location.protocol}//${broadcastingHost}:${broadcastingPort}/console/api/ws`;
-            }
-          }
-        }
-      } catch (err) {
-        // ignore env probe failures and fall back to same-origin proxy
-      }
-
-      try {
-        try { (window as any).__sseUrl = sseUrl; } catch {}
-        try { console.log('[TRACE] AgentStatus connecting EventSource ->', sseUrl); } catch {}
         es = new EventSource(sseUrl);
       } catch (err) {
         setAgentStatusError('ライブ接続に失敗しました');

--- a/routes/console/index.ts
+++ b/routes/console/index.ts
@@ -232,22 +232,7 @@ export const routes = {
       return new Response('proxy failed', { status: 502 });
     }
   },
-  '/console/env': async () => {
-    try {
-      try { console.log('[TRACE] /console/env requested'); } catch {}
-      // Normalize broadcasting host for browser clients: prefer IPv4
-      // loopback when configuration uses 'localhost' to avoid cases
-      // where 'localhost' resolves to an IPv6 address (::1) that the
-      // server is not bound to in some environments (Playwright CI).
-      const clientBroadcastingHost = BROADCASTING_HOST === 'localhost' ? '127.0.0.1' : BROADCASTING_HOST;
-      return new Response(JSON.stringify({ broadcastingHost: clientBroadcastingHost, broadcastingPort: BROADCASTING_PORT }), {
-        headers: { 'Content-Type': 'application/json' },
-        status: 200,
-      });
-    } catch (err) {
-      return new Response(JSON.stringify({}), { headers: { 'Content-Type': 'application/json' }, status: 500 });
-    }
-  },
+  
   '/console/*': ConsoleApp,
   '/console/robots.txt': robotsTxt,
   '/console/api/agent-state': agentState,


### PR DESCRIPTION
Prefer same-origin /console/api/ws for client connections and remove /console/env endpoint to prevent browsers attempting to connect to loopback 127.0.0.1:7777. Tests pass locally.