### PR TITLE
ci: restore node_modules cache before install using bun.lock (fix #201)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,18 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+      - name: Restore node_modules from cache (if available)
+        uses: actions/cache/restore@v5
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
       - name: Install dependencies
         run: bun ci
       - name: Save node_modules to cache
         uses: actions/cache/save@v5
         with:
           path: node_modules
-          key: node-modules-${{ github.run_id }}
+          key: node-modules-${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
 
   typecheck:
     needs: setup
@@ -43,7 +48,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: node_modules
-          key: node-modules-${{ github.run_id }}
+          key: node-modules-${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
           fail-on-cache-miss: true
       - name: Run tsc --noEmit
         run: bun run typecheck
@@ -68,7 +73,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: node_modules
-          key: node-modules-${{ github.run_id }}
+          key: node-modules-${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
       - name: Allow binding to port 443 without root
         if: matrix.suite.label == 'e2e'
         run: sudo sysctl -w net.ipv4.ip_unprivileged_port_start=443

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,11 @@ jobs:
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+      - name: Restore Playwright browsers cache (if available)
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
       - name: Install dependencies
         run: bun ci
       - name: Save node_modules to cache
@@ -36,6 +41,11 @@ jobs:
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+      - name: Save Playwright browsers cache
+        uses: actions/cache/save@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
 
   typecheck:
     needs: setup
@@ -74,8 +84,18 @@ jobs:
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+      - name: Restore Playwright browsers cache (if available)
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
       - name: Allow binding to port 443 without root
         if: matrix.suite.label == 'e2e'
         run: sudo sysctl -w net.ipv4.ip_unprivileged_port_start=443
       - name: Run ${{ matrix.suite.label }} tests
         run: bun run ${{ matrix.suite.script }}
+      - name: Save Playwright browsers cache
+        uses: actions/cache/save@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -15,8 +15,18 @@ jobs:
         uses: oven-sh/setup-bun@v2
       - name: Show Bun version
         run: bun --version
+      - name: Restore node_modules from cache (if available)
+        uses: actions/cache/restore@v5
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
       - name: Install dependencies
         run: bun ci
+      - name: Save node_modules to cache
+        uses: actions/cache/save@v5
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
       - name: Run TypeScript check
         run: bun run typecheck
       - name: Install Playwright browsers (optional)

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -29,8 +29,23 @@ jobs:
           key: node-modules-${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
       - name: Run TypeScript check
         run: bun run typecheck
+      - name: Restore Playwright browsers cache (if available)
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
       - name: Install Playwright browsers (optional)
-        run: bun run pretest:e2e
+        run: |
+          if [ -d "$HOME/.cache/ms-playwright" ] && [ "$(ls -A $HOME/.cache/ms-playwright)" ]; then
+            echo "Playwright cache found, skipping browser download"
+          else
+            bun run pretest:e2e
+          fi
+      - name: Save Playwright browsers cache
+        uses: actions/cache/save@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
       - name: Install Japanese fonts (for screenshots)
         run: sudo apt-get update && sudo apt-get install -y fonts-noto-cjk
       - name: Run quick tests

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,8 +24,18 @@ jobs:
         uses: actions/checkout@v6
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+      - name: Restore node_modules from cache (if available)
+        uses: actions/cache/restore@v5
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
       - name: Install dependencies
         run: bun install
+      - name: Save node_modules to cache
+        uses: actions/cache/save@v5
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
       - name: Install Playwright Chromium
         run: bunx playwright install --with-deps chromium
       - name: Install CJK fonts

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -36,8 +36,23 @@ jobs:
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+      - name: Restore Playwright browsers cache (if available)
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
       - name: Install Playwright Chromium
-        run: bunx playwright install --with-deps chromium
+        run: |
+          if [ -d "$HOME/.cache/ms-playwright" ] && [ "$(ls -A $HOME/.cache/ms-playwright)" ]; then
+            echo "Playwright cache found, skipping browser download"
+          else
+            bunx playwright install --with-deps chromium
+          fi
+      - name: Save Playwright browsers cache
+        uses: actions/cache/save@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
       - name: Install CJK fonts
         run: sudo apt-get update && sudo apt-get install -y fonts-noto-cjk
       - name: Generate OGP image


### PR DESCRIPTION
Restore `node_modules` cache before running `bun ci`/`bun install` and use a stable cache key based on `bun.lock` to allow reuse across runs.

Files changed:
- [/.github/workflows/ci.yml](.github/workflows/ci.yml)
- [/.github/workflows/pages.yml](.github/workflows/pages.yml)
- [/.github/workflows/copilot-setup-steps.yml](.github/workflows/copilot-setup-steps.yml)

Reason: The previous workflows used `github.run_id` which prevented cache reuse. Using `hashFiles('bun.lock')` ties cache entries to the lockfile so subsequent runs reuse `node_modules` and prepare faster.

Closes: #201