### PR TITLE
fix: avoid serving index.html for module requests (fix OBS embedded browser syntax error)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -35,6 +35,8 @@
 - [ ] [MUST] Run E2E Playwright test to verify fix — Pending; Playwright browser run not executed in this session.
 - [ ] [MUST] Update PR with patch and summary — Pending: prepare PR comment with explanation.
 
+- [x] [MUST] Fix OBS browser syntax error — Tightened navigation detection in `src/catchAll.ts` to avoid serving `index.html` for module/file requests (fixes syntax error in old OBS browser).
+
 - [x] [MUST] Issue #225: 管理コンソール - これまでの発話の改善 — 読了、テスト追加、実装（単語ごとにカード表示、非マルコフ文言の除去）を行いました。
 - [ ] [MUST] Commit changes and open PR for branch `225-管理コンソール-これまでの発話の改善` — Pending: create PR with description and attach screenshots if needed.
  - [ ] [SHOULD] Propose AGT library enhancement — create an issue requesting generation trace (node path) or API to return nodes visited during generation.

--- a/src/catchAll.ts
+++ b/src/catchAll.ts
@@ -5,7 +5,14 @@ export function handleCatchAll(req: Request): Response {
   const accept = req.headers.get('accept') ?? '';
   try { console.log('[TRACE] catch-all matched path=', path, 'accept=', accept); } catch {}
 
-  if (accept.includes('text/html') || path === '/') {
+  // Treat as a navigation (serve index.html) only when the request
+  // is explicitly for HTML navigation. Some embedded browsers (OBS)
+  // include `text/html` in Accept headers for subresource requests
+  // such as module imports (e.g. `/frontend.tsx`). Avoid returning
+  // `index.html` for requests that look like file/module paths by
+  // checking for a path extension.
+  const looksLikeFile = path.includes('.') && !path.endsWith('/');
+  if ((accept.includes('text/html') && !looksLikeFile) || path === '/') {
     try {
       return new Response(Bun.file('./src/index.html'), {
         headers: { 'Content-Type': 'text/html; charset=utf-8' },


### PR DESCRIPTION
Tightens navigation detection in  so file/module requests (e.g. ) are served as JS modules instead of . This prevents syntax errors in older embedded browsers like OBS.\n\n- Updated \n- Updated  to record the fix\n\nTests: Ran unit tests (excluding e2e) — all passing.\n\nCloses: #232