### PR TITLE
Fix: avoid serving JSX in raw TSX modules (OBS SyntaxError)

### DIFF
--- a/console/src/frontend.tsx
+++ b/console/src/frontend.tsx
@@ -6,11 +6,12 @@
  */
 
 import { createRoot } from "react-dom/client";
+import { createElement } from "react";
 import { App } from "./App";
 
 function start() {
   const root = createRoot(document.getElementById("root")!);
-  root.render(<App />);
+  root.render(createElement(App, null));
 }
 
 if (document.readyState === "loading") {

--- a/src/catchAll.test.ts
+++ b/src/catchAll.test.ts
@@ -10,7 +10,7 @@ test("serves frontend.tsx as JavaScript module", async () => {
   expect(ct).toMatch(/application\/javascript/);
   const body = await res.text();
   expect(body).toContain('This file is the entry point for the React app');
-  expect(body).toContain('import { StrictMode }');
+  expect(body).toContain('import { StrictMode');
 });
 
 test("serves index.html for navigation requests", async () => {

--- a/src/frontend.tsx
+++ b/src/frontend.tsx
@@ -5,13 +5,13 @@
  * It is included in `src/index.html`.
  */
 
-import { StrictMode } from "react";
+import { StrictMode, createElement } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
 
 function start() {
   const root = createRoot(document.getElementById("root")!);
-  root.render(<StrictMode><App /></StrictMode>);
+  root.render(createElement(StrictMode, null, createElement(App, null)));
 }
 
 if (document.readyState === "loading") {


### PR DESCRIPTION
This fixes issue #235 by ensuring the frontend entry modules do not contain JSX when served raw to embedded browsers like OBS. I replaced JSX with React.createElement in  and , and updated the related test.

Changes:
- src/frontend.tsx: use  instead of JSX
- console/src/frontend.tsx: use  instead of JSX
- src/catchAll.test.ts: adjust expectation for import line

Tests: ran [0m[1mbun test [0m[2mv1.3.13 (bf2e2cec)[0m
[TRACE] catch-all matched path= /frontend.tsx accept= */*
[TRACE] catch-all matched path= / accept= text/html locally — 2 tests passed.

Fixes #235