### PR TITLE
fix(console): rely on Bun.serve for /* and remove external import map (fix #239)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -463,8 +463,9 @@ const server = serve({
 
     '/console/robots.txt': robotsTxt,
 
-    // Rely on Bun's default handling for `/*` so it can serve static files
-    // and resolve module imports from the project (node_modules) correctly.
+    // Serve the application HTML via Bun's HTML import so Bun can rewrite
+    // and resolve module imports (safe, local resolution without external CDN).
+    '/*': App,
   },
 
   development: process.env.NODE_ENV !== "production" && {

--- a/index.ts
+++ b/index.ts
@@ -463,12 +463,8 @@ const server = serve({
 
     '/console/robots.txt': robotsTxt,
 
-    // Catch-all handler. Serve `index.html` only for navigation (HTML)
-    // requests; for other requests attempt to resolve static/module files
-    // from `./src` and `./src/public` so TypeScript/JSX modules can be
-    // requested by the browser (e.g. `/frontend.tsx`, `/App`). This avoids
-    // accidentally returning `index.html` for module imports.
-    '/*': handleCatchAll,
+    // Rely on Bun's default handling for `/*` so it can serve static files
+    // and resolve module imports from the project (node_modules) correctly.
   },
 
   development: process.env.NODE_ENV !== "production" && {


### PR DESCRIPTION
This change fixes an issue where the app attempted to resolve bare `react` imports in the browser and returned `index.html` for module requests, causing OBS Browser errors (see #239).

What I changed:
- Reverted import-map/es-module-shims approach and restored module script tags in `src` and `console/src` `index.html` files.
- Removed the custom `'/*'` catch-all route in `index.ts` so Bun's `serve` can handle static/module resolution correctly.

This keeps the runtime strictly local (no dynamic/external CDN loading) and leverages Bun's built-in static & module serving. See https://bun.sh/docs/runtime/http/server#html-imports for details.

Closes #239.