### PR TITLE
fix: strip content-length when proxying SSE to avoid incomplete chunked encoding (#241)

### DIFF
--- a/routes/console/index.ts
+++ b/routes/console/index.ts
@@ -12,6 +12,8 @@ try {
 function streamUpstreamResponse(proxied: Response) {
   const responseHeaders = new Headers(proxied.headers);
   responseHeaders.set('cache-control', 'no-cache');
+    // Remove content-length to avoid mismatches when streaming/chunked.
+    responseHeaders.delete('content-length');
   const upstreamBody: any = proxied.body;
   if (upstreamBody && typeof upstreamBody.getReader === 'function') {
     const wrapped = new ReadableStream({
@@ -235,6 +237,9 @@ export const routes = {
       if (contentType.includes('text/event-stream')) {
         const responseHeaders = new Headers(proxied.headers);
         responseHeaders.set('cache-control', 'no-cache');
+        // Remove content-length to avoid incomplete/chunked encoding errors
+        // when the upstream stream is proxied as a new ReadableStream.
+        responseHeaders.delete('content-length');
         const upstreamBody: any = proxied.body;
         if (upstreamBody && typeof upstreamBody.getReader === 'function') {
           const wrapped = new ReadableStream({


### PR DESCRIPTION
When the proxy wraps an upstream `text/event-stream` body into a new `ReadableStream`, the original `content-length` header can be incorrect and cause browsers to report `net::ERR_INCOMPLETE_CHUNKED_ENCODING` if the upstream closes the connection abruptly. This change removes `content-length` from proxied SSE responses to allow proper chunked transfer behavior.

- Remove `content-length` when rewrapping streaming responses
- Ensure `Cache-Control: no-cache` is preserved for SSE

Closes: #241