### PR TITLE
fix(console): preserve SSE streaming in proxy (fixes #243)

### DIFF
--- a/lib/console-proxy.ts
+++ b/lib/console-proxy.ts
@@ -259,5 +259,4 @@ export async function proxyConsoleUpgrade(req: Request, proxyUrl: string, proxyB
   }
 }
 
-// Re-export for route imports
-export { proxyConsoleUpgrade as proxyConsoleUpgrade };
+// proxyConsoleUpgrade is exported by its declaration above

--- a/lib/console-proxy.ts
+++ b/lib/console-proxy.ts
@@ -219,3 +219,45 @@ export async function proxyConsoleApiWsRequest(req: Request, proxyUrl: string, p
 
   return proxied;
 }
+
+export async function proxyConsoleUpgrade(req: Request, proxyUrl: string, proxyBase: string): Promise<Response> {
+  try {
+    const BROADCASTING_HOST = process.env.BROADCASTING_HOST ?? 'localhost';
+    const upstreamUrlObj = new URL(proxyUrl);
+    upstreamUrlObj.protocol = upstreamUrlObj.protocol === 'https:' ? 'wss:' : 'ws:';
+    if (upstreamUrlObj.hostname === 'localhost' || BROADCASTING_HOST === 'localhost') upstreamUrlObj.hostname = '127.0.0.1';
+    const upstreamWsUrl = upstreamUrlObj.toString();
+    try { console.log('[DEBUG] /console/api/ws upstream websocket url ->', upstreamWsUrl); } catch {}
+
+    const upgrader = getUpgrader();
+    if (!upgrader) {
+      try { console.warn('[WARN] no upgradeWebSocket API available for websocket bridge'); } catch {}
+      return new Response('websocket upgrade unavailable', { status: 501 });
+    }
+
+    try { console.log('[DEBUG] invoking upgrader for client request'); } catch {}
+    const upgraded = await performWebSocketUpgrade(req, upgrader, proxyBase).catch((err) => {
+      try { console.warn('[ERROR] upgrader threw', String(err)); } catch {}
+      return null;
+    });
+
+    try { console.log('[DEBUG] upgrader invoked, upgraded ->', upgraded && (upgraded.response || upgraded)); } catch {}
+    try {
+      if (upgraded && (upgraded instanceof Response)) {
+        return upgraded;
+      }
+      if (upgraded && upgraded.response) {
+        return upgraded.response;
+      }
+    } catch (err) {
+      try { console.warn('[ERROR] failed to return upgraded response', String(err)); } catch {}
+    }
+
+    return new Response('upgrade failed', { status: 500 });
+  } catch (err) {
+    return new Response('upgrade failed', { status: 500 });
+  }
+}
+
+// Re-export for route imports
+export { proxyConsoleUpgrade as proxyConsoleUpgrade };

--- a/lib/console-proxy.ts
+++ b/lib/console-proxy.ts
@@ -1,0 +1,192 @@
+export function streamUpstreamResponse(proxied: Response) {
+  const responseHeaders = new Headers(proxied.headers);
+  responseHeaders.set('cache-control', 'no-cache');
+  // Remove content-length to avoid mismatches when streaming/chunked.
+  responseHeaders.delete('content-length');
+  const upstreamBody: any = proxied.body;
+  if (upstreamBody && typeof upstreamBody.getReader === 'function') {
+    const wrapped = new ReadableStream({
+      start(controller) {
+        const reader = upstreamBody.getReader();
+        (async () => {
+          try {
+            while (true) {
+              const { done, value } = await reader.read();
+              if (done) { controller.close(); break; }
+              controller.enqueue(value);
+            }
+          } catch (e) {
+            try { controller.error(e); } catch {}
+          } finally {
+            try { reader.releaseLock(); } catch {}
+          }
+        })();
+      },
+      cancel() {
+        try { upstreamBody.cancel && upstreamBody.cancel(); } catch {}
+      },
+    });
+
+    return new Response(wrapped, { status: proxied.status, headers: responseHeaders });
+  }
+
+  return new Response(proxied.body, { status: proxied.status, headers: responseHeaders });
+}
+
+export function getUpgrader(): ((req: Request, opts: any) => any) | null {
+  try {
+    if (typeof globalThis !== 'undefined') {
+      if ((globalThis as any).Bun && typeof (globalThis as any).Bun.upgradeWebSocket === 'function') return (globalThis as any).Bun.upgradeWebSocket;
+      if (typeof (globalThis as any).upgradeWebSocket === 'function') return (globalThis as any).upgradeWebSocket;
+    }
+  } catch {}
+  try {
+    if (typeof Bun !== 'undefined' && (Bun as any).upgradeWebSocket) return (Bun as any).upgradeWebSocket;
+  } catch {}
+  return null;
+}
+
+export async function performWebSocketUpgrade(req: Request, upgrader: any, proxyBase: string) {
+  return new Promise<any>((resolve, _reject) => {
+    try {
+      const upgraded = upgrader(req, {
+        open(clientWs: any) {
+          (async () => {
+            try {
+              try { console.log('[DEBUG] websocket upgrade accepted; starting SSE->WS forwarder'); } catch {}
+              const sseUrl = `${proxyBase}/console/api/ws`;
+              try { console.log('[DEBUG] opening upstream SSE fetch ->', sseUrl); } catch {}
+              const res = await fetch(sseUrl, { headers: { accept: 'text/event-stream' } });
+              try { console.log('[DEBUG] upstream SSE response ->', { status: res.status, contentType: res.headers.get('content-type') }); } catch {}
+              const upstreamBody: any = res.body;
+
+              try {
+                const metaJson = await fetchMetaSnapshot(proxyBase);
+                try { clientWs.send(JSON.stringify(metaJson)); } catch {}
+              } catch (err) {
+                try { console.warn('[DIAG] failed to send initial meta snapshot', String(err)); } catch {}
+              }
+
+              if (!upstreamBody || typeof upstreamBody.getReader !== 'function') {
+                try {
+                  const json = await res.json().catch(() => ({}));
+                  try { clientWs.send(JSON.stringify(json)); } catch {}
+                } catch {}
+                return;
+              }
+
+              const cancelForward = forwardSSEEventsToSink(upstreamBody, (data) => {
+                try { clientWs.send(data); } catch (err) { try { clientWs.close(); } catch {} }
+              });
+
+              clientWs.onmessage = (_ev: any) => {};
+              clientWs.onclose = (_ev: any) => { cancelForward(); };
+              clientWs.onerror = (_ev: any) => { cancelForward(); };
+
+              return;
+            } catch (err) {
+              try { console.warn('[WARN] simplified websocket bridge failed', String(err)); } catch {}
+              try { clientWs.close(); } catch {}
+            }
+          })();
+        },
+        message() {},
+        close() {},
+      });
+      resolve(upgraded);
+    } catch (err) {
+      resolve(null);
+    }
+  });
+}
+
+export function forwardSSEEventsToSink(upstreamBody: any, sink: (data: string) => void) {
+  if (!upstreamBody || typeof upstreamBody.getReader !== 'function') {
+    return () => {};
+  }
+  const reader = upstreamBody.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let stopped = false;
+
+  (async () => {
+    try {
+      while (!stopped) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        let idx = buffer.indexOf('\r\n\r\n');
+        if (idx === -1) idx = buffer.indexOf('\n\n');
+        while (idx !== -1) {
+          const event = buffer.slice(0, idx);
+          buffer = buffer.slice(idx + (buffer.startsWith('\r\n', idx) ? 4 : 2));
+          const dataLines = event.split(/\r?\n/).filter((l) => l.startsWith('data:'));
+          if (dataLines.length > 0) {
+            const data = dataLines.map((l) => l.replace(/^data:\s?/, '')).join('\n');
+            try { sink(data); } catch {}
+          }
+          idx = buffer.indexOf('\r\n\r\n');
+          if (idx === -1) idx = buffer.indexOf('\n\n');
+        }
+      }
+    } catch (err) {
+      try { console.warn('[DIAG] SSE reader failed', String(err)); } catch {}
+    } finally {
+      try { reader.cancel && typeof reader.cancel === 'function' && reader.cancel(); } catch {}
+    }
+  })();
+
+  return () => {
+    stopped = true;
+    try { reader.cancel && typeof reader.cancel === 'function' && reader.cancel(); } catch {}
+  };
+}
+
+export function buildProxyHeaders(req: Request, proxyBase: string) {
+  const proxyHeaders = new Headers(req.headers);
+  try {
+    const proxyBaseHost = new URL(proxyBase).host;
+    proxyHeaders.set('host', proxyBaseHost);
+  } catch {
+    proxyHeaders.set('host', `${process.env.BROADCASTING_HOST ?? 'localhost'}:${process.env.BROADCASTING_PORT ?? '7777'}`);
+  }
+  proxyHeaders.delete('origin');
+  proxyHeaders.delete('referer');
+  if (!proxyHeaders.has('accept')) proxyHeaders.set('accept', 'text/event-stream');
+  return proxyHeaders;
+}
+
+export function computeProxyBase(req: Request) {
+  const BROADCASTING_HOST = process.env.BROADCASTING_HOST ?? 'localhost';
+  const BROADCASTING_PORT = process.env.BROADCASTING_PORT ?? '7777';
+  let proxyBase = `http://${BROADCASTING_HOST}:${BROADCASTING_PORT}`;
+  try {
+    const incomingHost = req.headers.get('host') ?? '';
+    if (incomingHost && proxyBase.includes(incomingHost)) {
+      proxyBase = `http://127.0.0.1:${BROADCASTING_PORT}`;
+      try { console.log('[WARN] Detected self-proxying; overriding proxyBase ->', proxyBase); } catch {}
+    }
+  } catch {}
+  return proxyBase;
+}
+
+export function computeProxyUrl(req: Request, proxyBase: string) {
+  let parsed: URL;
+  try { parsed = new URL(req.url); } catch (err) {
+    const BROADCASTING_HOST = process.env.BROADCASTING_HOST ?? 'localhost';
+    const BROADCASTING_PORT = process.env.BROADCASTING_PORT ?? '7777';
+    const hostForParse = req.headers.get('host') ?? `${BROADCASTING_HOST}:${BROADCASTING_PORT}`;
+    parsed = new URL(req.url, `http://${hostForParse}`);
+  }
+  return `${proxyBase}/console/api/ws${parsed.search ?? ''}`;
+}
+
+export async function fetchMetaSnapshot(proxyBase: string): Promise<any> {
+  try {
+    const res = await fetch(`${proxyBase}/api/meta`);
+    return await res.json().catch(() => ({}));
+  } catch (err) {
+    try { console.warn('[DIAG] fetchMetaSnapshot failed', String(err)); } catch {}
+    return {};
+  }
+}

--- a/lib/console-proxy.ts
+++ b/lib/console-proxy.ts
@@ -190,3 +190,32 @@ export async function fetchMetaSnapshot(proxyBase: string): Promise<any> {
     return {};
   }
 }
+
+export async function proxyConsoleApiWsRequest(req: Request, proxyUrl: string, proxyHeaders: Headers): Promise<Response> {
+  // HEAD handling: probe upstream with GET and return headers only
+  if ((req.method || 'GET').toUpperCase() === 'HEAD') {
+    const upstreamGet = await fetch(proxyUrl.toString(), {
+      method: 'GET',
+      headers: proxyHeaders,
+    });
+    const responseHeaders = new Headers(upstreamGet.headers);
+    if ((upstreamGet.headers.get('content-type') || '').includes('text/event-stream')) {
+      responseHeaders.set('cache-control', 'no-cache');
+    }
+    return new Response(null, { status: upstreamGet.status, headers: responseHeaders });
+  }
+
+  // Non-upgrade: proxy via fetch and rewrap SSE bodies when needed
+  const proxied = await fetch(proxyUrl.toString(), {
+    method: req.method,
+    headers: proxyHeaders,
+    body: req.body,
+  });
+
+  const contentType = proxied.headers.get('content-type') ?? '';
+  if (contentType.includes('text/event-stream')) {
+    return streamUpstreamResponse(proxied);
+  }
+
+  return proxied;
+}

--- a/routes/console/index.ts
+++ b/routes/console/index.ts
@@ -101,9 +101,7 @@ async function performWebSocketUpgrade(req: Request, upgrader: any, proxyBase: s
               clientWs.onclose = (_ev: any) => { cancelForward(); };
               clientWs.onerror = (_ev: any) => { cancelForward(); };
 
-              clientWs.onmessage = (_ev: any) => {};
-              clientWs.onclose = (_ev: any) => { stopped = true; try { reader.cancel && typeof reader.cancel === 'function' && reader.cancel(); } catch {} };
-              clientWs.onerror = (_ev: any) => { stopped = true; try { reader.cancel && typeof reader.cancel === 'function' && reader.cancel(); } catch {} };
+              // handlers set above by cancelForward
               return;
             } catch (err) {
               try { console.warn('[WARN] simplified websocket bridge failed', String(err)); } catch {}

--- a/routes/console/index.ts
+++ b/routes/console/index.ts
@@ -1,16 +1,14 @@
 import ConsoleApp from "../../console/src/index.html";
-import robotsTxt from "./robots.txt";
-import * as agentState from "./api/agent-state";
 import {
-  streamUpstreamResponse,
-  getUpgrader,
-  performWebSocketUpgrade,
-  forwardSSEEventsToSink,
   buildProxyHeaders,
   computeProxyBase,
   computeProxyUrl,
-  fetchMetaSnapshot,
+  getUpgrader,
+  performWebSocketUpgrade,
+  streamUpstreamResponse
 } from "../../lib/console-proxy";
+import * as agentState from "./api/agent-state";
+import robotsTxt from "./robots.txt";
 
 const BROADCASTING_HOST = process.env.BROADCASTING_HOST ?? 'localhost';
 const BROADCASTING_PORT = process.env.BROADCASTING_PORT ?? '7777';
@@ -19,179 +17,7 @@ try {
   console.log('[DEBUG] routes/console initializing', { BROADCASTING_HOST, BROADCASTING_PORT });
 } catch {}
 
-// moved helpers into ../../lib/console-proxy
-
-/**
- * Return an available upgradeWebSocket API compatible function or null.
- */
-function getUpgrader(): ((req: Request, opts: any) => any) | null {
-  try {
-    if (typeof globalThis !== 'undefined') {
-      if ((globalThis as any).Bun && typeof (globalThis as any).Bun.upgradeWebSocket === 'function') return (globalThis as any).Bun.upgradeWebSocket;
-      if (typeof (globalThis as any).upgradeWebSocket === 'function') return (globalThis as any).upgradeWebSocket;
-    }
-  } catch {}
-  try {
-    if (typeof Bun !== 'undefined' && (Bun as any).upgradeWebSocket) return (Bun as any).upgradeWebSocket;
-  } catch {}
-  return null;
-}
-
-/**
- * Perform the websocket upgrade and bridge SSE->WS to forward upstream SSE events.
- */
-async function performWebSocketUpgrade(req: Request, upgrader: any, proxyBase: string) {
-  return new Promise<any>((resolve, _reject) => {
-    try {
-      const upgraded = upgrader(req, {
-        open(clientWs: any) {
-          (async () => {
-            try {
-              try { console.log('[DEBUG] websocket upgrade accepted; starting SSE->WS forwarder'); } catch {}
-              const sseUrl = `${proxyBase}/console/api/ws`;
-              try { console.log('[DEBUG] opening upstream SSE fetch ->', sseUrl); } catch {}
-              const res = await fetch(sseUrl, { headers: { accept: 'text/event-stream' } });
-              try { console.log('[DEBUG] upstream SSE response ->', { status: res.status, contentType: res.headers.get('content-type') }); } catch {}
-              const upstreamBody: any = res.body;
-
-              try {
-                const metaJson = await fetchMetaSnapshot(proxyBase);
-                try { clientWs.send(JSON.stringify(metaJson)); } catch {}
-              } catch (err) {
-                try { console.warn('[DIAG] failed to send initial meta snapshot', String(err)); } catch {}
-              }
-
-              if (!upstreamBody || typeof upstreamBody.getReader !== 'function') {
-                try {
-                  const json = await res.json().catch(() => ({}));
-                  try { clientWs.send(JSON.stringify(json)); } catch {}
-                } catch {}
-                return;
-              }
-
-              const cancelForward = forwardSSEEventsToSink(upstreamBody, (data) => {
-                try { clientWs.send(data); } catch (err) { try { clientWs.close(); } catch {} }
-              });
-
-              clientWs.onmessage = (_ev: any) => {};
-              clientWs.onclose = (_ev: any) => { cancelForward(); };
-              clientWs.onerror = (_ev: any) => { cancelForward(); };
-
-              // handlers set above by cancelForward
-              return;
-            } catch (err) {
-              try { console.warn('[WARN] simplified websocket bridge failed', String(err)); } catch {}
-              try { clientWs.close(); } catch {}
-            }
-          })();
-        },
-        message() {},
-        close() {},
-      });
-      resolve(upgraded);
-    } catch (err) {
-      resolve(null);
-    }
-  });
-}
-
-async function fetchMetaSnapshot(proxyBase: string): Promise<any> {
-  try {
-    const res = await fetch(`${proxyBase}/api/meta`);
-    return await res.json().catch(() => ({}));
-  } catch (err) {
-    try { console.warn('[DIAG] fetchMetaSnapshot failed', String(err)); } catch {}
-    return {};
-  }
-}
-
-/**
- * Read an upstream EventSource stream and forward 'data:' payloads to sink.
- * Returns a cancel function to stop reading.
- */
-function forwardSSEEventsToSink(upstreamBody: any, sink: (data: string) => void) {
-  if (!upstreamBody || typeof upstreamBody.getReader !== 'function') {
-    return () => {};
-  }
-  const reader = upstreamBody.getReader();
-  const decoder = new TextDecoder();
-  let buffer = '';
-  let stopped = false;
-
-  (async () => {
-    try {
-      while (!stopped) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        buffer += decoder.decode(value, { stream: true });
-        let idx = buffer.indexOf('\r\n\r\n');
-        if (idx === -1) idx = buffer.indexOf('\n\n');
-        while (idx !== -1) {
-          const event = buffer.slice(0, idx);
-          buffer = buffer.slice(idx + (buffer.startsWith('\r\n', idx) ? 4 : 2));
-          const dataLines = event.split(/\r?\n/).filter((l) => l.startsWith('data:'));
-          if (dataLines.length > 0) {
-            const data = dataLines.map((l) => l.replace(/^data:\s?/, '')).join('\n');
-            try { sink(data); } catch {}
-          }
-          idx = buffer.indexOf('\r\n\r\n');
-          if (idx === -1) idx = buffer.indexOf('\n\n');
-        }
-      }
-    } catch (err) {
-      try { console.warn('[DIAG] SSE reader failed', String(err)); } catch {}
-    } finally {
-      try { reader.cancel && typeof reader.cancel === 'function' && reader.cancel(); } catch {}
-    }
-  })();
-
-  return () => {
-    stopped = true;
-    try { reader.cancel && typeof reader.cancel === 'function' && reader.cancel(); } catch {}
-  };
-}
-
-/**
- * Build sanitized proxy headers for upstream requests.
- */
-function buildProxyHeaders(req: Request, proxyBase: string) {
-  const proxyHeaders = new Headers(req.headers);
-  try {
-    const proxyBaseHost = new URL(proxyBase).host;
-    proxyHeaders.set('host', proxyBaseHost);
-  } catch {
-    proxyHeaders.set('host', `${BROADCASTING_HOST}:${BROADCASTING_PORT}`);
-  }
-  proxyHeaders.delete('origin');
-  proxyHeaders.delete('referer');
-  if (!proxyHeaders.has('accept')) proxyHeaders.set('accept', 'text/event-stream');
-  return proxyHeaders;
-}
-
-/**
- * Compute the proxy base URL to reach the broadcasting server.
- * Handles self-proxy detection by mapping to 127.0.0.1 when appropriate.
- */
-function computeProxyBase(req: Request) {
-  let proxyBase = `http://${BROADCASTING_HOST}:${BROADCASTING_PORT}`;
-  try {
-    const incomingHost = req.headers.get('host') ?? '';
-    if (incomingHost && proxyBase.includes(incomingHost)) {
-      proxyBase = `http://127.0.0.1:${BROADCASTING_PORT}`;
-      try { console.log('[WARN] Detected self-proxying; overriding proxyBase ->', proxyBase); } catch {}
-    }
-  } catch {}
-  return proxyBase;
-}
-
-function computeProxyUrl(req: Request, proxyBase: string) {
-  let parsed: URL;
-  try { parsed = new URL(req.url); } catch (err) {
-    const hostForParse = req.headers.get('host') ?? `${BROADCASTING_HOST}:${BROADCASTING_PORT}`;
-    parsed = new URL(req.url, `http://${hostForParse}`);
-  }
-  return `${proxyBase}/console/api/ws${parsed.search ?? ''}`;
-}
+// helpers moved to ../../lib/console-proxy
 
 export const routes = {
   // Proxy the console client's streaming endpoint to the broadcasting

--- a/routes/console/index.ts
+++ b/routes/console/index.ts
@@ -93,37 +93,13 @@ async function performWebSocketUpgrade(req: Request, upgrader: any, proxyBase: s
                 return;
               }
 
-              const reader = upstreamBody.getReader();
-              const decoder = new TextDecoder();
-              let buffer = '';
-              let stopped = false;
+              const cancelForward = forwardSSEEventsToSink(upstreamBody, (data) => {
+                try { clientWs.send(data); } catch (err) { try { clientWs.close(); } catch {} }
+              });
 
-              (async () => {
-                try {
-                  while (!stopped) {
-                    const { done, value } = await reader.read();
-                    if (done) break;
-                    buffer += decoder.decode(value, { stream: true });
-                    let idx = buffer.indexOf('\r\n\r\n');
-                    if (idx === -1) idx = buffer.indexOf('\n\n');
-                    while (idx !== -1) {
-                      const event = buffer.slice(0, idx);
-                      buffer = buffer.slice(idx + (buffer.startsWith('\r\n', idx) ? 4 : 2));
-                      const dataLines = event.split(/\r?\n/).filter((l) => l.startsWith('data:'));
-                      if (dataLines.length > 0) {
-                        const data = dataLines.map((l) => l.replace(/^data:\s?/, '')).join('\n');
-                        try { clientWs.send(data); } catch (err) { try { clientWs.close(); } catch {} }
-                      }
-                      idx = buffer.indexOf('\r\n\r\n');
-                      if (idx === -1) idx = buffer.indexOf('\n\n');
-                    }
-                  }
-                } catch (err) {
-                  try { console.warn('[DIAG] SSE reader failed', String(err)); } catch {}
-                } finally {
-                  try { reader.cancel && typeof reader.cancel === 'function' && reader.cancel(); } catch {}
-                }
-              })();
+              clientWs.onmessage = (_ev: any) => {};
+              clientWs.onclose = (_ev: any) => { cancelForward(); };
+              clientWs.onerror = (_ev: any) => { cancelForward(); };
 
               clientWs.onmessage = (_ev: any) => {};
               clientWs.onclose = (_ev: any) => { stopped = true; try { reader.cancel && typeof reader.cancel === 'function' && reader.cancel(); } catch {} };
@@ -143,6 +119,52 @@ async function performWebSocketUpgrade(req: Request, upgrader: any, proxyBase: s
       resolve(null);
     }
   });
+}
+
+/**
+ * Read an upstream EventSource stream and forward 'data:' payloads to sink.
+ * Returns a cancel function to stop reading.
+ */
+function forwardSSEEventsToSink(upstreamBody: any, sink: (data: string) => void) {
+  if (!upstreamBody || typeof upstreamBody.getReader !== 'function') {
+    return () => {};
+  }
+  const reader = upstreamBody.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let stopped = false;
+
+  (async () => {
+    try {
+      while (!stopped) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        let idx = buffer.indexOf('\r\n\r\n');
+        if (idx === -1) idx = buffer.indexOf('\n\n');
+        while (idx !== -1) {
+          const event = buffer.slice(0, idx);
+          buffer = buffer.slice(idx + (buffer.startsWith('\r\n', idx) ? 4 : 2));
+          const dataLines = event.split(/\r?\n/).filter((l) => l.startsWith('data:'));
+          if (dataLines.length > 0) {
+            const data = dataLines.map((l) => l.replace(/^data:\s?/, '')).join('\n');
+            try { sink(data); } catch {}
+          }
+          idx = buffer.indexOf('\r\n\r\n');
+          if (idx === -1) idx = buffer.indexOf('\n\n');
+        }
+      }
+    } catch (err) {
+      try { console.warn('[DIAG] SSE reader failed', String(err)); } catch {}
+    } finally {
+      try { reader.cancel && typeof reader.cancel === 'function' && reader.cancel(); } catch {}
+    }
+  })();
+
+  return () => {
+    stopped = true;
+    try { reader.cancel && typeof reader.cancel === 'function' && reader.cancel(); } catch {}
+  };
 }
 
 /**

--- a/routes/console/index.ts
+++ b/routes/console/index.ts
@@ -67,37 +67,8 @@ export const routes = {
         return new Response('upgrade failed', { status: 500 });
       }
 
-      // Non-upgrade: for HEAD requests upstream may omit body headers,
-      // so probe with GET and return the same headers for HEAD to ensure
-      // callers (tests) observe the expected Content-Type.
-      if ((req.method || 'GET').toUpperCase() === 'HEAD') {
-        const upstreamGet = await fetch(proxyUrl.toString(), {
-          method: 'GET',
-          headers: proxyHeaders,
-        });
-        const responseHeaders = new Headers(upstreamGet.headers);
-        // Ensure cache-control for SSE
-        if ((upstreamGet.headers.get('content-type') || '').includes('text/event-stream')) {
-          responseHeaders.set('cache-control', 'no-cache');
-        }
-        return new Response(null, { status: upstreamGet.status, headers: responseHeaders });
-      }
-
-      // Non-upgrade: proxy via fetch and rewrap SSE bodies when needed
-      const proxied = await fetch(proxyUrl.toString(), {
-        method: req.method,
-        headers: proxyHeaders,
-        body: req.body,
-      });
-
-      try { console.log('[DEBUG] /console/api/ws upstream response ->', { status: proxied.status, contentType: proxied.headers.get('content-type') }); } catch {}
-
-      const contentType = proxied.headers.get('content-type') ?? '';
-      if (contentType.includes('text/event-stream')) {
-        return streamUpstreamResponse(proxied);
-      }
-
-      return proxied;
+      // Delegate HEAD and proxy fetch handling to helper
+      return await proxyConsoleApiWsRequest(req, proxyUrl, proxyHeaders);
     } catch (err) {
       return new Response('proxy failed', { status: 502 });
     }

--- a/routes/console/index.ts
+++ b/routes/console/index.ts
@@ -7,6 +7,7 @@ import {
   performWebSocketUpgrade,
   streamUpstreamResponse,
   proxyConsoleApiWsRequest,
+  proxyConsoleUpgrade,
 } from "../../lib/console-proxy";
 import * as agentState from "./api/agent-state";
 import robotsTxt from "./robots.txt";

--- a/routes/console/index.ts
+++ b/routes/console/index.ts
@@ -235,39 +235,7 @@ export const routes = {
 
       const contentType = proxied.headers.get('content-type') ?? '';
       if (contentType.includes('text/event-stream')) {
-        const responseHeaders = new Headers(proxied.headers);
-        responseHeaders.set('cache-control', 'no-cache');
-        // Remove content-length to avoid incomplete/chunked encoding errors
-        // when the upstream stream is proxied as a new ReadableStream.
-        responseHeaders.delete('content-length');
-        const upstreamBody: any = proxied.body;
-        if (upstreamBody && typeof upstreamBody.getReader === 'function') {
-          const wrapped = new ReadableStream({
-            start(controller) {
-              const reader = upstreamBody.getReader();
-              (async () => {
-                try {
-                  while (true) {
-                    const { done, value } = await reader.read();
-                    if (done) { controller.close(); break; }
-                    controller.enqueue(value);
-                  }
-                } catch (e) {
-                  try { controller.error(e); } catch {}
-                } finally {
-                  try { reader.releaseLock(); } catch {}
-                }
-              })();
-            },
-            cancel() {
-              try { upstreamBody.cancel && upstreamBody.cancel(); } catch {}
-            },
-          });
-
-          return new Response(wrapped, { status: proxied.status, headers: responseHeaders });
-        }
-
-        return new Response(proxied.body, { status: proxied.status, headers: responseHeaders });
+        return streamUpstreamResponse(proxied);
       }
 
       return proxied;

--- a/routes/console/index.ts
+++ b/routes/console/index.ts
@@ -182,28 +182,39 @@ function buildProxyHeaders(req: Request, proxyBase: string) {
   return proxyHeaders;
 }
 
+/**
+ * Compute the proxy base URL to reach the broadcasting server.
+ * Handles self-proxy detection by mapping to 127.0.0.1 when appropriate.
+ */
+function computeProxyBase(req: Request) {
+  let proxyBase = `http://${BROADCASTING_HOST}:${BROADCASTING_PORT}`;
+  try {
+    const incomingHost = req.headers.get('host') ?? '';
+    if (incomingHost && proxyBase.includes(incomingHost)) {
+      proxyBase = `http://127.0.0.1:${BROADCASTING_PORT}`;
+      try { console.log('[WARN] Detected self-proxying; overriding proxyBase ->', proxyBase); } catch {}
+    }
+  } catch {}
+  return proxyBase;
+}
+
+function computeProxyUrl(req: Request, proxyBase: string) {
+  let parsed: URL;
+  try { parsed = new URL(req.url); } catch (err) {
+    const hostForParse = req.headers.get('host') ?? `${BROADCASTING_HOST}:${BROADCASTING_PORT}`;
+    parsed = new URL(req.url, `http://${hostForParse}`);
+  }
+  return `${proxyBase}/console/api/ws${parsed.search ?? ''}`;
+}
+
 export const routes = {
   // Proxy the console client's streaming endpoint to the broadcasting
   // server so the browser can open a same-origin EventSource/WS.
   '/console/api/ws': async (req: Request) => {
     try { console.log('[TRACE] incoming request headers ->', Object.fromEntries(req.headers)); } catch {}
     try {
-      let proxyBase = `http://${BROADCASTING_HOST}:${BROADCASTING_PORT}`;
-      try {
-        const incomingHost = req.headers.get('host') ?? '';
-        if (incomingHost && proxyBase.includes(incomingHost)) {
-          proxyBase = `http://127.0.0.1:${BROADCASTING_PORT}`;
-          try { console.log('[WARN] Detected self-proxying; overriding proxyBase ->', proxyBase); } catch {}
-        }
-      } catch {}
-
-      let parsed: URL;
-      try { parsed = new URL(req.url); } catch (err) {
-        const hostForParse = req.headers.get('host') ?? `${BROADCASTING_HOST}:${BROADCASTING_PORT}`;
-        parsed = new URL(req.url, `http://${hostForParse}`);
-      }
-
-      const proxyUrl = `${proxyBase}/console/api/ws${parsed.search ?? ''}`;
+      const proxyBase = computeProxyBase(req);
+      const proxyUrl = computeProxyUrl(req, proxyBase);
       try { console.log('[DEBUG] /console/api/ws proxy ->', { url: proxyUrl, method: req.method, accept: req.headers.get('accept'), upgrade: req.headers.get('upgrade'), secWebSocketKey: req.headers.get('sec-websocket-key'), secWebSocketProtocol: req.headers.get('sec-websocket-protocol') }); } catch {}
 
       const proxyHeaders = buildProxyHeaders(req, proxyBase);

--- a/routes/console/index.ts
+++ b/routes/console/index.ts
@@ -5,7 +5,8 @@ import {
   computeProxyUrl,
   getUpgrader,
   performWebSocketUpgrade,
-  streamUpstreamResponse
+  streamUpstreamResponse,
+  proxyConsoleApiWsRequest,
 } from "../../lib/console-proxy";
 import * as agentState from "./api/agent-state";
 import robotsTxt from "./robots.txt";

--- a/routes/console/index.ts
+++ b/routes/console/index.ts
@@ -78,8 +78,7 @@ async function performWebSocketUpgrade(req: Request, upgrader: any, proxyBase: s
               const upstreamBody: any = res.body;
 
               try {
-                const metaRes = await fetch(`${proxyBase}/api/meta`);
-                const metaJson = await metaRes.json().catch(() => ({}));
+                const metaJson = await fetchMetaSnapshot(proxyBase);
                 try { clientWs.send(JSON.stringify(metaJson)); } catch {}
               } catch (err) {
                 try { console.warn('[DIAG] failed to send initial meta snapshot', String(err)); } catch {}
@@ -117,6 +116,16 @@ async function performWebSocketUpgrade(req: Request, upgrader: any, proxyBase: s
       resolve(null);
     }
   });
+}
+
+async function fetchMetaSnapshot(proxyBase: string): Promise<any> {
+  try {
+    const res = await fetch(`${proxyBase}/api/meta`);
+    return await res.json().catch(() => ({}));
+  } catch (err) {
+    try { console.warn('[DIAG] fetchMetaSnapshot failed', String(err)); } catch {}
+    return {};
+  }
 }
 
 /**

--- a/routes/console/index.ts
+++ b/routes/console/index.ts
@@ -1,6 +1,16 @@
 import ConsoleApp from "../../console/src/index.html";
 import robotsTxt from "./robots.txt";
 import * as agentState from "./api/agent-state";
+import {
+  streamUpstreamResponse,
+  getUpgrader,
+  performWebSocketUpgrade,
+  forwardSSEEventsToSink,
+  buildProxyHeaders,
+  computeProxyBase,
+  computeProxyUrl,
+  fetchMetaSnapshot,
+} from "../../lib/console-proxy";
 
 const BROADCASTING_HOST = process.env.BROADCASTING_HOST ?? 'localhost';
 const BROADCASTING_PORT = process.env.BROADCASTING_PORT ?? '7777';
@@ -9,40 +19,7 @@ try {
   console.log('[DEBUG] routes/console initializing', { BROADCASTING_HOST, BROADCASTING_PORT });
 } catch {}
 
-function streamUpstreamResponse(proxied: Response) {
-  const responseHeaders = new Headers(proxied.headers);
-  responseHeaders.set('cache-control', 'no-cache');
-    // Remove content-length to avoid mismatches when streaming/chunked.
-    responseHeaders.delete('content-length');
-  const upstreamBody: any = proxied.body;
-  if (upstreamBody && typeof upstreamBody.getReader === 'function') {
-    const wrapped = new ReadableStream({
-      start(controller) {
-        const reader = upstreamBody.getReader();
-        (async () => {
-          try {
-            while (true) {
-              const { done, value } = await reader.read();
-              if (done) { controller.close(); break; }
-              controller.enqueue(value);
-            }
-          } catch (e) {
-            try { controller.error(e); } catch {}
-          } finally {
-            try { reader.releaseLock(); } catch {}
-          }
-        })();
-      },
-      cancel() {
-        try { upstreamBody.cancel && upstreamBody.cancel(); } catch {}
-      },
-    });
-
-    return new Response(wrapped, { status: proxied.status, headers: responseHeaders });
-  }
-
-  return new Response(proxied.body, { status: proxied.status, headers: responseHeaders });
-}
+// moved helpers into ../../lib/console-proxy
 
 /**
  * Return an available upgradeWebSocket API compatible function or null.

--- a/routes/console/index.ts
+++ b/routes/console/index.ts
@@ -35,37 +35,7 @@ export const routes = {
       const upgradeHeader = (req.headers.get('upgrade') || '').toLowerCase();
       const hasSecWebSocketKey = !!req.headers.get('sec-websocket-key');
       if (upgradeHeader === 'websocket' || hasSecWebSocketKey) {
-        const upstreamUrlObj = new URL(proxyUrl);
-        upstreamUrlObj.protocol = upstreamUrlObj.protocol === 'https:' ? 'wss:' : 'ws:';
-        if (upstreamUrlObj.hostname === 'localhost' || BROADCASTING_HOST === 'localhost') upstreamUrlObj.hostname = '127.0.0.1';
-        const upstreamWsUrl = upstreamUrlObj.toString();
-        try { console.log('[DEBUG] /console/api/ws upstream websocket url ->', upstreamWsUrl); } catch {}
-
-        const upgrader = getUpgrader();
-        if (!upgrader) {
-          try { console.warn('[WARN] no upgradeWebSocket API available for websocket bridge'); } catch {}
-          return new Response('websocket upgrade unavailable', { status: 501 });
-        }
-
-        try { console.log('[DEBUG] invoking upgrader for client request'); } catch {}
-        const upgraded = await performWebSocketUpgrade(req, upgrader, proxyBase).catch((err) => {
-          try { console.warn('[ERROR] upgrader threw', String(err)); } catch {}
-          return null;
-        });
-
-        try { console.log('[DEBUG] upgrader invoked, upgraded ->', upgraded && (upgraded.response || upgraded)); } catch {}
-        try {
-          if (upgraded && (upgraded instanceof Response)) {
-            return upgraded;
-          }
-          if (upgraded && upgraded.response) {
-            return upgraded.response;
-          }
-        } catch (err) {
-          try { console.warn('[ERROR] failed to return upgraded response', String(err)); } catch {}
-        }
-
-        return new Response('upgrade failed', { status: 500 });
+        return await proxyConsoleUpgrade(req, proxyUrl, proxyBase);
       }
 
       // Delegate HEAD and proxy fetch handling to helper

--- a/routes/console/index.ts
+++ b/routes/console/index.ts
@@ -44,6 +44,23 @@ function streamUpstreamResponse(proxied: Response) {
   return new Response(proxied.body, { status: proxied.status, headers: responseHeaders });
 }
 
+/**
+ * Build sanitized proxy headers for upstream requests.
+ */
+function buildProxyHeaders(req: Request, proxyBase: string) {
+  const proxyHeaders = new Headers(req.headers);
+  try {
+    const proxyBaseHost = new URL(proxyBase).host;
+    proxyHeaders.set('host', proxyBaseHost);
+  } catch {
+    proxyHeaders.set('host', `${BROADCASTING_HOST}:${BROADCASTING_PORT}`);
+  }
+  proxyHeaders.delete('origin');
+  proxyHeaders.delete('referer');
+  if (!proxyHeaders.has('accept')) proxyHeaders.set('accept', 'text/event-stream');
+  return proxyHeaders;
+}
+
 export const routes = {
   // Proxy the console client's streaming endpoint to the broadcasting
   // server so the browser can open a same-origin EventSource/WS.
@@ -68,16 +85,7 @@ export const routes = {
       const proxyUrl = `${proxyBase}/console/api/ws${parsed.search ?? ''}`;
       try { console.log('[DEBUG] /console/api/ws proxy ->', { url: proxyUrl, method: req.method, accept: req.headers.get('accept'), upgrade: req.headers.get('upgrade'), secWebSocketKey: req.headers.get('sec-websocket-key'), secWebSocketProtocol: req.headers.get('sec-websocket-protocol') }); } catch {}
 
-      const proxyHeaders = new Headers(req.headers);
-      try {
-        const proxyBaseHost = new URL(proxyBase).host;
-        proxyHeaders.set('host', proxyBaseHost);
-      } catch {
-        proxyHeaders.set('host', `${BROADCASTING_HOST}:${BROADCASTING_PORT}`);
-      }
-      proxyHeaders.delete('origin');
-      proxyHeaders.delete('referer');
-      if (!proxyHeaders.has('accept')) proxyHeaders.set('accept', 'text/event-stream');
+      const proxyHeaders = buildProxyHeaders(req, proxyBase);
 
       const upgradeHeader = (req.headers.get('upgrade') || '').toLowerCase();
       const hasSecWebSocketKey = !!req.headers.get('sec-websocket-key');

--- a/routes/console/index.ts
+++ b/routes/console/index.ts
@@ -45,6 +45,107 @@ function streamUpstreamResponse(proxied: Response) {
 }
 
 /**
+ * Return an available upgradeWebSocket API compatible function or null.
+ */
+function getUpgrader(): ((req: Request, opts: any) => any) | null {
+  try {
+    if (typeof globalThis !== 'undefined') {
+      if ((globalThis as any).Bun && typeof (globalThis as any).Bun.upgradeWebSocket === 'function') return (globalThis as any).Bun.upgradeWebSocket;
+      if (typeof (globalThis as any).upgradeWebSocket === 'function') return (globalThis as any).upgradeWebSocket;
+    }
+  } catch {}
+  try {
+    if (typeof Bun !== 'undefined' && (Bun as any).upgradeWebSocket) return (Bun as any).upgradeWebSocket;
+  } catch {}
+  return null;
+}
+
+/**
+ * Perform the websocket upgrade and bridge SSE->WS to forward upstream SSE events.
+ */
+async function performWebSocketUpgrade(req: Request, upgrader: any, proxyBase: string) {
+  return new Promise<any>((resolve, _reject) => {
+    try {
+      const upgraded = upgrader(req, {
+        open(clientWs: any) {
+          (async () => {
+            try {
+              try { console.log('[DEBUG] websocket upgrade accepted; starting SSE->WS forwarder'); } catch {}
+              const sseUrl = `${proxyBase}/console/api/ws`;
+              try { console.log('[DEBUG] opening upstream SSE fetch ->', sseUrl); } catch {}
+              const res = await fetch(sseUrl, { headers: { accept: 'text/event-stream' } });
+              try { console.log('[DEBUG] upstream SSE response ->', { status: res.status, contentType: res.headers.get('content-type') }); } catch {}
+              const upstreamBody: any = res.body;
+
+              try {
+                const metaRes = await fetch(`${proxyBase}/api/meta`);
+                const metaJson = await metaRes.json().catch(() => ({}));
+                try { clientWs.send(JSON.stringify(metaJson)); } catch {}
+              } catch (err) {
+                try { console.warn('[DIAG] failed to send initial meta snapshot', String(err)); } catch {}
+              }
+
+              if (!upstreamBody || typeof upstreamBody.getReader !== 'function') {
+                try {
+                  const json = await res.json().catch(() => ({}));
+                  try { clientWs.send(JSON.stringify(json)); } catch {}
+                } catch {}
+                return;
+              }
+
+              const reader = upstreamBody.getReader();
+              const decoder = new TextDecoder();
+              let buffer = '';
+              let stopped = false;
+
+              (async () => {
+                try {
+                  while (!stopped) {
+                    const { done, value } = await reader.read();
+                    if (done) break;
+                    buffer += decoder.decode(value, { stream: true });
+                    let idx = buffer.indexOf('\r\n\r\n');
+                    if (idx === -1) idx = buffer.indexOf('\n\n');
+                    while (idx !== -1) {
+                      const event = buffer.slice(0, idx);
+                      buffer = buffer.slice(idx + (buffer.startsWith('\r\n', idx) ? 4 : 2));
+                      const dataLines = event.split(/\r?\n/).filter((l) => l.startsWith('data:'));
+                      if (dataLines.length > 0) {
+                        const data = dataLines.map((l) => l.replace(/^data:\s?/, '')).join('\n');
+                        try { clientWs.send(data); } catch (err) { try { clientWs.close(); } catch {} }
+                      }
+                      idx = buffer.indexOf('\r\n\r\n');
+                      if (idx === -1) idx = buffer.indexOf('\n\n');
+                    }
+                  }
+                } catch (err) {
+                  try { console.warn('[DIAG] SSE reader failed', String(err)); } catch {}
+                } finally {
+                  try { reader.cancel && typeof reader.cancel === 'function' && reader.cancel(); } catch {}
+                }
+              })();
+
+              clientWs.onmessage = (_ev: any) => {};
+              clientWs.onclose = (_ev: any) => { stopped = true; try { reader.cancel && typeof reader.cancel === 'function' && reader.cancel(); } catch {} };
+              clientWs.onerror = (_ev: any) => { stopped = true; try { reader.cancel && typeof reader.cancel === 'function' && reader.cancel(); } catch {} };
+              return;
+            } catch (err) {
+              try { console.warn('[WARN] simplified websocket bridge failed', String(err)); } catch {}
+              try { clientWs.close(); } catch {}
+            }
+          })();
+        },
+        message() {},
+        close() {},
+      });
+      resolve(upgraded);
+    } catch (err) {
+      resolve(null);
+    }
+  });
+}
+
+/**
  * Build sanitized proxy headers for upstream requests.
  */
 function buildProxyHeaders(req: Request, proxyBase: string) {
@@ -96,112 +197,19 @@ export const routes = {
         const upstreamWsUrl = upstreamUrlObj.toString();
         try { console.log('[DEBUG] /console/api/ws upstream websocket url ->', upstreamWsUrl); } catch {}
 
-        const upgrader = (() => {
-          try {
-            if (typeof globalThis !== 'undefined') {
-              if ((globalThis as any).Bun && typeof (globalThis as any).Bun.upgradeWebSocket === 'function') return (globalThis as any).Bun.upgradeWebSocket;
-              if (typeof (globalThis as any).upgradeWebSocket === 'function') return (globalThis as any).upgradeWebSocket;
-            }
-          } catch {}
-          try {
-            if (typeof Bun !== 'undefined' && (Bun as any).upgradeWebSocket) return (Bun as any).upgradeWebSocket;
-          } catch {}
-          return null;
-        })();
+        const upgrader = getUpgrader();
         if (!upgrader) {
           try { console.warn('[WARN] no upgradeWebSocket API available for websocket bridge'); } catch {}
           return new Response('websocket upgrade unavailable', { status: 501 });
         }
 
         try { console.log('[DEBUG] invoking upgrader for client request'); } catch {}
-        let upgraded: any = null;
-        try {
-          upgraded = upgrader(req, {
-          open(clientWs: any) {
-            // Simplified bridge: always use SSE->WS forwarding on upgrades.
-            // This avoids relying on an upstream WebSocket client and
-            // ensures an initial JSON payload is sent to the browser.
-            (async () => {
-              try {
-                try { console.log('[DEBUG] websocket upgrade accepted; starting SSE->WS forwarder'); } catch {}
-
-                const sseUrl = `${proxyBase}/console/api/ws`;
-                try { console.log('[DEBUG] opening upstream SSE fetch ->', sseUrl); } catch {}
-                const res = await fetch(sseUrl, { headers: { accept: 'text/event-stream' } });
-                try { console.log('[DEBUG] upstream SSE response ->', { status: res.status, contentType: res.headers.get('content-type') }); } catch {}
-                const upstreamBody: any = res.body;
-
-                // Send a one-off /api/meta snapshot to ensure the client
-                // gets an initial JSON message promptly.
-                try {
-                  const metaRes = await fetch(`${proxyBase}/api/meta`);
-                  const metaJson = await metaRes.json().catch(() => ({}));
-                  try { clientWs.send(JSON.stringify(metaJson)); } catch {}
-                } catch (err) {
-                  try { console.warn('[DIAG] failed to send initial meta snapshot', String(err)); } catch {}
-                }
-
-                if (!upstreamBody || typeof upstreamBody.getReader !== 'function') {
-                  // Non-streaming fallback: send JSON body and return.
-                  try {
-                    const json = await res.json().catch(() => ({}));
-                    try { clientWs.send(JSON.stringify(json)); } catch {}
-                  } catch {}
-                  return;
-                }
-
-                const reader = upstreamBody.getReader();
-                const decoder = new TextDecoder();
-                let buffer = '';
-                let stopped = false;
-
-                (async () => {
-                  try {
-                    while (!stopped) {
-                      const { done, value } = await reader.read();
-                      if (done) break;
-                      buffer += decoder.decode(value, { stream: true });
-                      let idx = buffer.indexOf('\r\n\r\n');
-                      if (idx === -1) idx = buffer.indexOf('\n\n');
-                      while (idx !== -1) {
-                        const event = buffer.slice(0, idx);
-                        buffer = buffer.slice(idx + (buffer.startsWith('\r\n', idx) ? 4 : 2));
-                        const dataLines = event.split(/\r?\n/).filter((l) => l.startsWith('data:'));
-                        if (dataLines.length > 0) {
-                          const data = dataLines.map((l) => l.replace(/^data:\s?/, '')).join('\n');
-                          try { clientWs.send(data); } catch (err) { try { clientWs.close(); } catch {} }
-                        }
-                        idx = buffer.indexOf('\r\n\r\n');
-                        if (idx === -1) idx = buffer.indexOf('\n\n');
-                      }
-                    }
-                  } catch (err) {
-                    try { console.warn('[DIAG] SSE reader failed', String(err)); } catch {}
-                  } finally {
-                    try { reader.cancel && typeof reader.cancel === 'function' && reader.cancel(); } catch {}
-                  }
-                })();
-
-                clientWs.onmessage = (_ev: any) => {};
-                clientWs.onclose = (_ev: any) => { stopped = true; try { reader.cancel && typeof reader.cancel === 'function' && reader.cancel(); } catch {} };
-                clientWs.onerror = (_ev: any) => { stopped = true; try { reader.cancel && typeof reader.cancel === 'function' && reader.cancel(); } catch {} };
-                return;
-              } catch (err) {
-                try { console.warn('[WARN] simplified websocket bridge failed', String(err)); } catch {}
-                try { clientWs.close(); } catch {}
-              }
-            })();
-          },
-          message() {},
-          close() {},
-          });
-        } catch (err) {
+        const upgraded = await performWebSocketUpgrade(req, upgrader, proxyBase).catch((err) => {
           try { console.warn('[ERROR] upgrader threw', String(err)); } catch {}
-          upgraded = null;
-        }
+          return null;
+        });
 
         try { console.log('[DEBUG] upgrader invoked, upgraded ->', upgraded && (upgraded.response || upgraded)); } catch {}
-        // Support both forms: upgraded may be a Response or an object with `response`.
         try {
           if (upgraded && (upgraded instanceof Response)) {
             return upgraded;


### PR DESCRIPTION
Refactor console SSE proxy to use shared streaming helper  to avoid  mismatches when proxying SSE bodies. This prevents browsers from receiving incomplete/chunked encodings that cause  and the 'ライブ接続が切断されました' error.

Changes:
- Use  in  for SSE responses.

Verification:
- Integration tests for console proxy passed locally (4 tests, 0 failures).

Closes: #243