### PR TITLE
fix: preserve EventSource reconnect behavior for console live updates

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -37,6 +37,9 @@
 
 - [x] [MUST] Fix OBS browser syntax error — Tightened navigation detection in `src/catchAll.ts` to avoid serving `index.html` for module/file requests (fixes syntax error in old OBS browser).
 
+- [x] [MUST] Fix console SSE reconnect handling — Allow EventSource to auto-reconnect and avoid forcing immediate closure on transient SSE errors.
+- [x] [SHOULD] Add regression test for SSE EventSource error handling — Verify console status error only appears when the stream is fully closed.
+
 - [x] [MUST] Issue #225: 管理コンソール - これまでの発話の改善 — 読了、テスト追加、実装（単語ごとにカード表示、非マルコフ文言の除去）を行いました。
 - [ ] [MUST] Commit changes and open PR for branch `225-管理コンソール-これまでの発話の改善` — Pending: create PR with description and attach screenshots if needed.
  - [ ] [SHOULD] Propose AGT library enhancement — create an issue requesting generation trace (node path) or API to return nodes visited during generation.

--- a/console/src/AgentStatus.test.tsx
+++ b/console/src/AgentStatus.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
-import { AgentStatus } from "./AgentStatus";
+import { AgentStatus, shouldShowAgentStatusErrorForEventSourceError } from "./AgentStatus";
 import { GameStatusSection } from "./agentStatusSections/GameStatusSection";
 import { LiveDeliveryStatusSection } from "./agentStatusSections/LiveDeliveryStatusSection";
 import { MarkovModelStatusSection } from "./agentStatusSections/MarkovModelStatusSection";
@@ -106,5 +106,14 @@ describe("AgentStatus category sections", () => {
     expect(html).toContain("これまでの発話");
     // Expect each word to be rendered as a separate card element with distinctive class
     expect((html.match(/speech-word-chip/g) || []).length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe("AgentStatus SSE error handling", () => {
+  it("reports an error only when the EventSource is fully closed", () => {
+    expect(shouldShowAgentStatusErrorForEventSourceError(0)).toBe(false);
+    expect(shouldShowAgentStatusErrorForEventSourceError(1)).toBe(false);
+    expect(shouldShowAgentStatusErrorForEventSourceError(2)).toBe(true);
+    expect(shouldShowAgentStatusErrorForEventSourceError(-1)).toBe(false);
   });
 });

--- a/console/src/AgentStatus.tsx
+++ b/console/src/AgentStatus.tsx
@@ -9,4 +9,5 @@ export {
   startAgentStateAutoRefresh,
   AGENT_STATE_MOCK_NOTICE_MESSAGE,
   AGENT_STATE_REFRESH_INTERVAL_MS,
+  shouldShowAgentStatusErrorForEventSourceError,
 } from "./AgentStatus/index";

--- a/console/src/AgentStatus/index.tsx
+++ b/console/src/AgentStatus/index.tsx
@@ -7,6 +7,12 @@ import { GAME_SECTION_TITLE, GameStatusSection } from "../agentStatusSections/Ga
 import { LIVE_DELIVERY_SECTION_TITLE, LiveDeliveryStatusSection } from "../agentStatusSections/LiveDeliveryStatusSection";
 import { MARKOV_MODEL_SECTION_TITLE, MarkovModelStatusSection } from "../agentStatusSections/MarkovModelStatusSection";
 
+const EVENT_SOURCE_CLOSED = typeof EventSource !== 'undefined' ? EventSource.CLOSED : 2;
+
+export function shouldShowAgentStatusErrorForEventSourceError(readyState: number): boolean {
+  return readyState === EVENT_SOURCE_CLOSED;
+}
+
 /**
  * Response schema returned by `/console/api/agent-state`.
  * `error` is populated when the proxy endpoint returns a non-200 response.
@@ -519,8 +525,13 @@ export function AgentStatus() {
         }
       };
       es.onerror = () => {
-        setAgentStatusError('ライブ接続が切断されました');
-        try { es?.close(); } catch {}
+        try {
+          if (es?.readyState === EventSource.CLOSED) {
+            setAgentStatusError('ライブ接続が切断されました');
+          }
+        } catch {
+          setAgentStatusError('ライブ接続が切断されました');
+        }
       };
     })();
 


### PR DESCRIPTION
Fixes issue #245 by avoiding immediate EventSource closure on transient SSE errors in the console live status component. Added regression coverage verifying the error state is only shown when the EventSource is fully closed. Tests: bun run typecheck && bun test console/src/.