### PR TITLE
fix: console trace support for Markov speech history

### DIFF
--- a/console/src/AgentStatus.test.tsx
+++ b/console/src/AgentStatus.test.tsx
@@ -108,6 +108,33 @@ describe("AgentStatus category sections", () => {
     expect((html.match(/speech-word-chip/g) || []).length).toBeGreaterThanOrEqual(3);
   });
 
+  it("normalizes object speech payloads for top-level speech", () => {
+    const stateResponse = {
+      nGram: 4,
+      speech: { speech: { text: "コメント", nodes: ["コメント"] }, silent: false },
+    } as any;
+
+    const rows = require("./AgentStatus").createAgentStatusRows(stateResponse);
+    const speechRow = rows.find((row: any) => row.label === "発話内容");
+    expect(speechRow?.value).toBe("コメント");
+  });
+
+  it("normalizes object speech payloads in speech history", () => {
+    const stateResponse = {
+      nGram: 4,
+      speechHistory: [
+        { id: "speech-1", speech: { text: "コメント", nodes: ["コメント"] }, nGram: 4, nGramRaw: 4 },
+      ],
+    } as any;
+
+    const rows = require("./AgentStatus").createAgentStatusRows(stateResponse);
+    const markovRows = rows.filter((r: any) => r.label === "これまでの発話" || r.label === "生成N-gram");
+    const html = renderToStaticMarkup(<MarkovModelStatusSection markovModelRows={markovRows} />);
+
+    expect(html).toContain("コメント");
+    expect((html.match(/speech-word-chip/g) || []).length).toBe(1);
+  });
+
   it("renders markov trace nodes when available", () => {
     const stateResponse = {
       nGram: 4,

--- a/console/src/AgentStatus/index.tsx
+++ b/console/src/AgentStatus/index.tsx
@@ -41,12 +41,12 @@ type AgentStateResponse = {
   nGram?: number
   nGramRaw?: number
   speech?: {
-    speech?: string
+    speech?: string | { text?: string; nodes?: readonly string[] } | { speech?: string; text?: string; nodes?: readonly string[] }
     silent?: boolean
   }
   speechHistory?: Array<{
     id?: string
-    speech?: string
+    speech?: string | { text?: string; nodes?: readonly string[] }
     nGram?: number
     nGramRaw?: number
     nodes?: readonly string[]
@@ -160,6 +160,25 @@ const formatNGramValue = (nGram: number | undefined, nGramRaw: number | undefine
   return `${nGramValue} (${formattedRaw})`;
 };
 
+const normalizeSpeechText = (
+  speech: string | { text?: string; nodes?: readonly string[] } | { speech?: string; text?: string; nodes?: readonly string[] } | undefined,
+): string | undefined => {
+  if (typeof speech === 'string') {
+    return speech.trim() || undefined;
+  }
+
+  if (speech && typeof speech === 'object') {
+    const textValue = typeof (speech as any).text === 'string'
+      ? (speech as any).text
+      : typeof (speech as any).speech === 'string'
+        ? (speech as any).speech
+        : undefined;
+    return typeof textValue === 'string' ? textValue.trim() || undefined : undefined;
+  }
+
+  return undefined;
+};
+
 const formatSpeechHistoryItemText = (
   speechText: string,
   nGram: number | undefined,
@@ -182,7 +201,7 @@ const createSpeechHistoryDisplayItems = (
   }
   const speechHistoryItems = speechHistory.reduce<Array<{ id: string; speechText: string; displayLine: string; nGramLabel: string; nodes?: string[] }>>(
     (accumulatedItems, speechHistoryItem) => {
-      const speechText = speechHistoryItem.speech?.trim();
+      const speechText = normalizeSpeechText(speechHistoryItem.speech);
       if (!speechText) {
         return accumulatedItems;
       }
@@ -426,7 +445,7 @@ export const createAgentStatusRows = (stateResponse: AgentStateResponse | null):
   if (stateResponse?.canSpeak === false) {
     rows.push({ label: "発話内容", value: SPEECH_UNAVAILABLE_INDICATOR });
   } else if (stateResponse?.speech !== undefined) {
-    rows.push({ label: "発話内容", value: stateResponse.speech.speech ?? "-" });
+    rows.push({ label: "発話内容", value: normalizeSpeechText(stateResponse.speech.speech) ?? "-" });
   }
 
   return rows;

--- a/lib/MarkovChainModel/index.test.ts
+++ b/lib/MarkovChainModel/index.test.ts
@@ -29,6 +29,22 @@ describe('an empty markov chain model', () => {
     const model = new MarkovChainModel();
     expect(getResultText(model.generate())).toBe('。');
   });
+
+  it('should return trace nodes when generating text', () => {
+    const model = new MarkovChainModel({
+      '': { 'こん': 1 },
+      'こん': { 'にち': 1 },
+      'にち': { 'は': 1 },
+      'は': { '。': 1 },
+    });
+
+    const result = model.generate();
+    expect(typeof result).toBe('object');
+    expect(result).not.toBeNull();
+    expect((result as any).text).toBe('こんにちは。');
+    expect(Array.isArray((result as any).nodes)).toBe(true);
+    expect((result as any).nodes).toEqual(['こん', 'にち', 'は', '。']);
+  });
 });
 
 describe('a no-branch model', () => {

--- a/lib/MarkovChainModel/index.ts
+++ b/lib/MarkovChainModel/index.ts
@@ -77,8 +77,8 @@ export class MarkovChainModel implements TalkModel {
     nGram = 1,
   ): string | { text: string; nodes?: string[] } {
     // Delegates n-gram generation to AGT's MarkovModel implementation.
-    // AGT may return either a string or an object with `text` and `nodes`.
-    const res = this.#model.gen(start, nGram) as unknown;
+    // Request trace output so we can preserve node paths for console diagnostics.
+    const res = this.#model.gen(start, nGram, { trace: true }) as unknown;
     if (typeof res === 'string') return res;
     if (res && typeof res === 'object' && 'text' in res) {
       return {


### PR DESCRIPTION
## Summary

Enable AGT Markov trace generation for console speech history so the management console can display node trace information from generated speech.

## Changes

- `lib/MarkovChainModel/index.ts`: pass `{ trace: true }` to `this.#model.gen(...)`
- `lib/MarkovChainModel/index.test.ts`: add regression test verifying trace nodes are returned.

## Verification

- `bun test lib/MarkovChainModel/index.test.ts --run`
- `bun run typecheck`
