### PR TITLE
fix(console): preserve SSE proxy connection and remove hop-by-hop headers to prevent ERR_INCOMPLETE_CHUNKED_ENCODING

### DIFF
--- a/console/index.ts
+++ b/console/index.ts
@@ -36,6 +36,24 @@ export function createAccessDeniedRedirectResponse(requestURL: URL): Response {
   });
 }
 
+export function createLoopbackProxyHeaders(originalHeaders: Headers): Headers {
+  const headers = new Headers(originalHeaders);
+  const hopByHopHeaders = [
+    'connection',
+    'keep-alive',
+    'proxy-connection',
+    'transfer-encoding',
+    'te',
+    'trailer',
+    'upgrade',
+  ];
+  hopByHopHeaders.forEach((header) => headers.delete(header));
+  headers.delete('host');
+  headers.delete('origin');
+  headers.delete('referer');
+  return headers;
+}
+
 /**
  * Start the console server.
  *
@@ -200,10 +218,7 @@ export function startConsoleServer(certPath: string = consoleCertPath, keyPath: 
             }
 
             // Strip hop-by-hop and origin-specific headers that should not be forwarded as-is.
-            const proxyHeaders = new Headers(req.headers);
-            proxyHeaders.delete('host');
-            proxyHeaders.delete('origin');
-            proxyHeaders.delete('referer');
+            const proxyHeaders = createLoopbackProxyHeaders(req.headers);
 
             const response = await fetch(proxyURL.toString(), {
               method: req.method,

--- a/console/index.ts
+++ b/console/index.ts
@@ -38,6 +38,8 @@ export function createAccessDeniedRedirectResponse(requestURL: URL): Response {
 
 export function createLoopbackProxyHeaders(originalHeaders: Headers): Headers {
   const headers = new Headers(originalHeaders);
+  // Save Connection header value before removing it, so we can strip RFC 7230 tokens after.
+  const connectionValue = headers.get('connection');
   const hopByHopHeaders = [
     'connection',
     'keep-alive',
@@ -49,17 +51,16 @@ export function createLoopbackProxyHeaders(originalHeaders: Headers): Headers {
     'trailer',
     'upgrade',
   ];
+  hopByHopHeaders.forEach((header) => headers.delete(header));
+  headers.delete('host');
+  headers.delete('origin');
+  headers.delete('referer');
   // Per RFC 7230, also remove any header names listed in the Connection header value.
-  const connectionValue = headers.get('connection');
   if (connectionValue) {
     connectionValue.split(',').map(t => t.trim().toLowerCase()).forEach(token => {
       if (token) headers.delete(token);
     });
   }
-  hopByHopHeaders.forEach((header) => headers.delete(header));
-  headers.delete('host');
-  headers.delete('origin');
-  headers.delete('referer');
   return headers;
 }
 

--- a/console/index.ts
+++ b/console/index.ts
@@ -41,12 +41,21 @@ export function createLoopbackProxyHeaders(originalHeaders: Headers): Headers {
   const hopByHopHeaders = [
     'connection',
     'keep-alive',
+    'proxy-authenticate',
+    'proxy-authorization',
     'proxy-connection',
     'transfer-encoding',
     'te',
     'trailer',
     'upgrade',
   ];
+  // Per RFC 7230, also remove any header names listed in the Connection header value.
+  const connectionValue = headers.get('connection');
+  if (connectionValue) {
+    connectionValue.split(',').map(t => t.trim().toLowerCase()).forEach(token => {
+      if (token) headers.delete(token);
+    });
+  }
   hopByHopHeaders.forEach((header) => headers.delete(header));
   headers.delete('host');
   headers.delete('origin');

--- a/lib/console-proxy.test.ts
+++ b/lib/console-proxy.test.ts
@@ -1,0 +1,48 @@
+import { test, expect } from 'bun:test';
+import { createResilientSseProxy } from './console-proxy';
+
+test('createResilientSseProxy sends keepalive comments for idle SSE streams', async () => {
+  const firstResponse = new Response(new ReadableStream<Uint8Array>({
+    start() {
+      // Keep the first upstream stream open without sending any data.
+    },
+  }), {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    },
+  });
+
+  const proxyResponse = createResilientSseProxy(
+    firstResponse,
+    async () => {
+      return new Response(new ReadableStream<Uint8Array>({
+        start() {
+          // Keep the reconnect stream open as well.
+        },
+      }), {
+        headers: {
+          'Content-Type': 'text/event-stream',
+          'Cache-Control': 'no-cache',
+          Connection: 'keep-alive',
+        },
+      });
+    },
+    50,
+    20,
+  );
+
+  const reader = proxyResponse.body!.getReader();
+  const decoder = new TextDecoder();
+
+  const result = await Promise.race([
+    reader.read(),
+    new Promise<never>((_, reject) => setTimeout(() => reject(new Error('timeout waiting for keepalive')), 500)),
+  ]);
+
+  expect(result.done).toBe(false);
+  expect(decoder.decode(result.value)).toContain(': keepalive');
+
+  await reader.cancel();
+});

--- a/lib/console-proxy.ts
+++ b/lib/console-proxy.ts
@@ -325,7 +325,9 @@ export function createResilientSseProxy(
         clearInterval(keepaliveTimer);
         keepaliveTimer = null;
       }
+      // Abort any in-flight reconnect fetch and cancel any active upstream reader,
       // allowing the loop to exit promptly without leaking the upstream connection.
+      try { abortController.abort(); } catch {}
       try { currentReader?.cancel(); } catch {}
     },
   });

--- a/lib/console-proxy.ts
+++ b/lib/console-proxy.ts
@@ -216,15 +216,19 @@ function findSseBoundary(buffer: string): { end: number; length: number } | null
  * @param firstResponse - The initial upstream SSE response (already fetched by caller).
  * @param fetchUpstream - Factory called on each reconnect; receives an AbortSignal.
  * @param reconnectDelayMs - Delay before reconnecting after upstream drop.
+ * @param keepaliveIntervalMs - Periodically sends SSE comment pings on idle downstream
+ *   connections to avoid idle chunked-encoding termination.
  */
 export function createResilientSseProxy(
   firstResponse: Response,
   fetchUpstream: (signal: AbortSignal) => Promise<Response>,
   reconnectDelayMs = 500,
+  keepaliveIntervalMs = 5_000,
 ): Response {
   let stopped = false;
   let abortController = new AbortController();
   let currentReader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+  let keepaliveTimer: ReturnType<typeof setInterval> | null = null;
   const encoder = new TextEncoder();
 
   // Preserve SSE-relevant headers from the initial upstream response.
@@ -273,6 +277,13 @@ export function createResilientSseProxy(
 
   const stream = new ReadableStream<Uint8Array>({
     start(controller) {
+      if (keepaliveIntervalMs > 0) {
+        keepaliveTimer = setInterval(() => {
+          if (stopped) return;
+          try { controller.enqueue(encoder.encode(': keepalive\n\n')); } catch {}
+        }, keepaliveIntervalMs);
+      }
+
       (async () => {
         try {
           // Process the initial response body (already fetched by the caller).
@@ -294,16 +305,26 @@ export function createResilientSseProxy(
             }
           }
         } finally {
+          if (keepaliveTimer) {
+            clearInterval(keepaliveTimer);
+            keepaliveTimer = null;
+          }
           try { controller.close(); } catch {}
         }
       })().catch(() => {
+        if (keepaliveTimer) {
+          clearInterval(keepaliveTimer);
+          keepaliveTimer = null;
+        }
         try { controller.close(); } catch {}
       });
     },
     cancel() {
       stopped = true;
-      try { abortController.abort(); } catch {}
-      // Cancel the in-flight reader so reader.read() unblocks immediately,
+      if (keepaliveTimer) {
+        clearInterval(keepaliveTimer);
+        keepaliveTimer = null;
+      }
       // allowing the loop to exit promptly without leaking the upstream connection.
       try { currentReader?.cancel(); } catch {}
     },

--- a/tests/e2e/console/console.test.ts
+++ b/tests/e2e/console/console.test.ts
@@ -322,11 +322,10 @@ test.describe("console", () => {
       } as any;
       try {
         for (const key of Object.getOwnPropertyNames(OrigEventSource)) {
-          Object.defineProperty(
-            WrappedEventSource,
-            key,
-            Object.getOwnPropertyDescriptor(OrigEventSource, key)!
-          );
+          const descriptor = Object.getOwnPropertyDescriptor(OrigEventSource, key);
+          if (descriptor) {
+            Object.defineProperty(WrappedEventSource, key, descriptor);
+          }
         }
       } catch {}
       (window as any).EventSource = WrappedEventSource;

--- a/tests/e2e/console/console.test.ts
+++ b/tests/e2e/console/console.test.ts
@@ -309,6 +309,39 @@ test.describe("console", () => {
     await expect(detailsLocator).toContainText("4-gram", { timeout: 10_000 });
   });
 
+  test("keeps SSE connection open while the console browser tab is open", async ({ page, request }) => {
+    await page.addInitScript(() => {
+      const OrigEventSource = (window as any).EventSource;
+      Object.defineProperty(window, '__sseOpen', { value: false, writable: true, configurable: true });
+      Object.defineProperty(window, '__sseError', { value: false, writable: true, configurable: true });
+      (window as any).EventSource = function (url: string) {
+        const es = new OrigEventSource(url);
+        try { es.addEventListener('open', () => { (window as any).__sseOpen = true; }); } catch {}
+        try { es.addEventListener('error', () => { (window as any).__sseError = true; }); } catch {}
+        return es;
+      } as any;
+      try { (window as any).EventSource.prototype = OrigEventSource.prototype; } catch {}
+    });
+
+    await page.goto(`${CONSOLE_BASE_URL}/console/`, { waitUntil: 'domcontentloaded', timeout: BROWSER_PAGE_LOAD_TIMEOUT_MS });
+    await page.waitForFunction(() => (window as any).__sseOpen === true, { timeout: 10_000 });
+
+    // Keep the console tab open long enough for idle SSE/keepalive behavior
+    // to be observed, then send a broadcast update.
+    await page.waitForTimeout(6_000);
+    expect(await page.evaluate(() => (window as any).__sseError)).toBeFalsy();
+
+    const payload = cloneAgentStateResponseMockFixture();
+    const res = await request.post(`${BROADCASTING_BASE_URL}/api/meta`, { data: payload });
+    expect(res.ok(), `broadcast POST failed: ${res.status()}`).toBeTruthy();
+
+    const detailsLocator = page.getByTestId("agent-status-details");
+    await detailsLocator.waitFor({ timeout: 10_000 });
+    await expect(detailsLocator).toContainText("生成N-gram");
+    await expect(detailsLocator).toContainText("4-gram", { timeout: 10_000 });
+    expect(await page.evaluate(() => (window as any).__sseError)).toBeFalsy();
+  });
+
   test("proxy returns SSE content-type at /console/api/ws", async ({ request }) => {
     // Use HEAD to inspect headers without opening a persistent SSE stream
     // which can cause the test runner's HTTP client to abort on chunked

--- a/tests/e2e/console/console.test.ts
+++ b/tests/e2e/console/console.test.ts
@@ -314,13 +314,22 @@ test.describe("console", () => {
       const OrigEventSource = (window as any).EventSource;
       Object.defineProperty(window, '__sseOpen', { value: false, writable: true, configurable: true });
       Object.defineProperty(window, '__sseError', { value: false, writable: true, configurable: true });
-      (window as any).EventSource = function (url: string) {
+      const WrappedEventSource = function (url: string) {
         const es = new OrigEventSource(url);
         try { es.addEventListener('open', () => { (window as any).__sseOpen = true; }); } catch {}
         try { es.addEventListener('error', () => { (window as any).__sseError = true; }); } catch {}
         return es;
       } as any;
-      try { (window as any).EventSource.prototype = OrigEventSource.prototype; } catch {}
+      try {
+        for (const key of Object.getOwnPropertyNames(OrigEventSource)) {
+          Object.defineProperty(
+            WrappedEventSource,
+            key,
+            Object.getOwnPropertyDescriptor(OrigEventSource, key)!
+          );
+        }
+      } catch {}
+      (window as any).EventSource = WrappedEventSource;
     });
 
     await page.goto(`${CONSOLE_BASE_URL}/console/`, { waitUntil: 'domcontentloaded', timeout: BROWSER_PAGE_LOAD_TIMEOUT_MS });

--- a/tests/integration/console/index.test.ts
+++ b/tests/integration/console/index.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { consoleBasePath, consoleRedirectURL, createAccessDeniedRedirectResponse, startConsoleServer } from "../../../console/index";
+import { createLoopbackProxyHeaders, consoleBasePath, consoleRedirectURL, createAccessDeniedRedirectResponse, startConsoleServer } from "../../../console/index";
 
 test("throws when TLS certificate file is missing", () => {
   const tmpDir = mkdtempSync(join(tmpdir(), 'console-test-'));
@@ -37,4 +37,23 @@ test("returns 308 to /console/ for denied non-console access", () => {
   const response = createAccessDeniedRedirectResponse(new URL('https://example.com/other/path'));
   expect(response.status).toBe(308);
   expect(response.headers.get('location')).toBe(consoleBasePath);
+});
+
+test("strips hop-by-hop headers from loopback proxy requests", () => {
+  const originalHeaders = new Headers([
+    ['connection', 'keep-alive'],
+    ['upgrade', 'websocket'],
+    ['host', 'x85-131-251-123.static.xvps.ne.jp'],
+    ['origin', 'https://x85-131-251-123.static.xvps.ne.jp'],
+    ['referer', 'https://x85-131-251-123.static.xvps.ne.jp/console/'],
+    ['accept', 'text/event-stream'],
+  ]);
+
+  const headers = createLoopbackProxyHeaders(originalHeaders);
+  expect(headers.get('connection')).toBeNull();
+  expect(headers.get('upgrade')).toBeNull();
+  expect(headers.get('host')).toBeNull();
+  expect(headers.get('origin')).toBeNull();
+  expect(headers.get('referer')).toBeNull();
+  expect(headers.get('accept')).toBe('text/event-stream');
 });

--- a/tests/integration/console/index.test.ts
+++ b/tests/integration/console/index.test.ts
@@ -57,3 +57,31 @@ test("strips hop-by-hop headers from loopback proxy requests", () => {
   expect(headers.get('referer')).toBeNull();
   expect(headers.get('accept')).toBe('text/event-stream');
 });
+
+test("strips proxy-authenticate and proxy-authorization from loopback proxy requests", () => {
+  const originalHeaders = new Headers([
+    ['proxy-authenticate', 'Basic realm="proxy"'],
+    ['proxy-authorization', 'Basic dXNlcjpwYXNz'],
+    ['authorization', 'Bearer token123'],
+  ]);
+
+  const headers = createLoopbackProxyHeaders(originalHeaders);
+  expect(headers.get('proxy-authenticate')).toBeNull();
+  expect(headers.get('proxy-authorization')).toBeNull();
+  expect(headers.get('authorization')).toBe('Bearer token123');
+});
+
+test("strips headers named in Connection header value (RFC 7230)", () => {
+  const originalHeaders = new Headers([
+    ['connection', 'x-custom-hop, another-hop'],
+    ['x-custom-hop', 'some-value'],
+    ['another-hop', 'other-value'],
+    ['x-preserved', 'preserved'],
+  ]);
+
+  const headers = createLoopbackProxyHeaders(originalHeaders);
+  expect(headers.get('connection')).toBeNull();
+  expect(headers.get('x-custom-hop')).toBeNull();
+  expect(headers.get('another-hop')).toBeNull();
+  expect(headers.get('x-preserved')).toBe('preserved');
+});


### PR DESCRIPTION
Fixes #259 by sanitizing hop-by-hop headers in the outer console proxy and keeping SSE idle connections alive with periodic keepalive comments. Includes regression tests for browser SSE persistence and loopback proxy header stripping.