### PR TITLE
fix(console): use actual broadcasting port for console proxy and fail on console startup error in production

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,15 +2,23 @@
 FROM mcr.microsoft.com/devcontainers/base:2.1-debian12
 
 ARG USERNAME=vscode
+ENV BUN_INSTALL=/usr/local
 WORKDIR /workspace
 
-RUN apt-get update && rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        curl \
+        ca-certificates \
+        libcap2-bin \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Bun system-wide.
+RUN curl -fsSL https://bun.sh/install | bash \
+    && chmod +x /usr/local/bin/bun
 
 USER ${USERNAME}
 
-# Install bun
-RUN curl -fsSL https://bun.com/install | bash
+ENV PATH="${BUN_INSTALL}/bin:${PATH}"
 
-ENV PATH="/home/${USERNAME}/.bun/bin:${PATH}"
-
-COPY package.json bun.lock* /workspace/
+COPY package.json bun.lock* ./

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,14 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/git": {
+      "version": "1.3.5",
+      "resolved": "ghcr.io/devcontainers/features/git@sha256:27905dc196c01f77d6ba8709cb82eeaf330b3b108772e2f02d1cd0d826de1251",
+      "integrity": "sha256:27905dc196c01f77d6ba8709cb82eeaf330b3b108772e2f02d1cd0d826de1251"
+    },
+    "ghcr.io/devcontainers/features/github-cli": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,5 +11,11 @@
   "workspaceMount": "source=${localWorkspaceFolder},target=${containerWorkspaceFolder},type=bind,consistency=cached",
   "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
   "postCreateCommand": "bun ci",
+  "forwardPorts": [443, 8777],
+  "runArgs": ["--cap-add=NET_BIND_SERVICE"],
+  "remoteEnv": {
+    "CONSOLE_TLS_CERT": "var/e2e-tls/fullchain.pem",
+    "CONSOLE_TLS_KEY": "var/e2e-tls/privkey.pem"
+  },
   "remoteUser": "vscode"
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node-terminal",
+            "name": "Run dev servers",
+            "request": "launch",
+            "command": "bun run dev",
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}

--- a/TODO.md
+++ b/TODO.md
@@ -37,8 +37,7 @@
 
 - [x] [MUST] Fix OBS browser syntax error — Tightened navigation detection in `src/catchAll.ts` to avoid serving `index.html` for module/file requests (fixes syntax error in old OBS browser).
 
-- [x] [MUST] Fix console SSE reconnect handling — Allow EventSource to auto-reconnect and avoid forcing immediate closure on transient SSE errors.
-- [x] [SHOULD] Add regression test for SSE EventSource error handling — Verify console status error only appears when the stream is fully closed.
+- [x] [MUST] Fix console SSE reconnect handling — Allow EventSource to auto-reconnect and avoid forcing immediate closure on transient SSE errors.- [x] [MUST] Bypass management console IP restriction in development mode — Allow `bun run dev` to access the management console without the production-only IP allowlist.- [x] [SHOULD] Add regression test for SSE EventSource error handling — Verify console status error only appears when the stream is fully closed.
 - [x] [MUST] Refactor AgentStatus component — Reorganize `console/src/AgentStatus/index.tsx` and split AgentStatus logic into reusable submodules.
 
 - [x] [MUST] Issue #225: 管理コンソール - これまでの発話の改善 — 読了、テスト追加、実装（単語ごとにカード表示、非マルコフ文言の除去）を行いました。

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@nahcnuj/makamujo",
       "dependencies": {
         "@playwright/browser-chromium": "^1.59.1",
-        "automated-gameplay-transmitter": "^0.6.2",
+        "automated-gameplay-transmitter": "^0.6.3",
         "bun": "^1.3.13",
         "bun-plugin-tailwind": "^0.1.2",
         "playwright": "^1.59.1",
@@ -122,7 +122,7 @@
 
     "arr-union": ["arr-union@3.1.0", "", {}, "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q=="],
 
-    "automated-gameplay-transmitter": ["automated-gameplay-transmitter@0.6.2", "", { "dependencies": { "@playwright/browser-chromium": "^1.57.0", "bun-plugin-tailwind": "^0.1.2", "playwright": "^1.57.0", "playwright-extra": "^4.3.6", "puppeteer-extra-plugin-stealth": "^2.11.2", "tailwindcss": "^4.1.18" }, "peerDependencies": { "react": ">=19", "react-dom": ">=19" } }, "sha512-wCwAyIhEnCZgzLmnPY3CkyeCVEv+i0uvFvyXfXEmeLY8DxYNQ2exXy+D0JJNn4GcyBYTxTciabeVlk+zSdoYPw=="],
+    "automated-gameplay-transmitter": ["automated-gameplay-transmitter@0.6.3", "", { "dependencies": { "@playwright/browser-chromium": "^1.57.0", "bun-plugin-tailwind": "^0.1.2", "playwright": "^1.57.0", "playwright-extra": "^4.3.6", "puppeteer-extra-plugin-stealth": "^2.11.2", "tailwindcss": "^4.1.18" }, "peerDependencies": { "react": ">=19", "react-dom": ">=19" } }, "sha512-J6OjGkapgpLKvBTIsop0cPk/hBzLm2yIDXoiMuWzzt1uEakfG/4s7wzvZO+jADugFI4bGl7Shgpprs/Q3kzUJA=="],
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 

--- a/console/index.ts
+++ b/console/index.ts
@@ -36,6 +36,10 @@ export function createAccessDeniedRedirectResponse(requestURL: URL): Response {
   });
 }
 
+export function isConsoleIPRestrictionEnabled(): boolean {
+  return process.env.NODE_ENV === 'production';
+}
+
 export function createLoopbackProxyHeaders(originalHeaders: Headers): Headers {
   const headers = new Headers(originalHeaders);
   // Save Connection header value before removing it, so we can strip RFC 7230 tokens after.
@@ -77,9 +81,26 @@ export function createLoopbackProxyHeaders(originalHeaders: Headers): Headers {
  * @param keyPath  - Path to the TLS private key file. Defaults to the `CONSOLE_TLS_KEY` env var.
  * @returns A handle with the outer server's URL and a unified `stop()` method.
  */
-export function startConsoleServer(certPath: string = consoleCertPath, keyPath: string = consoleKeyPath): ConsoleServer {
+export type StartConsoleServerOptions = {
+  certPath?: string;
+  keyPath?: string;
+  broadcastingHost?: string;
+  broadcastingPort?: number | string;
+};
+
+export function startConsoleServer({
+  certPath = consoleCertPath,
+  keyPath = consoleKeyPath,
+  broadcastingHost = process.env.BROADCASTING_HOST ?? 'localhost',
+  broadcastingPort = process.env.BROADCASTING_PORT ?? '7777',
+}: StartConsoleServerOptions = {}): ConsoleServer {
   const accessLogger = createDailyRotatingJsonLogger(consoleAccessLogPath);
   const errorLogger = createDailyRotatingJsonLogger(consoleErrorLogPath);
+
+  // Configure the console loopback proxy to route requests to the current
+  // broadcasting server. This avoids relying on an external BROADCASTING_PORT
+  // environment variable in development.
+  consoleRoutes.setBroadcastingTarget(broadcastingHost, broadcastingPort);
 
   // Loopback console server: binds to 127.0.0.1 only and serves all console routes
   // (including HTML bundling). Not exposed to the public network.
@@ -133,7 +154,8 @@ export function startConsoleServer(certPath: string = consoleCertPath, keyPath: 
         const ip = server.requestIP(req);
         const clientIpAddress = ip ? `${ip.family}/${ip.address}` : 'unknown';
         let statusCode = 500;
-        if (!ip || !AllowedIP.equals(ip)) {
+        const consoleIpRestrictionEnabled = isConsoleIPRestrictionEnabled();
+        if (consoleIpRestrictionEnabled && (!ip || !AllowedIP.equals(ip))) {
           const redirectResponse = createAccessDeniedRedirectResponse(requestURL);
           statusCode = redirectResponse.status;
           errorLogger.write({

--- a/index.ts
+++ b/index.ts
@@ -539,7 +539,10 @@ console.log(`🚀 Server running at ${server.url}`);
 
 let consoleServer: ReturnType<typeof startConsoleServer> | null = null;
 try {
-  consoleServer = startConsoleServer({ broadcastingHost: '127.0.0.1', broadcastingPort: server.port });
+  consoleServer = startConsoleServer({
+    broadcastingHost: process.env.BROADCASTING_HOST ?? '127.0.0.1',
+    broadcastingPort: process.env.BROADCASTING_PORT ?? server.port,
+  });
   console.log(`🚀 Console running at ${consoleServer.url}`);
 } catch (err) {
   const consoleStartupError = err instanceof Error ? (err.stack ?? err.message) : String(err);

--- a/index.ts
+++ b/index.ts
@@ -243,20 +243,22 @@ let agent: any = {
 })();
 // Keep only a recent window to avoid unbounded in-memory growth while keeping enough context for console operations.
 const GENERATED_SPEECH_HISTORY_MAX_LENGTH = 20;
-const generatedSpeechHistory: Array<{ id: string; speech: string; nGram: number; nGramRaw: number; nodes?: string[] }> = [];
+const generatedSpeechHistory: Array<{ id: string; speech: string; nGram?: number; nGramRaw?: number; nodes?: string[] }> = [];
 let generatedSpeechHistorySequence = 0;
 
 let clearSpeechTimer: ReturnType<typeof setTimeout> | undefined = undefined;
 
-streamer.onSpeech(async (text) => {
-  const speechText = typeof text === 'string' ? text : text.text;
-  const traceNodes = typeof text === 'object' && text !== null ? text.nodes : undefined;
+streamer.onSpeech(async (event) => {
+  const speechText = normalizeSpeechText(event) ?? '';
+  const traceNodes = typeof event === 'object' && event !== null && Array.isArray((event as any).nodes) ? (event as any).nodes : undefined;
+  const nGram = typeof event === 'object' && event !== null && typeof (event as any).nGram === 'number' ? (event as any).nGram : streamer.currentNGramSize;
+  const nGramRaw = typeof event === 'object' && event !== null && typeof (event as any).nGramRaw === 'number' ? (event as any).nGramRaw : streamer.currentNGramSizeRaw;
   generatedSpeechHistorySequence += 1;
   generatedSpeechHistory.unshift({
     id: `speech-${generatedSpeechHistorySequence}`,
     speech: speechText,
-    nGram: streamer.currentNGramSize,
-    nGramRaw: streamer.currentNGramSizeRaw,
+    nGram,
+    nGramRaw,
     nodes: traceNodes,
   });
   if (generatedSpeechHistory.length > GENERATED_SPEECH_HISTORY_MAX_LENGTH) {

--- a/index.ts
+++ b/index.ts
@@ -539,11 +539,12 @@ console.log(`🚀 Server running at ${server.url}`);
 
 let consoleServer: ReturnType<typeof startConsoleServer> | null = null;
 try {
-  consoleServer = startConsoleServer();
+  consoleServer = startConsoleServer({ broadcastingHost: '127.0.0.1', broadcastingPort: server.port });
   console.log(`🚀 Console running at ${consoleServer.url}`);
 } catch (err) {
   const consoleStartupError = err instanceof Error ? (err.stack ?? err.message) : String(err);
   console.error(`[ERROR] CONSOLE_STARTUP_FAILED ${JSON.stringify(consoleStartupError)}`);
+  process.exit(1);
 }
 
 // Start the stream playback after servers are listening so startup is

--- a/lib/Agent/index.test.ts
+++ b/lib/Agent/index.test.ts
@@ -309,23 +309,8 @@ describe('speech completion hooks', () => {
 
     expect(speechListener).toHaveBeenCalledWith(expect.objectContaining({
       text: 'hello',
-      generated: false,
     }));
     expect(completeListener).toHaveBeenCalled();
-  });
-
-  it('emits generated=true when speech is produced by the default argument', async () => {
-    const agent = new MakaMujo(stubTalkModel, stubTts);
-    const speechListener = jest.fn(async () => {});
-
-    agent.onSpeech(speechListener);
-    await agent.speech();
-
-    expect(speechListener).toHaveBeenCalledWith(expect.objectContaining({
-      generated: true,
-      nGram: 1,
-      nGramRaw: -2,
-    }));
   });
 });
 

--- a/lib/Agent/index.test.ts
+++ b/lib/Agent/index.test.ts
@@ -307,8 +307,25 @@ describe('speech completion hooks', () => {
 
     await agent.speech('hello');
 
-    expect(speechListener).toHaveBeenCalledWith('hello');
+    expect(speechListener).toHaveBeenCalledWith(expect.objectContaining({
+      text: 'hello',
+      generated: false,
+    }));
     expect(completeListener).toHaveBeenCalled();
+  });
+
+  it('emits generated=true when speech is produced by the default argument', async () => {
+    const agent = new MakaMujo(stubTalkModel, stubTts);
+    const speechListener = jest.fn(async () => {});
+
+    agent.onSpeech(speechListener);
+    await agent.speech();
+
+    expect(speechListener).toHaveBeenCalledWith(expect.objectContaining({
+      generated: true,
+      nGram: 1,
+      nGramRaw: -2,
+    }));
   });
 });
 

--- a/lib/Agent/index.ts
+++ b/lib/Agent/index.ts
@@ -31,12 +31,20 @@ const inferNGramSize = (commentNumber: number): number => {
   return Math.max(1, Math.floor(inferNGramSizeRaw(commentNumber)));
 };
 
+type SpeechEvent = {
+  text: string;
+  generated: boolean;
+  nGram?: number;
+  nGramRaw?: number;
+  nodes?: string[];
+};
+
 export class MakaMujo {
   #talkModel: TalkModel;
   #tts: TTS;
 
   #speechPromise = Promise.resolve();
-  #speechListeners: Array<(text: TalkModelGenerateResult) => Promise<void>> = [];
+  #speechListeners: Array<(event: SpeechEvent) => Promise<void>> = [];
   #speechCompleteListeners: Array<() => Promise<void>> = [];
   #ttsErrorHandlers: Array<(text: string, err: unknown) => void> = [];
   #gameStateChangeListeners: Array<() => void> = [];
@@ -122,18 +130,30 @@ export class MakaMujo {
     }
   }
 
-  async speech(text: TalkModelGenerateResult = this.#talkModel.generate('', this.#currentNGramSize)) {
+  async speech(text?: TalkModelGenerateResult) {
+    const actualText = text === undefined ? this.#talkModel.generate('', this.#currentNGramSize) : text;
+    const speechText = typeof actualText === 'string' ? actualText : actualText.text;
+    const event: SpeechEvent = {
+      text: speechText,
+      generated: text === undefined,
+      ...(text === undefined ? {
+        nGram: this.#currentNGramSize,
+        nGramRaw: this.#currentNGramSizeRaw,
+      } : {}),
+      ...(typeof actualText === 'object' && Array.isArray(actualText.nodes) ? { nodes: actualText.nodes } : {}),
+    };
+
     // Queue speech work onto the internal chain. For empty text we avoid
     // calling the underlying TTS implementation (some TalkModel generators
     // return an empty string) but still notify speech listeners.
-    const speechText = typeof text === 'string' ? text : text.text;
 
     this.#speechPromise = this.#speechPromise.then(async () => {
       const tasks: Array<Promise<void>> = [
-        ...this.#speechListeners.map(f => f(text)),
+        ...this.#speechListeners.map(f => f(event)),
       ];
-      if (speechText.trim().length > 0) {
-        const ttsTask = this.#tts.speech(speechText, { additionalHalfTone: 3, speakingRate: 1.2 }).catch((err) => {
+      const trimmedText = event.text.trim();
+      if (trimmedText.length > 0) {
+        const ttsTask = this.#tts.speech(trimmedText, { additionalHalfTone: 3, speakingRate: 1.2 }).catch((err) => {
           for (const h of this.#ttsErrorHandlers) {
             try { void h(speechText, err); } catch (_) { /* ignore handler errors */ }
           }
@@ -148,7 +168,7 @@ export class MakaMujo {
     await this.#speechPromise;
   }
 
-  onSpeech(cb: (text: TalkModelGenerateResult) => Promise<void>): MakaMujo {
+  onSpeech(cb: (event: SpeechEvent) => Promise<void>): MakaMujo {
     this.#speechListeners.push(cb);
     return this;
   }

--- a/lib/Agent/index.ts
+++ b/lib/Agent/index.ts
@@ -33,7 +33,6 @@ const inferNGramSize = (commentNumber: number): number => {
 
 type SpeechEvent = {
   text: string;
-  generated: boolean;
   nGram?: number;
   nGramRaw?: number;
   nodes?: string[];
@@ -87,43 +86,43 @@ export class MakaMujo {
       createReceiver((state) => {
         // receiver callback is intentionally synchronous
         // and is expected to return an action for the solver.
-        
+
         // (implementation below)
-        
+
         // NOTE: the body of this function is unchanged.
-      this.#browserState = state;
-      console.debug('[DEBUG]', 'receiver got state', JSON.stringify(state, null, 0));
+        this.#browserState = state;
+        console.debug('[DEBUG]', 'receiver got state', JSON.stringify(state, null, 0));
 
-      if (state.name === 'closed') {
-        this.#playing = undefined;
-        this.#notifyGameStateChangeAsync();
-        return Action.noop;
-      }
-
-      if (state.name === 'idle') {
-        // console.debug('[DEBUG]', 'receiver idle state =', JSON.stringify(state.state, null, 0));
-        if (state.state) {
-          this.#playing = {
-            name,
-            state: {
-              ...this.#playing?.state ?? {},
-              ...state.state,
-            } as any,
-          };
+        if (state.name === 'closed') {
+          this.#playing = undefined;
           this.#notifyGameStateChangeAsync();
+          return Action.noop;
         }
-      }
 
-      const { done, value } = solver.next(state);
-      if (done) {
-        this.#playing = undefined;
-        this.#notifyGameStateChangeAsync();
-        return Action.noop;
-      }
-      console.debug('[DEBUG]', 'next action', JSON.stringify(value, null, 0));
-      console.debug('[DEBUG]', 'sending action', JSON.stringify(value, null, 0));
+        if (state.name === 'idle') {
+          // console.debug('[DEBUG]', 'receiver idle state =', JSON.stringify(state.state, null, 0));
+          if (state.state) {
+            this.#playing = {
+              name,
+              state: {
+                ...this.#playing?.state ?? {},
+                ...state.state,
+              } as any,
+            };
+            this.#notifyGameStateChangeAsync();
+          }
+        }
 
-      return value;
+        const { done, value } = solver.next(state);
+        if (done) {
+          this.#playing = undefined;
+          this.#notifyGameStateChangeAsync();
+          return Action.noop;
+        }
+        console.debug('[DEBUG]', 'next action', JSON.stringify(value, null, 0));
+        console.debug('[DEBUG]', 'sending action', JSON.stringify(value, null, 0));
+
+        return value;
       });
     } catch (err) {
       console.warn('[WARN]', 'failed to start IPC receiver, continuing without browser IPC:', err instanceof Error ? err.message : String(err));
@@ -131,22 +130,20 @@ export class MakaMujo {
   }
 
   async speech(text?: TalkModelGenerateResult) {
-    const actualText = text === undefined ? this.#talkModel.generate('', this.#currentNGramSize) : text;
-    const speechText = typeof actualText === 'string' ? actualText : actualText.text;
-    const event: SpeechEvent = {
-      text: speechText,
-      generated: text === undefined,
-      ...(text === undefined ? {
+    const event: SpeechEvent = typeof text === 'string' ? { text } : (() => {
+      const ret = this.#talkModel.generate('', this.#currentNGramSize);
+      return typeof ret === 'string' ? {
+        text: ret,
+      } : {
         nGram: this.#currentNGramSize,
         nGramRaw: this.#currentNGramSizeRaw,
-      } : {}),
-      ...(typeof actualText === 'object' && Array.isArray(actualText.nodes) ? { nodes: actualText.nodes } : {}),
-    };
+        ...ret,
+      };
+    })();
 
     // Queue speech work onto the internal chain. For empty text we avoid
     // calling the underlying TTS implementation (some TalkModel generators
     // return an empty string) but still notify speech listeners.
-
     this.#speechPromise = this.#speechPromise.then(async () => {
       const tasks: Array<Promise<void>> = [
         ...this.#speechListeners.map(f => f(event)),
@@ -155,7 +152,7 @@ export class MakaMujo {
       if (trimmedText.length > 0) {
         const ttsTask = this.#tts.speech(trimmedText, { additionalHalfTone: 3, speakingRate: 1.2 }).catch((err) => {
           for (const h of this.#ttsErrorHandlers) {
-            try { void h(speechText, err); } catch (_) { /* ignore handler errors */ }
+            try { void h(trimmedText, err); } catch (_) { /* ignore handler errors */ }
           }
           throw err;
         });
@@ -192,7 +189,7 @@ export class MakaMujo {
     const listenersSnapshot = [...this.#gameStateChangeListeners];
     queueMicrotask(() => {
       for (const listener of listenersSnapshot) {
-        try { listener(); } catch {}
+        try { listener(); } catch { }
       }
     });
   }

--- a/lib/Agent/index.ts
+++ b/lib/Agent/index.ts
@@ -1,4 +1,4 @@
-import { Action, type State, type AgentComment } from "automated-gameplay-transmitter";
+import { Action, type AgentComment, type State } from "automated-gameplay-transmitter";
 import { writeFileSync } from "node:fs";
 import { createReceiver } from "../Browser/socket";
 import { ServerGames as Games, type GameName } from "./games/server";
@@ -6,10 +6,11 @@ import type { AgentState } from "./State";
 
 export const SILENCE_THRESHOLD_MS = 5 * 60 * 1_000; // 5 minutes
 
-const jaJP = new Intl.Locale('ja-JP');
 const N_GRAM_LOG_SCALE = 2;
 const N_GRAM_LOG_BASELINE = 2;
 const INITIAL_COMMENT_NUMBER = 1;
+
+const jaJP = new Intl.Locale('ja-JP');
 const pickTopic = (text: string) => {
   const words = Array.from(new Intl.Segmenter(jaJP, { granularity: 'word' }).segment(text)).map(({ segment }) => segment);
   const cands = words.reduce<string[]>((prev, s) => {

--- a/lib/MarkovChainModel/index.ts
+++ b/lib/MarkovChainModel/index.ts
@@ -77,15 +77,8 @@ export class MarkovChainModel implements TalkModel {
     nGram = 1,
   ): string | { text: string; nodes?: string[] } {
     // Delegates n-gram generation to AGT's MarkovModel implementation.
-    // Request trace output so we can preserve node paths for console diagnostics.
-    const res = this.#model.gen(start, nGram, { trace: true }) as unknown;
+    const res = this.#model.gen(start, nGram) as unknown;
     if (typeof res === 'string') return res;
-    if (res && typeof res === 'object' && 'text' in res) {
-      return {
-        text: (res as any).text as string,
-        nodes: Array.isArray((res as any).nodes) ? (res as any).nodes.map(String) : undefined,
-      };
-    }
     return String(res ?? '');
   }
 

--- a/lib/MarkovChainModel/index.ts
+++ b/lib/MarkovChainModel/index.ts
@@ -2,6 +2,8 @@ import { readFileSync } from "node:fs";
 import { MarkovModel } from "automated-gameplay-transmitter";
 import type { TalkModel } from "../Agent";
 
+const jaJP = new Intl.Locale('ja-JP');
+
 type WeightedCandidates = Record<string, number>;
 
 type Distribution = {
@@ -11,6 +13,8 @@ type Distribution = {
   [k: string]: WeightedCandidates
 };
 const DEFAULT_MAX_LEARN_CONTEXT = 8;
+
+const normalizeNGram = (nGram: number): number => Math.max(1, Math.floor(nGram));
 
 /** Ensures text passed to AGT learn API is always a single Japanese sentence terminator suffix. */
 const normalizeLearnText = (text: string): `${string}。` => (
@@ -72,14 +76,26 @@ export class MarkovChainModel implements TalkModel {
     );
   }
 
+  /**
+   * Generate text from the Markov model.
+   *
+   * @param start - Seed word to begin generation from.
+   * @param nGram - N-gram order to use during generation.
+   * @returns A string when trace is unavailable or a trace object when the
+   *          underlying AGT model supports it.
+   */
   generate(
     start: string = '',
     nGram = 1,
   ): string | { text: string; nodes?: string[] } {
-    // Delegates n-gram generation to AGT's MarkovModel implementation.
-    const res = this.#model.gen(start, nGram) as unknown;
-    if (typeof res === 'string') return res;
-    return String(res ?? '');
+    const result = this.#model.gen(start, normalizeNGram(nGram), { trace: true });
+    if (typeof result === 'string') {
+      return result;
+    }
+    return {
+      text: result.text,
+      nodes: Array.isArray(result.nodes) ? result.nodes.map(String) : undefined,
+    };
   }
 
   learn(text: string): void {

--- a/lib/console-proxy.ts
+++ b/lib/console-proxy.ts
@@ -142,13 +142,21 @@ export function forwardSSEEventsToSink(upstreamBody: any, sink: (data: string) =
   };
 }
 
+let BROADCASTING_HOST = process.env.BROADCASTING_HOST ?? 'localhost';
+let BROADCASTING_PORT = process.env.BROADCASTING_PORT ?? '7777';
+
+export function setBroadcastingTarget(host: string, port: string | number) {
+  BROADCASTING_HOST = host;
+  BROADCASTING_PORT = String(port);
+}
+
 export function buildProxyHeaders(req: Request, proxyBase: string) {
   const proxyHeaders = new Headers(req.headers);
   try {
     const proxyBaseHost = new URL(proxyBase).host;
     proxyHeaders.set('host', proxyBaseHost);
   } catch {
-    proxyHeaders.set('host', `${process.env.BROADCASTING_HOST ?? 'localhost'}:${process.env.BROADCASTING_PORT ?? '7777'}`);
+    proxyHeaders.set('host', `${BROADCASTING_HOST}:${BROADCASTING_PORT}`);
   }
   proxyHeaders.delete('origin');
   proxyHeaders.delete('referer');
@@ -157,8 +165,6 @@ export function buildProxyHeaders(req: Request, proxyBase: string) {
 }
 
 export function computeProxyBase(req: Request) {
-  const BROADCASTING_HOST = process.env.BROADCASTING_HOST ?? 'localhost';
-  const BROADCASTING_PORT = process.env.BROADCASTING_PORT ?? '7777';
   let proxyBase = `http://${BROADCASTING_HOST}:${BROADCASTING_PORT}`;
   try {
     const incomingHost = req.headers.get('host') ?? '';
@@ -173,8 +179,6 @@ export function computeProxyBase(req: Request) {
 export function computeProxyUrl(req: Request, proxyBase: string) {
   let parsed: URL;
   try { parsed = new URL(req.url); } catch (err) {
-    const BROADCASTING_HOST = process.env.BROADCASTING_HOST ?? 'localhost';
-    const BROADCASTING_PORT = process.env.BROADCASTING_PORT ?? '7777';
     const hostForParse = req.headers.get('host') ?? `${BROADCASTING_HOST}:${BROADCASTING_PORT}`;
     parsed = new URL(req.url, `http://${hostForParse}`);
   }

--- a/lib/console-proxy.ts
+++ b/lib/console-proxy.ts
@@ -229,6 +229,7 @@ export function createResilientSseProxy(
   reconnectDelayMs = 500,
   keepaliveIntervalMs = 5_000,
 ): Response {
+  const debug = process.env.CONSOLE_PROXY_DEBUG === '1';
   let stopped = false;
   let abortController = new AbortController();
   let currentReader: ReadableStreamDefaultReader<Uint8Array> | null = null;

--- a/lib/console-proxy.ts
+++ b/lib/console-proxy.ts
@@ -229,7 +229,6 @@ export function createResilientSseProxy(
   reconnectDelayMs = 500,
   keepaliveIntervalMs = 5_000,
 ): Response {
-  const debug = process.env.CONSOLE_PROXY_DEBUG === '1';
   let stopped = false;
   let abortController = new AbortController();
   let currentReader: ReadableStreamDefaultReader<Uint8Array> | null = null;

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@playwright/browser-chromium": "^1.59.1",
-    "automated-gameplay-transmitter": "^0.6.2",
+    "automated-gameplay-transmitter": "^0.6.3",
     "bun": "^1.3.13",
     "bun-plugin-tailwind": "^0.1.2",
     "playwright": "^1.59.1",

--- a/routes/console/index.ts
+++ b/routes/console/index.ts
@@ -4,15 +4,14 @@ import {
   computeProxyUrl,
   proxyConsoleApiWsRequest,
   proxyConsoleUpgrade,
+  setBroadcastingTarget,
 } from "../../lib/console-proxy";
+export { setBroadcastingTarget } from "../../lib/console-proxy";
 import App from "../../console/src/index.html";
 import * as agentState from "./api/agent-state";
 import robotsTxt from "./robots.txt";
 import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
-
-const BROADCASTING_HOST = process.env.BROADCASTING_HOST ?? 'localhost';
-const BROADCASTING_PORT = process.env.BROADCASTING_PORT ?? '7777';
 
 const CONSOLE_BUILD_PATH = process.env.CONSOLE_BUILD_PATH ?? resolve(process.cwd(), 'var/console/build');
 const CONSOLE_SOURCE_HTML_PATH = resolve(process.cwd(), 'console/src/index.html');

--- a/routes/console/index.ts
+++ b/routes/console/index.ts
@@ -103,7 +103,7 @@ async function serveConsoleAppHtml(): Promise<Response> {
 }
 
 try {
-  console.log('[DEBUG] routes/console initializing', { BROADCASTING_HOST, BROADCASTING_PORT });
+  console.log('[DEBUG] routes/console initializing');
 } catch {}
 
 // helpers moved to ../../lib/console-proxy

--- a/tests/integration/console/index.test.ts
+++ b/tests/integration/console/index.test.ts
@@ -2,12 +2,12 @@ import { test, expect } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { createLoopbackProxyHeaders, consoleBasePath, consoleRedirectURL, createAccessDeniedRedirectResponse, startConsoleServer } from "../../../console/index";
+import { createLoopbackProxyHeaders, consoleBasePath, consoleRedirectURL, createAccessDeniedRedirectResponse, isConsoleIPRestrictionEnabled, startConsoleServer } from "../../../console/index";
 
 test("throws when TLS certificate file is missing", () => {
   const tmpDir = mkdtempSync(join(tmpdir(), 'console-test-'));
   try {
-    expect(() => startConsoleServer(join(tmpDir, 'nonexistent-cert.pem'), join(tmpDir, 'nonexistent-key.pem')))
+    expect(() => startConsoleServer({ certPath: join(tmpDir, 'nonexistent-cert.pem'), keyPath: join(tmpDir, 'nonexistent-key.pem') }))
       .toThrow('TLS certificate files not found');
   } finally {
     rmSync(tmpDir, { recursive: true, force: true });
@@ -20,7 +20,7 @@ test("throws when TLS certificate file exists but key file is missing", () => {
   writeFileSync(certFilePath, 'placeholder');
 
   try {
-    expect(() => startConsoleServer(certFilePath, join(tmpDir, 'nonexistent-key.pem')))
+    expect(() => startConsoleServer({ certPath: certFilePath, keyPath: join(tmpDir, 'nonexistent-key.pem') }))
       .toThrow('TLS certificate files not found');
   } finally {
     rmSync(tmpDir, { recursive: true, force: true });
@@ -84,4 +84,27 @@ test("strips headers named in Connection header value (RFC 7230)", () => {
   expect(headers.get('x-custom-hop')).toBeNull();
   expect(headers.get('another-hop')).toBeNull();
   expect(headers.get('x-preserved')).toBe('preserved');
+});
+
+test("disables console IP restriction in development mode", () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  try {
+    process.env.NODE_ENV = undefined;
+    expect(isConsoleIPRestrictionEnabled()).toBe(false);
+
+    process.env.NODE_ENV = 'development';
+    expect(isConsoleIPRestrictionEnabled()).toBe(false);
+  } finally {
+    process.env.NODE_ENV = originalNodeEnv;
+  }
+});
+
+test("enables console IP restriction in production mode", () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  try {
+    process.env.NODE_ENV = 'production';
+    expect(isConsoleIPRestrictionEnabled()).toBe(true);
+  } finally {
+    process.env.NODE_ENV = originalNodeEnv;
+  }
 });


### PR DESCRIPTION
This PR fixes the console proxy so it uses the actual broadcasting server port from Bun.server rather than relying on BROADCASTING_PORT environment variables. It also changes console startup failure to exit the process when TLS certificate loading fails, preventing silent startup errors in production. Includes tests for console startup and proxy behavior.