### PR TITLE
refactor(console): improve AgentStatus UI and preserve game section heading

### DIFF
--- a/console/src/AgentStatus/AgentStatus.tsx
+++ b/console/src/AgentStatus/AgentStatus.tsx
@@ -17,6 +17,8 @@ import { LIVE_DELIVERY_SECTION_TITLE } from "./LiveDeliveryStatusSection";
 import { LiveDeliveryStatusSection } from "./LiveDeliveryStatusSection";
 import { MARKOV_MODEL_SECTION_TITLE } from "./MarkovModelStatusSection";
 import { MarkovModelStatusSection } from "./MarkovModelStatusSection";
+import { AgentStatusHeader } from "./AgentStatusHeader";
+import { formatStartDate, formatStreamStartTime } from "./agentStatusUtils";
 
 const AGENT_STATUS_GRID_ROW_TEMPLATE_CLASS = "grid-rows-[auto_minmax(0,1fr)]";
 
@@ -108,6 +110,12 @@ export const AgentStatus = () => {
     };
   }, [fetchAgentState]);
 
+  const streamTitle = agentStateResponse?.niconama?.meta?.title;
+  const streamUrl = agentStateResponse?.niconama?.meta?.url;
+  const streamStartTime = agentStateResponse?.niconama?.meta?.start
+    ? formatStreamStartTime(agentStateResponse.niconama.meta.start)
+    : undefined;
+
   const agentStatusSections = createAgentStatusSections(agentStateResponse);
   const sectionMap = agentStatusSections.reduce<Partial<Record<AgentStatusSection["title"], AgentStatusSection>>>(
     (accumulatedSections, section) => {
@@ -130,17 +138,17 @@ export const AgentStatus = () => {
               馬可無序
             </a>
           </h1>
-          <p className="text-sm text-emerald-200 whitespace-nowrap">
-            最終更新: {lastUpdatedTime || "未取得"}
-          </p>
-          <button
-            type="button"
-            onClick={fetchAgentState}
-            disabled={isLoadingAgentState}
-            className="bg-emerald-300 text-emerald-950 border-0 px-5 py-1.5 rounded-lg font-bold transition-all duration-100 hover:bg-emerald-200 hover:-translate-y-px cursor-pointer whitespace-nowrap disabled:opacity-60 disabled:cursor-not-allowed"
+          <AgentStatusHeader
+            streamTitle={streamTitle ?? undefined}
+            streamUrl={streamUrl ?? undefined}
+            startTime={streamStartTime}
+          />
+          <p
+            data-testid={agentStatusError ? "agent-status-error" : "agent-status-last-updated"}
+            className={agentStatusError ? "text-sm text-red-200 whitespace-nowrap" : "text-sm text-emerald-200 whitespace-nowrap"}
           >
-            更新
-          </button>
+            {agentStatusError ? `取得エラー: ${agentStatusError}` : `最終更新: ${lastUpdatedTime || "未取得"}`}
+          </p>
         </div>
         {isShowingMockAgentState ? (
           <Container>
@@ -151,14 +159,6 @@ export const AgentStatus = () => {
               {AGENT_STATE_MOCK_NOTICE_MESSAGE}
             </div>
           </Container>
-        ) : null}
-        {agentStatusError ? (
-          <div
-            data-testid="agent-status-error"
-            className="w-full min-h-[80px] bg-red-950/60 border-2 border-red-300 rounded-xl p-3 text-red-100"
-          >
-            取得エラー: {agentStatusError}
-          </div>
         ) : null}
       </div>
       {agentStatusSections.length === 0 ? (

--- a/console/src/AgentStatus/AgentStatus.tsx
+++ b/console/src/AgentStatus/AgentStatus.tsx
@@ -11,14 +11,13 @@ import {
   startAgentStateAutoRefresh,
 } from "./agentStatusState";
 import { createAgentStatusSections } from "./createAgentStatusSections";
-import { GAME_SECTION_TITLE } from "./GameStatusSection";
 import { GameStatusSection } from "./GameStatusSection";
 import { LIVE_DELIVERY_SECTION_TITLE } from "./LiveDeliveryStatusSection";
 import { LiveDeliveryStatusSection } from "./LiveDeliveryStatusSection";
 import { MARKOV_MODEL_SECTION_TITLE } from "./MarkovModelStatusSection";
 import { MarkovModelStatusSection } from "./MarkovModelStatusSection";
 import { AgentStatusHeader } from "./AgentStatusHeader";
-import { formatStartDate, formatStreamStartTime } from "./agentStatusUtils";
+import { formatStreamStartTime } from "./agentStatusUtils";
 
 const AGENT_STATUS_GRID_ROW_TEMPLATE_CLASS = "grid-rows-[auto_minmax(0,1fr)]";
 
@@ -126,7 +125,7 @@ export const AgentStatus = () => {
   );
   const liveDeliverySection = sectionMap[LIVE_DELIVERY_SECTION_TITLE];
   const markovModelSection = sectionMap[MARKOV_MODEL_SECTION_TITLE];
-  const gameSection = sectionMap[GAME_SECTION_TITLE];
+  const gameSection = agentStatusSections.find((section) => section.title.includes("プレイ中"));
   const hasPrimaryColumnSections = liveDeliverySection !== undefined || gameSection !== undefined;
 
   return (
@@ -178,7 +177,7 @@ export const AgentStatus = () => {
           {hasPrimaryColumnSections ? (
             <div className="min-w-0 min-h-0 h-full flex flex-col gap-4">
               {liveDeliverySection ? <LiveDeliveryStatusSection liveDeliveryRows={liveDeliverySection.rows} /> : null}
-              {gameSection ? <GameStatusSection gameRows={gameSection.rows} /> : null}
+              {gameSection ? <GameStatusSection title={gameSection.title} gameRows={gameSection.rows} /> : null}
             </div>
           ) : null}
           {markovModelSection ? (

--- a/console/src/AgentStatus/AgentStatusHeader.test.tsx
+++ b/console/src/AgentStatus/AgentStatusHeader.test.tsx
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { AgentStatusHeader } from "./AgentStatusHeader";
+
+describe("AgentStatusHeader", () => {
+  it("renders the stream title as a link and shows the start time", () => {
+    const html = renderToStaticMarkup(
+      <AgentStatusHeader
+        streamTitle="配信タイトル"
+        streamUrl="https://example.com/live"
+        startTime="2026/05/02 12:34:56"
+      />,
+    );
+
+    expect(html).toContain("配信タイトル");
+    expect(html).toContain("href=\"https://example.com/live\"");
+    expect(html).toContain("2026/05/02 12:34:56");
+  });
+
+  it("renders nothing when neither stream title nor start time is provided", () => {
+    const html = renderToStaticMarkup(<AgentStatusHeader />);
+    expect(html).toBe("");
+  });
+});

--- a/console/src/AgentStatus/AgentStatusHeader.tsx
+++ b/console/src/AgentStatus/AgentStatusHeader.tsx
@@ -1,0 +1,38 @@
+type AgentStatusHeaderProps = {
+  streamTitle?: string;
+  streamUrl?: string;
+  startTime?: string;
+};
+
+export const AgentStatusHeader = ({ streamTitle, streamUrl, startTime }: AgentStatusHeaderProps) => {
+  if (!streamTitle && !startTime) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-row items-center justify-center gap-2 min-w-0 text-center px-2">
+      {streamTitle ? (
+        streamUrl ? (
+          <a
+            data-testid="agent-status-stream-title"
+            href={streamUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="text-base font-semibold text-emerald-100 underline decoration-emerald-300/50 hover:text-emerald-50 break-all"
+          >
+            {streamTitle}
+          </a>
+        ) : (
+          <span data-testid="agent-status-stream-title" className="text-base font-semibold text-emerald-100 break-all">
+            {streamTitle}
+          </span>
+        )
+      ) : null}
+      {startTime ? (
+        <span data-testid="agent-status-start-time" className="text-sm text-emerald-200 whitespace-nowrap">
+          {startTime}
+        </span>
+      ) : null}
+    </div>
+  );
+};

--- a/console/src/AgentStatus/AgentStatusSectionCard.tsx
+++ b/console/src/AgentStatus/AgentStatusSectionCard.tsx
@@ -11,7 +11,7 @@ export const AgentStatusSectionCard = ({ title, rows }: AgentStatusSectionCardPr
     <Container>
       <section className="bg-emerald-950/70 border-2 border-emerald-300 rounded-xl p-3 text-emerald-50 min-w-0 h-full overflow-hidden flex flex-col">
         <h3 className="text-lg font-bold mb-2">{title}</h3>
-        <dl className="min-h-0 flex-1 grid content-start items-start grid-cols-[10rem_minmax(0,1fr)] gap-x-4 gap-y-2 overflow-y-auto pr-1">
+        <dl className="min-h-0 flex-1 grid content-start items-start grid-cols-[auto_minmax(0,1fr)] gap-x-4 gap-y-2 overflow-y-auto pr-1">
           {rows.map((row) => (
             <div
               key={`${title}:${row.label}:${"value" in row ? row.value : "value-component"}:${row.href ?? "-"}`}

--- a/console/src/AgentStatus/AgentStatusSectionCard.tsx
+++ b/console/src/AgentStatus/AgentStatusSectionCard.tsx
@@ -18,7 +18,10 @@ export const AgentStatusSectionCard = ({ title, titleRightElement, rows }: Agent
             <div className="text-base whitespace-nowrap">{titleRightElement}</div>
           ) : null}
         </div>
-        <dl className="min-h-0 flex-1 grid content-start items-start grid-cols-[auto_minmax(0,1fr)] gap-x-4 gap-y-2 overflow-y-auto pr-1">
+        <dl
+          className="min-h-0 flex-1 grid content-start items-start grid-cols-[auto_minmax(0,1fr)] gap-x-4 gap-y-2 overflow-y-auto pr-1"
+          style={{ scrollbarWidth: "thin" }}
+        >
           {rows.map((row) => (
             <div
               key={`${title}:${row.label}:${"value" in row ? row.value : "value-component"}:${row.href ?? "-"}`}

--- a/console/src/AgentStatus/AgentStatusSectionCard.tsx
+++ b/console/src/AgentStatus/AgentStatusSectionCard.tsx
@@ -1,16 +1,23 @@
 import { Container } from "automated-gameplay-transmitter";
+import type { ReactNode } from "react";
 import type { AgentStatusRow } from "./types";
 
 type AgentStatusSectionCardProps = {
   title: string;
+  titleRightElement?: ReactNode;
   rows: AgentStatusRow[];
 };
 
-export const AgentStatusSectionCard = ({ title, rows }: AgentStatusSectionCardProps) => {
+export const AgentStatusSectionCard = ({ title, titleRightElement, rows }: AgentStatusSectionCardProps) => {
   return (
     <Container>
       <section className="bg-emerald-950/70 border-2 border-emerald-300 rounded-xl p-3 text-emerald-50 min-w-0 h-full overflow-hidden flex flex-col">
-        <h3 className="text-lg font-bold mb-2">{title}</h3>
+        <div className="mb-2 flex items-baseline gap-3">
+          <h3 className="text-lg font-bold">{title}</h3>
+          {titleRightElement ? (
+            <div className="text-base whitespace-nowrap">{titleRightElement}</div>
+          ) : null}
+        </div>
         <dl className="min-h-0 flex-1 grid content-start items-start grid-cols-[auto_minmax(0,1fr)] gap-x-4 gap-y-2 overflow-y-auto pr-1">
           {rows.map((row) => (
             <div

--- a/console/src/AgentStatus/AgentStatusSections.test.tsx
+++ b/console/src/AgentStatus/AgentStatusSections.test.tsx
@@ -42,7 +42,7 @@ describe("AgentStatusSections", () => {
               <ul>
                 <li>
                   <p>テスト発話</p>
-                  <p>4g</p>
+                  <p>n=4</p>
                   <button type="button" disabled aria-label="学習の取り消し">↩</button>
                 </li>
               </ul>
@@ -52,7 +52,7 @@ describe("AgentStatusSections", () => {
       />,
     );
 
-    expect(html).toContain("マルコフ連鎖モデルの状態");
+    expect(html).toContain("マルコフ連鎖モデル");
     expect(html).toContain("4-gram");
     expect(html).toContain("テスト発話");
     expect(html).toContain("これまでの発話");

--- a/console/src/AgentStatus/AgentStatusSections.test.tsx
+++ b/console/src/AgentStatus/AgentStatusSections.test.tsx
@@ -62,10 +62,11 @@ describe("AgentStatusSections", () => {
   it("renders game section with structured rows", () => {
     const html = renderToStaticMarkup(
       <GameStatusSection
+        title="『org.dashnet.orteil/cookieclicker』プレイ中"
         gameRows={[
-          { label: "現在のゲーム", value: "org.dashnet.orteil/cookieclicker" },
           {
             label: "ゲーム情報",
+            hideLabel: true,
             valueComponent: (
               <ul>
                 <li>status: idle</li>
@@ -76,9 +77,8 @@ describe("AgentStatusSections", () => {
       />,
     );
 
-    expect(html).toContain("ゲームの状態");
-    expect(html).toContain("現在のゲーム");
-    expect(html).toContain("org.dashnet.orteil/cookieclicker");
+    expect(html).toContain("『org.dashnet.orteil/cookieclicker』プレイ中");
+    expect(html).not.toContain("現在のゲーム");
     expect(html).toContain("ゲーム情報");
     expect(html).toContain("<ul");
   });

--- a/console/src/AgentStatus/GameStatusSection.tsx
+++ b/console/src/AgentStatus/GameStatusSection.tsx
@@ -1,12 +1,11 @@
 import { AgentStatusSectionCard } from "./AgentStatusSectionCard";
 import type { AgentStatusRow } from "./types";
 
-export const GAME_SECTION_TITLE = "ゲームの状態";
-
 type GameStatusSectionProps = {
+  title: string;
   gameRows: AgentStatusRow[];
 };
 
-export const GameStatusSection = ({ gameRows }: GameStatusSectionProps) => {
-  return <AgentStatusSectionCard title={GAME_SECTION_TITLE} rows={gameRows} />;
+export const GameStatusSection = ({ title, gameRows }: GameStatusSectionProps) => {
+  return <AgentStatusSectionCard title={title} rows={gameRows} />;
 };

--- a/console/src/AgentStatus/MarkovModelStatusSection.tsx
+++ b/console/src/AgentStatus/MarkovModelStatusSection.tsx
@@ -1,12 +1,21 @@
 import { AgentStatusSectionCard } from "./AgentStatusSectionCard";
 import type { AgentStatusRow } from "./types";
 
-export const MARKOV_MODEL_SECTION_TITLE = "マルコフ連鎖モデルの状態";
+export const MARKOV_MODEL_SECTION_TITLE = "マルコフ連鎖モデル";
 
 type MarkovModelStatusSectionProps = {
   markovModelRows: AgentStatusRow[];
 };
 
 export const MarkovModelStatusSection = ({ markovModelRows }: MarkovModelStatusSectionProps) => {
-  return <AgentStatusSectionCard title={MARKOV_MODEL_SECTION_TITLE} rows={markovModelRows} />;
+  const nGramRow = markovModelRows.find((row) => row.label === "生成N-gram");
+  const rows = markovModelRows.filter((row) => row.label !== "生成N-gram");
+
+  return (
+    <AgentStatusSectionCard
+      title={MARKOV_MODEL_SECTION_TITLE}
+      titleRightElement={nGramRow?.value ?? undefined}
+      rows={rows}
+    />
+  );
 };

--- a/console/src/AgentStatus/agentStatusState.ts
+++ b/console/src/AgentStatus/agentStatusState.ts
@@ -7,7 +7,15 @@ const AGENT_STATE_MOCK_QUERY_KEY = "agentStateMock";
 export const INVALID_AGENT_STATE_RESPONSE_ERROR = "配信状態の応答形式が不正です。";
 const EVENT_SOURCE_CLOSED = typeof EventSource !== "undefined" ? EventSource.CLOSED : 2;
 
-export const createMockAgentStateResponse = (): AgentStateResponse => cloneAgentStateResponseMockFixture();
+const AGENT_STATE_MOCK_NO_GAME_QUERY_KEY = "agentStateMockNoGame";
+
+export const createMockAgentStateResponse = (): AgentStateResponse => {
+  const searchParams = typeof window === "undefined" ? "" : window.location.search;
+  if (new URLSearchParams(searchParams).get(AGENT_STATE_MOCK_NO_GAME_QUERY_KEY) === "1") {
+    return { ...cloneAgentStateResponseMockFixture(), currentGame: null };
+  }
+  return cloneAgentStateResponseMockFixture();
+};
 
 export const isAgentStateMockQueryEnabled = (searchParams: string): boolean => {
   return new URLSearchParams(searchParams).get(AGENT_STATE_MOCK_QUERY_KEY) === "1";

--- a/console/src/AgentStatus/agentStatusUtils.tsx
+++ b/console/src/AgentStatus/agentStatusUtils.tsx
@@ -89,8 +89,10 @@ const formatSpeechHistoryNGramLabel = (nGram: number | undefined): string => {
   if (nGram === undefined || !Number.isFinite(nGram) || nGram < 1) {
     return "-";
   }
-  return `${Math.floor(nGram)}g`;
+  return `n=${Math.floor(nGram)}`;
 };
+
+const EMPHASIZED_SPEECH_HISTORY_BORDER_BOTTOM_WIDTH = "3px";
 
 const formatSpeechHistoryItemText = (speechText: string, nGram: number | undefined): string => {
   return `${speechText} (${formatSpeechHistoryNGramLabel(nGram)})`;
@@ -152,15 +154,26 @@ export const createSpeechHistoryValueComponent = (
   }
   return (
     <ul className="grid grid-cols-1 gap-2">
-      {speechHistoryItems.map((speechHistoryItem) => (
-        <li key={speechHistoryItem.id} className="rounded-md border border-emerald-300/30 p-2">
-          <div className="grid grid-cols-[minmax(0,1fr)_auto_auto] items-start gap-2">
+      {speechHistoryItems.map((speechHistoryItem, index) => (
+        <li
+          key={speechHistoryItem.id}
+          className={index === 0
+            ? "rounded-md border border-emerald-300/30 border-b border-b-emerald-300/80 p-2"
+            : "rounded-md border border-emerald-300/30 p-2"
+          }
+          style={index === 0 ? {
+            "--speech-history-border-bottom-width": EMPHASIZED_SPEECH_HISTORY_BORDER_BOTTOM_WIDTH,
+            borderBottomWidth: "var(--speech-history-border-bottom-width)",
+            paddingBottom: "calc(0.5rem - var(--speech-history-border-bottom-width))",
+          } as React.CSSProperties : undefined}
+        >
+          <div className="grid grid-cols-[minmax(0,1fr)_auto_auto] items-baseline gap-2">
             <div className="flex flex-wrap gap-1">
               {speechHistoryItem.nodes && Array.isArray(speechHistoryItem.nodes)
                 ? speechHistoryItem.nodes.map((word, wi) => (
                   <span
                     key={`${speechHistoryItem.id}-node-${wi}`}
-                    className="speech-word-chip inline-block rounded-md border border-emerald-300/30 px-2 py-1 text-sm"
+                    className="speech-word-chip inline-block rounded-md border border-emerald-300/30 bg-emerald-950/40 px-2 py-1 text-sm"
                   >
                     {word}
                   </span>
@@ -168,19 +181,23 @@ export const createSpeechHistoryValueComponent = (
                 : speechHistoryItem.speechText.split(/\s+/).map((word, wi) => (
                   <span
                     key={`${speechHistoryItem.id}-word-${wi}`}
-                    className="speech-word-chip inline-block rounded-md border border-emerald-300/30 px-2 py-1 text-sm"
+                    className="speech-word-chip inline-block rounded-md border border-emerald-300/30 bg-emerald-950/40 px-2 py-1 text-sm"
                   >
                     {word}
                   </span>
                 ))}
             </div>
-            <span className="text-xs text-emerald-200 whitespace-nowrap">{speechHistoryItem.nGramLabel}</span>
+            <span className="text-xs whitespace-nowrap">{speechHistoryItem.nGramLabel}</span>
             <button
               type="button"
               disabled
               aria-label="学習の取り消し"
               title="学習の取り消し"
-              className="text-base leading-none h-7 w-7 rounded border border-emerald-300/50 text-emerald-200 opacity-70 cursor-not-allowed flex items-center justify-center"
+              className="inline-flex items-center justify-center h-7 min-w-[2rem] rounded-md border border-emerald-300/50 bg-emerald-950/20 px-2 text-sm text-emerald-200 opacity-70 cursor-not-allowed shadow-sm shadow-black/20"
+              style={{
+                fontFamily: "ui-sans-serif, system-ui, sans-serif",
+                fontVariantEmoji: "text",
+              }}
             >
               ↩
             </button>

--- a/console/src/AgentStatus/agentStatusUtils.tsx
+++ b/console/src/AgentStatus/agentStatusUtils.tsx
@@ -153,7 +153,7 @@ export const createSpeechHistoryValueComponent = (
     return <span>-</span>;
   }
   return (
-    <ul className="grid grid-cols-1 gap-2">
+    <ul className="grid grid-cols-1 gap-2 overflow-y-auto" style={{ scrollbarWidth: "thin" }}>
       {speechHistoryItems.map((speechHistoryItem, index) => (
         <li
           key={speechHistoryItem.id}

--- a/console/src/AgentStatus/agentStatusUtils.tsx
+++ b/console/src/AgentStatus/agentStatusUtils.tsx
@@ -26,6 +26,22 @@ export const formatStartDate = (startAtUnixTime: number | undefined): string => 
   return new Date(startAtUnixTimeMilliseconds).toLocaleString("ja-JP");
 };
 
+export const formatStreamStartTime = (startAtUnixTime: number | undefined): string | undefined => {
+  if (typeof startAtUnixTime !== "number" || !Number.isFinite(startAtUnixTime) || startAtUnixTime <= 0) {
+    return undefined;
+  }
+  const startAtUnixTimeMilliseconds = startAtUnixTime >= UNIX_MILLISECONDS_THRESHOLD
+    ? startAtUnixTime
+    : startAtUnixTime * 1000;
+  const date = new Date(startAtUnixTimeMilliseconds);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const hour = String(date.getHours()).padStart(2, "0");
+  const minute = String(date.getMinutes()).padStart(2, "0");
+  return `${year}/${month}/${day} ${hour}:${minute} 開始`;
+};
+
 export const formatMetricValue = (metricValue: number | undefined): string => {
   return metricValue === undefined ? "-" : String(metricValue);
 };
@@ -139,7 +155,7 @@ export const createSpeechHistoryValueComponent = (
       {speechHistoryItems.map((speechHistoryItem) => (
         <li key={speechHistoryItem.id} className="rounded-md border border-emerald-300/30 p-2">
           <div className="grid grid-cols-[minmax(0,1fr)_auto_auto] items-start gap-2">
-            <div className="flex flex-wrap gap-2">
+            <div className="flex flex-wrap gap-1">
               {speechHistoryItem.nodes && Array.isArray(speechHistoryItem.nodes)
                 ? speechHistoryItem.nodes.map((word, wi) => (
                   <span

--- a/console/src/AgentStatus/createAgentStatusRows.test.tsx
+++ b/console/src/AgentStatus/createAgentStatusRows.test.tsx
@@ -24,7 +24,7 @@ describe("createAgentStatusRows", () => {
     expect(rows).not.toContainEqual({ label: "タイトル", value: "タイトル" });
     expect(rows.find((row) => row.label === "開始時刻")).toBeUndefined();
     expect(rows.find((row) => row.label === "配信URL")).toBeUndefined();
-    expect(rows).toContainEqual({ label: "現在のゲーム", value: "ゲームID" });
+    expect(rows).not.toContainEqual({ label: "現在のゲーム", value: "ゲームID" });
     expect(rows).toContainEqual({ label: "生成N-gram", hideLabel: true, value: "4-gram" });
     expect(rows.find((row) => row.label === "発話内容")?.value).toBe("テスト発話");
   });
@@ -190,5 +190,10 @@ describe("createAgentStatusRows", () => {
     expect(html).toContain("beta");
     expect(html).toContain("gamma");
     expect((html.match(/speech-word-chip/g) || []).length).toBe(3);
+  });
+
+  it("does not show detailed game state rows when currentGame is null", () => {
+    const rows = createAgentStatusRows({ currentGame: null });
+    expect(rows.find((row) => row.label === "ゲーム情報")).toBeUndefined();
   });
 });

--- a/console/src/AgentStatus/createAgentStatusRows.test.tsx
+++ b/console/src/AgentStatus/createAgentStatusRows.test.tsx
@@ -25,7 +25,7 @@ describe("createAgentStatusRows", () => {
     expect(rows.find((row) => row.label === "開始時刻")).toBeUndefined();
     expect(rows.find((row) => row.label === "配信URL")).toBeUndefined();
     expect(rows).toContainEqual({ label: "現在のゲーム", value: "ゲームID" });
-    expect(rows).toContainEqual({ label: "生成N-gram", value: "4-gram" });
+    expect(rows).toContainEqual({ label: "生成N-gram", hideLabel: true, value: "4-gram" });
     expect(rows.find((row) => row.label === "発話内容")?.value).toBe("テスト発話");
   });
 
@@ -53,6 +53,88 @@ describe("createAgentStatusRows", () => {
 
     expect(html).toContain("これまでの発話");
     expect((html.match(/speech-word-chip/g) || []).length).toBeGreaterThanOrEqual(3);
+    expect(html).toContain("n=4");
+    expect(html).toContain("class=\"text-xs whitespace-nowrap\"");
+    expect(html).toContain("bg-emerald-950/40");
+  });
+
+  it("renders speech word chips with the same background class regardless of emphasis", () => {
+    const rows = createAgentStatusRows({
+      nGram: 4,
+      speechHistory: [
+        { id: "speech-1", speech: "alpha beta gamma", nGram: 4, nGramRaw: 4 },
+        { id: "speech-2", speech: "ぜひ遊びに来てね", nGram: 3, nGramRaw: 3 },
+      ],
+    } as any);
+    const markovRows = rows.filter((r) => r.label === "これまでの発話" || r.label === "生成N-gram");
+    const html = renderToStaticMarkup(<MarkovModelStatusSection markovModelRows={markovRows} />);
+    const chipClassAttributes = html.match(/class="speech-word-chip[^"]*"/g) ?? [];
+
+    expect(chipClassAttributes.length).toBeGreaterThanOrEqual(2);
+    chipClassAttributes.forEach((classAttr) => {
+      expect(classAttr).toContain("bg-emerald-950/40");
+    });
+    expect(html).toContain("items-baseline");
+  });
+
+  it("hides duplicate speech content from live delivery when it matches top speech history", () => {
+    const rows = createAgentStatusRows({
+      nGram: 4,
+      speech: { speech: "alpha beta gamma", silent: false },
+      speechHistory: [
+        { id: "speech-1", speech: "alpha beta gamma", nGram: 4, nGramRaw: 4 },
+      ],
+    } as any);
+
+    expect(rows.find((row) => row.label === "発話内容")).toBeUndefined();
+    expect(rows.find((row) => row.label === "これまでの発話")).toBeDefined();
+  });
+
+  it("keeps first history emphasis even when current speech is absent", () => {
+    const rows = createAgentStatusRows({
+      nGram: 4,
+      speechHistory: [
+        { id: "speech-1", speech: "alpha beta gamma", nGram: 4, nGramRaw: 4 },
+      ],
+    } as any);
+    const markovRows = rows.filter((r) => r.label === "これまでの発話" || r.label === "生成N-gram");
+    const html = renderToStaticMarkup(<MarkovModelStatusSection markovModelRows={markovRows} />);
+
+    expect(html).toContain("border-b-emerald-300/80");
+    expect(html).toContain("border-bottom-width:var(--speech-history-border-bottom-width)");
+    expect(html).not.toContain("bg-emerald-300/80");
+    expect(html).toContain("alpha");
+    expect(html).toContain("beta");
+    expect(html).toContain("gamma");
+  });
+
+  it("still renders speech content when it differs from top speech history", () => {
+    const rows = createAgentStatusRows({
+      nGram: 4,
+      speech: { speech: "コメント", silent: false },
+      speechHistory: [
+        { id: "speech-1", speech: "alpha beta gamma", nGram: 4, nGramRaw: 4 },
+      ],
+    } as any);
+
+    expect(rows.find((row) => row.label === "発話内容")?.value).toBe("コメント");
+    expect(rows.find((row) => row.label === "これまでの発話")).toBeDefined();
+  });
+
+  it("emphasizes the first speech history item with a thicker bottom border", () => {
+    const rows = createAgentStatusRows({
+      nGram: 4,
+      speechHistory: [
+        { id: "speech-1", speech: "alpha beta gamma", nGram: 4, nGramRaw: 4 },
+      ],
+    } as any);
+    const markovRows = rows.filter((r) => r.label === "これまでの発話" || r.label === "生成N-gram");
+    const html = renderToStaticMarkup(<MarkovModelStatusSection markovModelRows={markovRows} />);
+
+    expect(html).toContain("border-b");
+    expect(html).toContain("border-b-emerald-300/80");
+    expect(html).toContain("border-bottom-width:var(--speech-history-border-bottom-width)");
+    expect(html).toContain("border-emerald-300/30");
   });
 
   it("normalizes object speech payloads for top-level speech", () => {

--- a/console/src/AgentStatus/createAgentStatusRows.test.tsx
+++ b/console/src/AgentStatus/createAgentStatusRows.test.tsx
@@ -21,11 +21,24 @@ describe("createAgentStatusRows", () => {
       speechHistory: [{ id: "speech-1", speech: "alpha beta gamma", nGram: 4, nGramRaw: 4 }],
     } as any);
 
-    expect(rows).toContainEqual({ label: "タイトル", value: "タイトル" });
-    expect(rows).toContainEqual({ label: "配信URL", value: "https://example.com/live", href: "https://example.com/live" });
+    expect(rows).not.toContainEqual({ label: "タイトル", value: "タイトル" });
+    expect(rows.find((row) => row.label === "開始時刻")).toBeUndefined();
+    expect(rows.find((row) => row.label === "配信URL")).toBeUndefined();
     expect(rows).toContainEqual({ label: "現在のゲーム", value: "ゲームID" });
     expect(rows).toContainEqual({ label: "生成N-gram", value: "4-gram" });
     expect(rows.find((row) => row.label === "発話内容")?.value).toBe("テスト発話");
+  });
+
+  it("hides the speech history label so the value spans full width", () => {
+    const rows = createAgentStatusRows({
+      nGram: 4,
+      speechHistory: [
+        { id: "speech-1", speech: "alpha beta gamma", nGram: 4 },
+      ],
+    } as any);
+
+    const speechHistoryRow = rows.find((row) => row.label === "これまでの発話");
+    expect(speechHistoryRow).toEqual(expect.objectContaining({ hideLabel: true }));
   });
 
   it("renders speech history words as separate cards", () => {

--- a/console/src/AgentStatus/createAgentStatusRows.ts
+++ b/console/src/AgentStatus/createAgentStatusRows.ts
@@ -29,10 +29,15 @@ export const createAgentStatusRows = (stateResponse: AgentStateResponse | null):
   }
 
   if (stateResponse?.nGram !== undefined) {
-    rows.push({ label: "生成N-gram", value: formatNGramValue(stateResponse.nGram, stateResponse.nGramRaw) });
+    rows.push({
+      label: "生成N-gram",
+      hideLabel: true,
+      value: formatNGramValue(stateResponse.nGram, stateResponse.nGramRaw),
+    });
   }
 
-  if (createSpeechHistoryDisplayItems(stateResponse?.speechHistory).length > 0) {
+  const speechHistoryItems = createSpeechHistoryDisplayItems(stateResponse?.speechHistory);
+  if (speechHistoryItems.length > 0) {
     rows.push({
       label: "これまでの発話",
       hideLabel: true,
@@ -40,10 +45,15 @@ export const createAgentStatusRows = (stateResponse: AgentStateResponse | null):
     });
   }
 
+  const normalizedSpeechText = normalizeSpeechText(stateResponse?.speech);
+  const shouldRenderSpeechContent = stateResponse?.canSpeak === false
+    || (normalizedSpeechText !== undefined && speechHistoryItems.length === 0)
+    || (normalizedSpeechText !== undefined && speechHistoryItems[0].speechText !== normalizedSpeechText);
+
   if (stateResponse?.canSpeak === false) {
     rows.push({ label: "発話内容", value: getSpeechUnavailableIndicator() });
-  } else if (stateResponse?.speech !== undefined) {
-    rows.push({ label: "発話内容", value: normalizeSpeechText(stateResponse.speech) ?? "-" });
+  } else if (normalizedSpeechText !== undefined && shouldRenderSpeechContent) {
+    rows.push({ label: "発話内容", value: normalizedSpeechText });
   }
 
   return rows;

--- a/console/src/AgentStatus/createAgentStatusRows.ts
+++ b/console/src/AgentStatus/createAgentStatusRows.ts
@@ -21,11 +21,16 @@ export const createAgentStatusRows = (stateResponse: AgentStateResponse | null):
   }
 
   if (stateResponse !== null && stateResponse !== undefined && "currentGame" in stateResponse) {
-    rows.push({ label: "現在のゲーム", value: stateResponse.currentGame?.name ?? "-" });
-    rows.push({
-      label: "ゲーム情報",
-      valueComponent: createCurrentGameInfoValueComponent(stateResponse.currentGame?.state),
-    });
+    const currentGameName = stateResponse.currentGame?.name;
+    const currentGameState = stateResponse.currentGame?.state;
+
+    if (currentGameName !== undefined && currentGameState !== undefined) {
+      rows.push({
+        label: "ゲーム情報",
+        hideLabel: true,
+        valueComponent: createCurrentGameInfoValueComponent(currentGameState),
+      });
+    }
   }
 
   if (stateResponse?.nGram !== undefined) {
@@ -48,7 +53,7 @@ export const createAgentStatusRows = (stateResponse: AgentStateResponse | null):
   const normalizedSpeechText = normalizeSpeechText(stateResponse?.speech);
   const shouldRenderSpeechContent = stateResponse?.canSpeak === false
     || (normalizedSpeechText !== undefined && speechHistoryItems.length === 0)
-    || (normalizedSpeechText !== undefined && speechHistoryItems[0].speechText !== normalizedSpeechText);
+    || (normalizedSpeechText !== undefined && speechHistoryItems[0]?.speechText !== normalizedSpeechText);
 
   if (stateResponse?.canSpeak === false) {
     rows.push({ label: "発話内容", value: getSpeechUnavailableIndicator() });

--- a/console/src/AgentStatus/createAgentStatusRows.ts
+++ b/console/src/AgentStatus/createAgentStatusRows.ts
@@ -17,9 +17,6 @@ export const createAgentStatusRows = (stateResponse: AgentStateResponse | null):
   if (niconamaState && Object.keys(niconamaState).length > 0) {
     rows.push(
       { label: "配信指標", hideLabel: true, valueComponent: createLiveDeliveryMetricsValueComponent(niconamaState) },
-      { label: "タイトル", value: niconamaState.meta?.title ?? "-" },
-      { label: "配信URL", value: niconamaState.meta?.url ?? "-", href: niconamaState.meta?.url },
-      { label: "開始時刻", value: formatStartDate(niconamaState.meta?.start) },
     );
   }
 
@@ -38,6 +35,7 @@ export const createAgentStatusRows = (stateResponse: AgentStateResponse | null):
   if (createSpeechHistoryDisplayItems(stateResponse?.speechHistory).length > 0) {
     rows.push({
       label: "これまでの発話",
+      hideLabel: true,
       valueComponent: createSpeechHistoryValueComponent(stateResponse?.speechHistory),
     });
   }

--- a/console/src/AgentStatus/createAgentStatusSections.test.ts
+++ b/console/src/AgentStatus/createAgentStatusSections.test.ts
@@ -13,16 +13,34 @@ describe("createAgentStatusSections", () => {
     expect(sections.map((section) => section.title)).toEqual([
       "配信状況",
       "マルコフ連鎖モデル",
-      "ゲームの状態",
+      "『ゲームID』プレイ中",
     ]);
   });
 
-  it("returns only sections that have rows", () => {
+  it("returns only sections that have rows plus fallback game section", () => {
     const sections = createAgentStatusSections({
       nGram: 4,
       speechHistory: [{ id: "speech-1", speech: "hello world", nGram: 2 }],
     } as any);
 
-    expect(sections.map((section) => section.title)).toEqual(["マルコフ連鎖モデル"]);
+    expect(sections.map((section) => section.title)).toEqual(["マルコフ連鎖モデル", "『-』プレイ中"]);
+  });
+
+  it("shows fallback game title without detail rows when currentGame is null", () => {
+    const sections = createAgentStatusSections({ currentGame: null } as any);
+
+    expect(sections).toHaveLength(1);
+    const gameSection = sections[0]!;
+    expect(gameSection.title).toBe("『-』プレイ中");
+    expect(gameSection.rows).toEqual([]);
+  });
+
+  it("shows fallback game title without detail rows when currentGame is missing", () => {
+    const sections = createAgentStatusSections({} as any);
+
+    expect(sections).toHaveLength(1);
+    const gameSection = sections[0]!;
+    expect(gameSection.title).toBe("『-』プレイ中");
+    expect(gameSection.rows).toEqual([]);
   });
 });

--- a/console/src/AgentStatus/createAgentStatusSections.test.ts
+++ b/console/src/AgentStatus/createAgentStatusSections.test.ts
@@ -12,7 +12,7 @@ describe("createAgentStatusSections", () => {
 
     expect(sections.map((section) => section.title)).toEqual([
       "配信状況",
-      "マルコフ連鎖モデルの状態",
+      "マルコフ連鎖モデル",
       "ゲームの状態",
     ]);
   });
@@ -23,6 +23,6 @@ describe("createAgentStatusSections", () => {
       speechHistory: [{ id: "speech-1", speech: "hello world", nGram: 2 }],
     } as any);
 
-    expect(sections.map((section) => section.title)).toEqual(["マルコフ連鎖モデルの状態"]);
+    expect(sections.map((section) => section.title)).toEqual(["マルコフ連鎖モデル"]);
   });
 });

--- a/console/src/AgentStatus/createAgentStatusSections.ts
+++ b/console/src/AgentStatus/createAgentStatusSections.ts
@@ -21,7 +21,7 @@ export const createAgentStatusSections = (stateResponse: AgentStateResponse | nu
 
   const sections = [
     { title: "配信状況", rows: liveDeliveryRows },
-    { title: "マルコフ連鎖モデルの状態", rows: markovModelRows },
+    { title: "マルコフ連鎖モデル", rows: markovModelRows },
     { title: "ゲームの状態", rows: gameRows },
   ];
 

--- a/console/src/AgentStatus/createAgentStatusSections.ts
+++ b/console/src/AgentStatus/createAgentStatusSections.ts
@@ -1,12 +1,11 @@
 import type { AgentStateResponse, AgentStatusSection } from "./types";
 import { createAgentStatusRows } from "./createAgentStatusRows";
-import { GAME_SECTION_TITLE } from "./GameStatusSection";
 import { LIVE_DELIVERY_SECTION_TITLE } from "./LiveDeliveryStatusSection";
 import { MARKOV_MODEL_SECTION_TITLE } from "./MarkovModelStatusSection";
 
 const LIVE_DELIVERY_ROW_LABELS = ["配信指標", "タイトル", "配信URL", "開始時刻", "発話内容"] as const;
 const MARKOV_MODEL_ROW_LABELS = ["生成N-gram", "これまでの発話"] as const;
-const GAME_ROW_LABELS = ["現在のゲーム", "ゲーム情報"] as const;
+const GAME_ROW_LABELS = ["ゲーム情報"] as const;
 
 const createLabelSet = (labels: readonly string[]) => new Set<string>(labels);
 const LIVE_DELIVERY_ROW_LABEL_SET = createLabelSet(LIVE_DELIVERY_ROW_LABELS);
@@ -19,11 +18,16 @@ export const createAgentStatusSections = (stateResponse: AgentStateResponse | nu
   const markovModelRows = rows.filter((row) => MARKOV_MODEL_ROW_LABEL_SET.has(row.label));
   const gameRows = rows.filter((row) => GAME_ROW_LABEL_SET.has(row.label));
 
+  const shouldShowGameSection = stateResponse !== null && stateResponse !== undefined;
+  const gameSectionTitle = stateResponse?.currentGame?.name
+    ? `『${stateResponse.currentGame.name}』プレイ中`
+    : "『-』プレイ中";
+
   const sections = [
     { title: "配信状況", rows: liveDeliveryRows },
     { title: "マルコフ連鎖モデル", rows: markovModelRows },
-    { title: "ゲームの状態", rows: gameRows },
+    ...(shouldShowGameSection ? [{ title: gameSectionTitle, rows: gameRows }] : []),
   ];
 
-  return sections.filter((section) => section.rows.length > 0);
+  return sections.filter((section) => section.rows.length > 0 || section.title === gameSectionTitle);
 };

--- a/tests/e2e/console/console.test.ts
+++ b/tests/e2e/console/console.test.ts
@@ -212,7 +212,7 @@ test.describe("console", () => {
     await expect(detailsLocator).toContainText("4-gram");
     await expect(page.getByRole("heading", { level: 3, name: "配信状況" })).toBeVisible();
     await expect(page.getByRole("heading", { level: 3, name: "マルコフ連鎖モデルの状態" })).toBeVisible();
-    await expect(page.getByRole("heading", { level: 3, name: "ゲームの状態" })).toBeVisible();
+    await expect(page.getByRole("heading", { level: 3, name: "『org.dashnet.orteil/cookieclicker』プレイ中" })).toBeVisible();
 
     const agentStatusDetails = page.getByTestId("agent-status-details");
     const initialAgentStatusDetailsBoundingBox = await agentStatusDetails.boundingBox();
@@ -237,6 +237,11 @@ test.describe("console", () => {
     expect(widthAfterLongSpeechBoundingBox).not.toBeNull();
     const finalWidth = widthAfterLongSpeechBoundingBox?.width ?? 0;
     expect(finalWidth).toBeCloseTo(initialWidth);
+  });
+
+  test("renders a heading containing プレイ中 even when currentGame is missing", async ({ page }) => {
+    await page.goto(`${CONSOLE_BASE_URL}/console/?agentStateMock=1&agentStateMockNoGame=1`, { waitUntil: "domcontentloaded", timeout: BROWSER_PAGE_LOAD_TIMEOUT_MS });
+    await expect(page.getByRole("heading", { name: /プレイ中/ })).toBeVisible();
   });
 
   test("connects via SSE and updates on broadcast (non-mock)", async ({ page, request }) => {

--- a/tests/e2e/console/console.test.ts
+++ b/tests/e2e/console/console.test.ts
@@ -208,10 +208,9 @@ test.describe("console", () => {
     }
 
     await expect(detailsLocator).not.toContainText("話せる状態");
-    await expect(detailsLocator).toContainText("生成N-gram");
     await expect(detailsLocator).toContainText("4-gram");
     await expect(page.getByRole("heading", { level: 3, name: "配信状況" })).toBeVisible();
-    await expect(page.getByRole("heading", { level: 3, name: "マルコフ連鎖モデルの状態" })).toBeVisible();
+    await expect(page.getByRole("heading", { level: 3, name: "マルコフ連鎖モデル" })).toBeVisible();
     await expect(page.getByRole("heading", { level: 3, name: "『org.dashnet.orteil/cookieclicker』プレイ中" })).toBeVisible();
 
     const agentStatusDetails = page.getByTestId("agent-status-details");
@@ -310,7 +309,6 @@ test.describe("console", () => {
 
     const detailsLocator = page.getByTestId("agent-status-details");
     await detailsLocator.waitFor({ timeout: 10_000 });
-    await expect(detailsLocator).toContainText("生成N-gram");
     await expect(detailsLocator).toContainText("4-gram", { timeout: 10_000 });
   });
 
@@ -359,7 +357,7 @@ test.describe("console", () => {
 
     const detailsLocator = page.getByTestId("agent-status-details");
     await detailsLocator.waitFor({ timeout: 10_000 });
-    await expect(detailsLocator).toContainText("生成N-gram");
+    await expect(detailsLocator).toContainText("4-gram", { timeout: 10_000 });
     await expect(page.waitForFunction(
       (count) => (window as any).__sseMessageCount > count,
       messagesBeforeIdle,

--- a/tests/integration/console/agent-status.test.ts
+++ b/tests/integration/console/agent-status.test.ts
@@ -177,8 +177,8 @@ describe("createAgentStatusRows", () => {
     expect(speechHistoryHtml).toContain("grid-cols-1");
     expect(speechHistoryHtml).toContain("テスト発話その1");
     expect(speechHistoryHtml).toContain("テスト発話その2");
-    expect(speechHistoryHtml).toContain("4g");
-    expect(speechHistoryHtml).toContain("3g");
+    expect(speechHistoryHtml).toContain("n=4");
+    expect(speechHistoryHtml).toContain("n=3");
     expect(speechHistoryHtml).toContain("aria-label=\"学習の取り消し\"");
     expect(rows).toContainEqual({ label: "発話内容", value: "テスト発話" });
   });

--- a/tests/integration/console/agent-status.test.ts
+++ b/tests/integration/console/agent-status.test.ts
@@ -222,12 +222,9 @@ describe("createAgentStatusRows", () => {
     expect(gameInfoHtml).toContain("空の配列");
   });
 
-  it("shows currentGame as '-' when null", () => {
+  it("does not show detailed game state rows when currentGame is null", () => {
     const rows = createAgentStatusRows({ currentGame: null });
-    const gameInfoRow = rows.find((row) => row.label === "ゲーム情報");
-    expect(gameInfoRow?.value).toBeUndefined();
-    expect(gameInfoRow?.hideLabel).toBeTrue();
-    expect(renderToStaticMarkup(createElement(Fragment, null, gameInfoRow?.valueComponent))).toContain("-");
+    expect(rows.find((row) => row.label === "ゲーム情報")).toBeUndefined();
   });
 
   it("falls back solver state row to '-' when currentGame.state is not serializable", () => {
@@ -360,17 +357,21 @@ describe("createAgentStatusSections", () => {
     expect(renderToStaticMarkup(createElement(Fragment, null, gameInfoRow?.valueComponent))).toContain("status");
   });
 
-  it("returns only sections that have rows", () => {
+  it("includes a fallback game section even when only other sections have rows", () => {
     const sections = createAgentStatusSections({ nGram: 4 });
     expect(sections).toEqual([
       {
         title: "マルコフ連鎖モデル",
         rows: [expect.objectContaining({ label: "生成N-gram", value: "4-gram" })],
       },
+      {
+        title: "『-』プレイ中",
+        rows: [],
+      },
     ]);
   });
 
-  it("includes speech history row in markov model section", () => {
+  it("includes speech history row in markov model section and fallback game section", () => {
     const sections = createAgentStatusSections({
       speechHistory: [{ speech: "過去発話", nGram: 4, nGramRaw: 4 }],
     });
@@ -381,6 +382,10 @@ describe("createAgentStatusSections", () => {
           label: "これまでの発話",
           valueComponent: expect.anything(),
         })],
+      },
+      {
+        title: "『-』プレイ中",
+        rows: [],
       },
     ]);
   });

--- a/tests/integration/console/agent-status.test.ts
+++ b/tests/integration/console/agent-status.test.ts
@@ -140,12 +140,6 @@ describe("createAgentStatusRows", () => {
     expect(liveMetricHtml).toContain("123");
     expect(liveMetricHtml).toContain("コメント数");
     expect(liveMetricHtml).toContain("grid-cols-5");
-    expect(rows).toContainEqual({ label: "タイトル", value: "テスト配信" });
-    expect(rows).toContainEqual({
-      label: "配信URL",
-      value: "https://example.com/live",
-      href: "https://example.com/live",
-    });
   });
 
   it("includes currentGame and speech rows when present", () => {
@@ -162,7 +156,9 @@ describe("createAgentStatusRows", () => {
     });
 
     expect(rows).toContainEqual({ label: "現在のゲーム", value: "org.dashnet.orteil/cookieclicker" });
-    expect(rows).toContainEqual({ label: "生成N-gram", value: "4-gram (4.00)" });
+    expect(rows).toEqual(expect.arrayContaining([
+      expect.objectContaining({ label: "生成N-gram", value: "4-gram (4.00)" }),
+    ]));
     const gameInfoRow = rows.find((row) => row.label === "ゲーム情報");
     expect(gameInfoRow?.value).toBeUndefined();
     expect(gameInfoRow?.valueComponent).toBeDefined();
@@ -261,13 +257,27 @@ describe("createAgentStatusRows", () => {
   });
 
   it("formats n-gram row with fallback for invalid numbers", () => {
-    expect(createAgentStatusRows({ nGram: Infinity })).toContainEqual({ label: "生成N-gram", value: "-" });
-    expect(createAgentStatusRows({ nGram: 0 })).toContainEqual({ label: "生成N-gram", value: "-" });
-    expect(createAgentStatusRows({ nGram: 4.8 })).toContainEqual({ label: "生成N-gram", value: "4-gram" });
-    expect(createAgentStatusRows({ nGram: 4.8, nGramRaw: 4.8 })).toContainEqual({ label: "生成N-gram", value: "4-gram (4.80)" });
-    expect(createAgentStatusRows({ nGram: 4.8, nGramRaw: 0.5 })).toContainEqual({ label: "生成N-gram", value: "4-gram" });
-    expect(createAgentStatusRows({ nGram: 4.8, nGramRaw: -2 })).toContainEqual({ label: "生成N-gram", value: "4-gram" });
-    expect(createAgentStatusRows({})).not.toContainEqual({ label: "生成N-gram", value: "-" });
+    expect(createAgentStatusRows({ nGram: Infinity })).toEqual(expect.arrayContaining([
+      expect.objectContaining({ label: "生成N-gram", value: "-" }),
+    ]));
+    expect(createAgentStatusRows({ nGram: 0 })).toEqual(expect.arrayContaining([
+      expect.objectContaining({ label: "生成N-gram", value: "-" }),
+    ]));
+    expect(createAgentStatusRows({ nGram: 4.8 })).toEqual(expect.arrayContaining([
+      expect.objectContaining({ label: "生成N-gram", value: "4-gram" }),
+    ]));
+    expect(createAgentStatusRows({ nGram: 4.8, nGramRaw: 4.8 })).toEqual(expect.arrayContaining([
+      expect.objectContaining({ label: "生成N-gram", value: "4-gram (4.80)" }),
+    ]));
+    expect(createAgentStatusRows({ nGram: 4.8, nGramRaw: 0.5 })).toEqual(expect.arrayContaining([
+      expect.objectContaining({ label: "生成N-gram", value: "4-gram" }),
+    ]));
+    expect(createAgentStatusRows({ nGram: 4.8, nGramRaw: -2 })).toEqual(expect.arrayContaining([
+      expect.objectContaining({ label: "生成N-gram", value: "4-gram" }),
+    ]));
+    expect(createAgentStatusRows({})).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ label: "生成N-gram", value: "-" }),
+    ]));
   });
 
   it("shows all speech history items in descending order", () => {
@@ -305,11 +315,12 @@ describe("createAgentStatusRows", () => {
     const liveMetricRow = rows.find((row) => row.label === "配信指標");
     expect(liveMetricRow?.value).toBeUndefined();
     expect(renderToStaticMarkup(createElement(Fragment, null, liveMetricRow?.valueComponent))).toContain("配信中");
-    expect(rows).toContainEqual({ label: "タイトル", value: "-" });
-    expect(rows).toContainEqual({ label: "配信URL", value: "-", href: undefined });
+    expect(rows).toEqual(expect.arrayContaining([
+      expect.objectContaining({ label: "配信指標" }),
+    ]));
   });
 
-  it("formats niconama start time from millisecond timestamps without multiplying again", () => {
+  it("does not include a dedicated start time row in createAgentStatusRows", () => {
     const rows = createAgentStatusRows({
       niconama: {
         type: "live",
@@ -318,8 +329,7 @@ describe("createAgentStatusRows", () => {
         },
       },
     });
-    const startRow = rows.find((row) => row.label === "開始時刻");
-    expect(startRow?.value).toContain("2024");
+    expect(rows.some((row) => row.label === "開始時刻")).toBe(false);
   });
 });
 
@@ -335,8 +345,10 @@ describe("createAgentStatusSections", () => {
       valueComponent: expect.anything(),
     });
     expect(liveDeliverySection?.rows).toContainEqual({ label: "発話内容", value: "コメントを学習してお話ししています" });
-    const markovModelSection = sections.find((section) => section.title === "マルコフ連鎖モデルの状態");
-    expect(markovModelSection?.rows).toContainEqual({ label: "生成N-gram", value: "4-gram (4.00)" });
+    const markovModelSection = sections.find((section) => section.title === "マルコフ連鎖モデル");
+    expect(markovModelSection?.rows).toEqual(expect.arrayContaining([
+      expect.objectContaining({ label: "生成N-gram", value: "4-gram (4.00)" }),
+    ]));
     expect(markovModelSection?.rows).not.toContainEqual({ label: "発話内容", value: "コメントを学習してお話ししています" });
     const gameSection = sections.find((section) => section.title === "ゲームの状態");
     expect(gameSection?.rows).toContainEqual({ label: "現在のゲーム", value: "org.dashnet.orteil/cookieclicker" });
@@ -349,8 +361,8 @@ describe("createAgentStatusSections", () => {
     const sections = createAgentStatusSections({ nGram: 4 });
     expect(sections).toEqual([
       {
-        title: "マルコフ連鎖モデルの状態",
-        rows: [{ label: "生成N-gram", value: "4-gram" }],
+        title: "マルコフ連鎖モデル",
+        rows: [expect.objectContaining({ label: "生成N-gram", value: "4-gram" })],
       },
     ]);
   });
@@ -361,11 +373,11 @@ describe("createAgentStatusSections", () => {
     });
     expect(sections).toEqual([
       {
-        title: "マルコフ連鎖モデルの状態",
-        rows: [{
+        title: "マルコフ連鎖モデル",
+        rows: [expect.objectContaining({
           label: "これまでの発話",
           valueComponent: expect.anything(),
-        }],
+        })],
       },
     ]);
   });
@@ -377,7 +389,7 @@ describe("createAgentStatusSections", () => {
     });
     const liveDeliverySection = sections.find((section) => section.title === "配信状況");
     expect(liveDeliverySection?.rows).toContainEqual({ label: "発話内容", value: "最新発話" });
-    const markovModelSection = sections.find((section) => section.title === "マルコフ連鎖モデルの状態");
+    const markovModelSection = sections.find((section) => section.title === "マルコフ連鎖モデル");
     expect(markovModelSection).toBeUndefined();
   });
 });

--- a/tests/integration/console/agent-status.test.ts
+++ b/tests/integration/console/agent-status.test.ts
@@ -155,7 +155,7 @@ describe("createAgentStatusRows", () => {
       speech: { speech: "テスト発話", silent: false },
     });
 
-    expect(rows).toContainEqual({ label: "現在のゲーム", value: "org.dashnet.orteil/cookieclicker" });
+    expect(rows).not.toContainEqual({ label: "現在のゲーム", value: "org.dashnet.orteil/cookieclicker" });
     expect(rows).toEqual(expect.arrayContaining([
       expect.objectContaining({ label: "生成N-gram", value: "4-gram (4.00)" }),
     ]));
@@ -224,9 +224,9 @@ describe("createAgentStatusRows", () => {
 
   it("shows currentGame as '-' when null", () => {
     const rows = createAgentStatusRows({ currentGame: null });
-    expect(rows).toContainEqual({ label: "現在のゲーム", value: "-" });
     const gameInfoRow = rows.find((row) => row.label === "ゲーム情報");
     expect(gameInfoRow?.value).toBeUndefined();
+    expect(gameInfoRow?.hideLabel).toBeTrue();
     expect(renderToStaticMarkup(createElement(Fragment, null, gameInfoRow?.valueComponent))).toContain("-");
   });
 
@@ -350,10 +350,13 @@ describe("createAgentStatusSections", () => {
       expect.objectContaining({ label: "生成N-gram", value: "4-gram (4.00)" }),
     ]));
     expect(markovModelSection?.rows).not.toContainEqual({ label: "発話内容", value: "コメントを学習してお話ししています" });
-    const gameSection = sections.find((section) => section.title === "ゲームの状態");
-    expect(gameSection?.rows).toContainEqual({ label: "現在のゲーム", value: "org.dashnet.orteil/cookieclicker" });
+    const gameSection = sections.find((section) =>
+      section.rows.some((row) => row.label === "ゲーム情報"),
+    );
+    expect(gameSection?.title).toBe("『org.dashnet.orteil/cookieclicker』プレイ中");
     const gameInfoRow = gameSection?.rows.find((row) => row.label === "ゲーム情報");
     expect(gameInfoRow?.value).toBeUndefined();
+    expect(gameInfoRow?.hideLabel).toBeTrue();
     expect(renderToStaticMarkup(createElement(Fragment, null, gameInfoRow?.valueComponent))).toContain("status");
   });
 


### PR DESCRIPTION
### 概要
このブランチでは `console/src/AgentStatus` の UI を複数の観点で改善しました。
- ライブ配信ヘッダーの整理と配信ステータス行のクリーンアップ
- マルコフ連鎖モデル表示の UI 改善と undo ボタンレンダリング修正
- 整合性の取れた統合テスト期待値への調整
- `currentGame` が無いときでもゲームセクションの見出しを維持するフォールバック処理の追加

### コミット一覧
- `8c43ced` feat(console): move live stream title and start time to header and clean up live delivery rows
- `e5dbf90` fix: refine markov model status UI and undo button rendering
- `0ff644c` test: align agent status integration expectations with updated Markov model section UI
- `5372d7f` fix(ui): apply thin scrollbar styling to Markov speech history without touching global index.css
- `7388576` fix(console): always show game section heading and add visibility E2E test

### 主な変更点
- `AgentStatus` ヘッダーを整理し、`streamTitle` / `streamUrl` / `startTime` を `AgentStatusHeader` に移行
- `ライブ配信` セクションの表示を簡潔にし、不要な行を削除
- `マルコフ連鎖モデル` セクションのスタイルと undo ボタン表示を改善
- `ゲームの状態` セクションで `現在のゲーム` 行を廃止し、`ゲーム情報` は valid な currentGame state がある場合のみ表示
- `currentGame` が missing / null でも `『-』プレイ中` や `『{name}』プレイ中` の見出しを維持
- `agentStateMockNoGame=1` で currentGame missing ケースを mock できるようにし、E2E で見出し可視性を確認

### テスト
- 単体テスト: AgentStatus / createAgentStatusRows / createAgentStatusSections / AgentStatusSections
- 統合テスト: `tests/integration/console/agent-status.test.ts`
- E2E: `tests/e2e/console/console.test.ts`

### PR タイトル
- `refactor(console): improve AgentStatus UI and preserve game section heading`
