### PR TITLE
fix: preserve missing comments count in /api/meta normalization

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -174,12 +174,59 @@ const broadcastCurrentPayload = (context: string) => {
   }
 };
 
+const normalizePublishedStreamState = (state: unknown): unknown => {
+  if (!state || typeof state !== 'object') {
+    return state;
+  }
+
+  const rawState = state as Record<string, unknown>;
+
+  if (rawState.type === 'niconama') {
+    const data = rawState.data as Record<string, unknown> | undefined;
+    const total: Record<string, unknown> = {};
+    if (typeof data?.total === 'number') {
+      total.listeners = data.total;
+    }
+    if (data?.points && typeof (data.points as Record<string, unknown>).gift !== 'undefined') {
+      total.gift = (data.points as Record<string, unknown>).gift;
+    }
+    if (data?.points && typeof (data.points as Record<string, unknown>).ad !== 'undefined') {
+      total.ad = (data.points as Record<string, unknown>).ad;
+    }
+
+    return {
+      niconama: {
+        type: data?.isLive ? 'live' : 'offline',
+        meta: {
+          title: data?.title ?? undefined,
+          url: data?.url ?? undefined,
+          start: data?.startTime ?? undefined,
+          total: Object.keys(total).length > 0 ? total : undefined,
+        },
+      },
+    };
+  }
+
+  if ('niconama' in rawState && rawState.niconama && typeof rawState.niconama === 'object') {
+    return rawState;
+  }
+
+  if (rawState.type === 'live' || rawState.type === 'offline') {
+    return {
+      niconama: rawState,
+    };
+  }
+
+  return rawState;
+};
+
 const getCurrentStreamPayload = () => {
   const agentStreamState = agent.getStreamState?.();
   const streamState = (lastPublishedStreamState === undefined || lastPublishedStreamState === null)
     ? agentStreamState
     : lastPublishedStreamState;
-  const base = streamState && typeof streamState === 'object' ? (streamState as any) : {};
+  const normalizedStreamState = normalizePublishedStreamState(streamState);
+  const base = normalizedStreamState && typeof normalizedStreamState === 'object' ? (normalizedStreamState as any) : {};
   return {
     niconama: base.niconama ?? {},
     canSpeak: base.canSpeak ?? streamer.canSpeak,
@@ -386,30 +433,16 @@ const server = serve({
             return Response.json({}, { status: 400 });
           }
 
-          let published = body.data ?? body;
+          let published: unknown = body;
+          if (published && typeof published === 'object' && !('type' in published) && 'data' in published) {
+            published = (published as any).data;
+          }
 
-          // Normalize legacy stream payloads of the form { type: 'niconama', data: {...} }
-          // into the internal shape expected by getCurrentStreamPayload().
+          // Normalize any published stream state into the internal shape expected by
+          // getCurrentStreamPayload(). This includes legacy payloads of the form
+          // { type: 'niconama', data: {...} } and raw stream state objects.
           try {
-            if (published && typeof published === 'object' && 'type' in published && published.type === 'niconama') {
-              const d = published.data ?? {};
-              published = {
-                niconama: {
-                  type: d.isLive ? 'live' : 'offline',
-                  meta: {
-                    title: d.title ?? undefined,
-                    url: d.url ?? undefined,
-                    start: d.startTime ?? undefined,
-                    total: {
-                      listeners: typeof d.total === 'number' ? d.total : undefined,
-                      gift: d.points?.gift ?? undefined,
-                      ad: d.points?.ad ?? undefined,
-                      comments: undefined,
-                    },
-                  },
-                },
-              } as const;
-            }
+            published = normalizePublishedStreamState(published);
           } catch (err) {
             console.warn('[WARN] failed to normalize published stream state:', err instanceof Error ? err.message : String(err));
           }

--- a/tests/e2e/server.test.ts
+++ b/tests/e2e/server.test.ts
@@ -109,6 +109,31 @@ test.describe("server", () => {
     expect(res.ok()).toBeTruthy();
   });
 
+  test("normalizes legacy /api/meta payload and preserves missing comments count", async ({ request }) => {
+    const res = await request.post(`${BASE_URL}/api/meta`, {
+      data: {
+        type: 'niconama',
+        data: {
+          isLive: true,
+          title: 'legacy normalization',
+          startTime: 0,
+          total: 1,
+          points: { gift: 0, ad: 0 },
+          url: 'https://example.com/legacy',
+        },
+      },
+    });
+
+    expect(res.ok()).toBeTruthy();
+
+    const metaRes = await request.get(`${BASE_URL}/api/meta`);
+    expect(metaRes.ok()).toBeTruthy();
+    const metaJson = await metaRes.json();
+    expect(metaJson).toHaveProperty('niconama.type', 'live');
+    expect(metaJson).toHaveProperty('niconama.meta.url', 'https://example.com/legacy');
+    expect(metaJson.niconama.meta.total).not.toHaveProperty('comments');
+  });
+
   test("accepts PUT / via comment route", async ({ request }) => {
     const postRes = await request.post(`${BASE_URL}/`);
     expect(postRes.ok()).toBeTruthy();


### PR DESCRIPTION
Fix API metadata normalization so missing niconama.comments is preserved and console display stays '-' when comments are absent. Includes an e2e regression test for legacy /api/meta payloads.