### PR TITLE
feat(console): show reply target comment in Markov model

### DIFF
--- a/console/src/AgentStatus/agentStatusUtils.tsx
+++ b/console/src/AgentStatus/agentStatusUtils.tsx
@@ -85,6 +85,59 @@ export const normalizeSpeechText = (speech: SpeechPayload): string | undefined =
   return undefined;
 };
 
+const createHighlightedCommentLines = (commentText: string, pickedTopic: string) => {
+  if (!pickedTopic) {
+    return [commentText];
+  }
+  if (pickedTopic === commentText) {
+    return ["", pickedTopic, ""];
+  }
+  return commentText.split(pickedTopic).flatMap((segment, index, segments) => (
+    index === segments.length - 1
+      ? [segment]
+      : [segment, pickedTopic]
+  ));
+};
+
+export const createReplyTargetCommentValueComponent = (
+  replyTargetComment: AgentStateResponse["replyTargetComment"],
+): ReactNode => {
+  const text = replyTargetComment?.text?.trim();
+  const pickedTopic = replyTargetComment?.pickedTopic?.trim();
+  if (!text) {
+    return <span>-</span>;
+  }
+
+  const commentNodes = pickedTopic
+    ? createHighlightedCommentLines(text, pickedTopic)
+    : [text];
+
+  return (
+    <div className="space-y-2">
+      <p className="break-words whitespace-pre-wrap">
+        {commentNodes.map((part, index) => (
+          index % 2 === 1 ? (
+            <span
+              key={`highlighted-topic-${index}`}
+              className="rounded bg-emerald-300/30 px-1 font-semibold text-emerald-100"
+            >
+              {part}
+            </span>
+          ) : (
+            <span key={`comment-part-${index}`}>{part}</span>
+          )
+        ))}
+      </p>
+      {pickedTopic ? (
+        <div className="inline-flex flex-wrap items-center gap-2 rounded border border-emerald-300/40 bg-emerald-950/40 px-2 py-1 text-xs text-emerald-100">
+          <span className="text-slate-300">picked topic</span>
+          <span className="font-semibold">{pickedTopic}</span>
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
 const formatSpeechHistoryNGramLabel = (nGram: number | undefined): string => {
   if (nGram === undefined || !Number.isFinite(nGram) || nGram < 1) {
     return "-";

--- a/console/src/AgentStatus/createAgentStatusRows.test.tsx
+++ b/console/src/AgentStatus/createAgentStatusRows.test.tsx
@@ -176,6 +176,27 @@ describe("createAgentStatusRows", () => {
     expect((html.match(/speech-word-chip/g) || []).length).toBe(3);
   });
 
+  it("renders reply target comment with picked topic highlight", () => {
+    const rows = createAgentStatusRows({
+      nGram: 4,
+      replyTargetComment: {
+        text: "このコメントに返信します",
+        pickedTopic: "返信",
+      },
+    } as any);
+    const replyRow = rows.find((row) => row.label === "返信先コメント");
+
+    expect(replyRow).toBeDefined();
+    expect(replyRow?.hideLabel).toBe(true);
+    const html = renderToStaticMarkup(<MarkovModelStatusSection markovModelRows={[replyRow!] as any} />);
+
+    expect(html).toContain("このコメントに");
+    expect(html).toContain("します");
+    expect(html).toContain("picked topic");
+    expect(html).toContain("返信");
+    expect(html).toContain("bg-emerald-300/30");
+  });
+
   it("renders trace nodes even when nGram is invalid", () => {
     const rows = createAgentStatusRows({
       speechHistory: [

--- a/console/src/AgentStatus/createAgentStatusRows.ts
+++ b/console/src/AgentStatus/createAgentStatusRows.ts
@@ -2,6 +2,7 @@ import type { AgentStateResponse, AgentStatusRow } from "./types";
 import {
   createCurrentGameInfoValueComponent,
   createLiveDeliveryMetricsValueComponent,
+  createReplyTargetCommentValueComponent,
   createSpeechHistoryDisplayItems,
   createSpeechHistoryValueComponent,
   formatNGramValue,
@@ -41,8 +42,15 @@ export const createAgentStatusRows = (stateResponse: AgentStateResponse | null):
     });
   }
 
-  const isSpeechSilent = stateResponse?.speech?.silent === true;
+  if (stateResponse?.replyTargetComment?.text) {
+    rows.push({
+      label: "返信先コメント",
+      hideLabel: true,
+      valueComponent: createReplyTargetCommentValueComponent(stateResponse.replyTargetComment),
+    });
+  }
 
+  const isSpeechSilent = stateResponse?.speech?.silent === true;
   const speechHistoryItems = createSpeechHistoryDisplayItems(stateResponse?.speechHistory);
   if (speechHistoryItems.length > 0) {
     rows.push({

--- a/console/src/AgentStatus/createAgentStatusSections.test.ts
+++ b/console/src/AgentStatus/createAgentStatusSections.test.ts
@@ -26,6 +26,21 @@ describe("createAgentStatusSections", () => {
     expect(sections.map((section) => section.title)).toEqual(["マルコフ連鎖モデル", "『-』プレイ中"]);
   });
 
+  it("includes reply target comments in the markov model section", () => {
+    const sections = createAgentStatusSections({
+      nGram: 4,
+      replyTargetComment: {
+        text: "返信先コメントを表示します",
+        pickedTopic: "返信",
+      },
+    } as any);
+
+    const markovSection = sections.find((section) => section.title === "マルコフ連鎖モデル");
+    expect(markovSection?.rows).toEqual(expect.arrayContaining([
+      expect.objectContaining({ label: "返信先コメント" }),
+    ]));
+  });
+
   it("shows fallback game title without detail rows when currentGame is null", () => {
     const sections = createAgentStatusSections({ currentGame: null } as any);
 

--- a/console/src/AgentStatus/createAgentStatusSections.ts
+++ b/console/src/AgentStatus/createAgentStatusSections.ts
@@ -4,7 +4,7 @@ import { LIVE_DELIVERY_SECTION_TITLE } from "./LiveDeliveryStatusSection";
 import { MARKOV_MODEL_SECTION_TITLE } from "./MarkovModelStatusSection";
 
 const LIVE_DELIVERY_ROW_LABELS = ["配信指標", "タイトル", "配信URL", "開始時刻", "発話内容"] as const;
-const MARKOV_MODEL_ROW_LABELS = ["生成N-gram", "これまでの発話"] as const;
+const MARKOV_MODEL_ROW_LABELS = ["生成N-gram", "返信先コメント", "これまでの発話"] as const;
 const GAME_ROW_LABELS = ["ゲーム情報"] as const;
 
 const createLabelSet = (labels: readonly string[]) => new Set<string>(labels);

--- a/console/src/AgentStatus/types.ts
+++ b/console/src/AgentStatus/types.ts
@@ -53,5 +53,9 @@ export type AgentStateResponse = {
     nGramRaw?: number
     nodes?: readonly string[]
   }>
+  replyTargetComment?: {
+    text?: string
+    pickedTopic?: string
+  }
   commentCount?: number
 };

--- a/index.ts
+++ b/index.ts
@@ -227,6 +227,10 @@ const getCurrentStreamPayload = () => {
     : lastPublishedStreamState;
   const normalizedStreamState = normalizePublishedStreamState(streamState);
   const base = normalizedStreamState && typeof normalizedStreamState === 'object' ? (normalizedStreamState as any) : {};
+  const replyTargetComment = base.replyTargetComment && typeof base.replyTargetComment === 'object'
+    ? base.replyTargetComment
+    : undefined;
+
   return {
     niconama: base.niconama ?? {},
     canSpeak: base.canSpeak ?? streamer.canSpeak,
@@ -235,6 +239,7 @@ const getCurrentStreamPayload = () => {
     nGramRaw: base.nGramRaw ?? streamer.currentNGramSizeRaw,
     speech: base.speech ?? agent.getSpeech(),
     speechHistory: base.speechHistory ?? generatedSpeechHistory,
+    replyTargetComment,
     commentCount: base.commentCount ?? streamer.streamState?.meta?.total?.comments,
   } as const;
 };
@@ -416,6 +421,9 @@ const server = serve({
             return Response.json({}, { status: 400 });
           }
 
+          const replyTargetComment = body && typeof body === 'object' && 'replyTargetComment' in body
+            ? (body as any).replyTargetComment
+            : undefined;
           let published: unknown = body;
           if (published && typeof published === 'object' && !('type' in published) && 'data' in published) {
             published = (published as any).data;
@@ -436,6 +444,13 @@ const server = serve({
           // { type: 'niconama', data: {...} } and raw stream state objects.
           try {
             published = normalizePublishedStreamState(published);
+            if (replyTargetComment !== undefined) {
+              if (published && typeof published === 'object') {
+                (published as any).replyTargetComment = replyTargetComment;
+              } else {
+                published = { replyTargetComment };
+              }
+            }
           } catch (err) {
             console.warn('[WARN] failed to normalize published stream state:', err instanceof Error ? err.message : String(err));
           }

--- a/tests/e2e/server.test.ts
+++ b/tests/e2e/server.test.ts
@@ -102,6 +102,27 @@ test.describe("server", () => {
     expect(data).toHaveProperty("nGram");
   });
 
+  test("propagates replyTargetComment through /api/meta responses", async ({ request }) => {
+    const postRes = await request.post(`${BASE_URL}/api/meta`, {
+      data: {
+        replyTargetComment: {
+          text: 'わかりました。返信します',
+          pickedTopic: '返信',
+        },
+      },
+    });
+    expect(postRes.ok()).toBeTruthy();
+
+    const metaRes = await request.get(`${BASE_URL}/api/meta`);
+    expect(metaRes.ok()).toBeTruthy();
+    const metaJson = await metaRes.json();
+    expect(metaJson).toHaveProperty('replyTargetComment');
+    expect(metaJson.replyTargetComment).toEqual({
+      text: 'わかりました。返信します',
+      pickedTopic: '返信',
+    });
+  });
+
   test("accepts POST /api/meta", async ({ request }) => {
     const res = await request.post(`${BASE_URL}/api/meta`, {
       data: { data: { type: 'niconama', data: { isLive: false, title: 'test', startTime: 0, total: 0, points: { gift: 0, ad: 0 }, url: 'https://example.com' } } },


### PR DESCRIPTION
Add reply target comment display to the console Markov model status section with highlighted picked topic.\n\nIncludes server-side support for propagating replyTargetComment through /api/meta.\n\nTests: unit and integration passed; a separate e2e game IPC test currently fails in tests/e2e/games/org.dashnet.orteil/cookieclicker/full-ipc.test.ts.\n