### PR TITLE
Fix Tailwind CSS loading for main app and admin console

### DIFF
--- a/console/src/App.tsx
+++ b/console/src/App.tsx
@@ -1,6 +1,5 @@
 /** @jsxImportSource hono/jsx */
 import { AgentStatus } from "./AgentStatus";
-import "./index.css";
 
 export function App() {
   return (

--- a/console/src/index.html
+++ b/console/src/index.html
@@ -7,8 +7,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="https://live.nicovideo.jp/watch/user/14171889" />
   <link rel="canonical" href="https://live.nicovideo.jp/watch/user/14171889" />
-  <link rel="stylesheet" href="./frontend.css" />
   <title>馬可無序 - 管理コンソール</title>
+  <link rel="stylesheet" href="/console/index.css" />
 </head>
 
 <body>

--- a/index.ts
+++ b/index.ts
@@ -18,6 +18,7 @@ import * as index from "./routes/index";
 import * as speechHistoryRoute from "./routes/api/speech-history";
 import type { SpeechHistoryEntry } from "./routes/api/speech-history";
 import { handleCatchAll } from "./src/frontendServer";
+import { compileTailwindCss } from "./lib/tailwind";
 
 process.on('exit', exitHandler.bind(null, { cleanup: true }));
 process.on('SIGINT', signalHandler.bind(null, { exit: true }));
@@ -595,6 +596,11 @@ const mainApp = new Hono()
   // WebSocket / SSE endpoints
   .get('/api/ws', (c) => makeStreamHandler('/api/ws')(c.req.raw))
   .get('/console/api/ws', (c) => makeStreamHandler('/console/api/ws')(c.req.raw))
+  .get('/index.css', async () => {
+    return new Response(await compileTailwindCss('src/index.css'), {
+      headers: { 'Content-Type': 'text/css; charset=utf-8' },
+    });
+  })
 
   // Delegate all /api/* routes to the existing Hono app
   .route('/', apiApp)

--- a/index.ts
+++ b/index.ts
@@ -18,7 +18,7 @@ import * as index from "./routes/index";
 import * as speechHistoryRoute from "./routes/api/speech-history";
 import type { SpeechHistoryEntry } from "./routes/api/speech-history";
 import { handleCatchAll } from "./src/frontendServer";
-import { compileTailwindCss } from "./lib/tailwind";
+import { compileTailwindCss, createCssResponse } from "./lib/tailwind";
 
 process.on('exit', exitHandler.bind(null, { cleanup: true }));
 process.on('SIGINT', signalHandler.bind(null, { exit: true }));
@@ -596,10 +596,9 @@ const mainApp = new Hono()
   // WebSocket / SSE endpoints
   .get('/api/ws', (c) => makeStreamHandler('/api/ws')(c.req.raw))
   .get('/console/api/ws', (c) => makeStreamHandler('/console/api/ws')(c.req.raw))
-  .get('/index.css', async () => {
-    return new Response(await compileTailwindCss('src/index.css'), {
-      headers: { 'Content-Type': 'text/css; charset=utf-8' },
-    });
+  .get('/index.css', async (c) => {
+    const css = await compileTailwindCss('src/index.css');
+    return createCssResponse(css, c.req.raw);
   })
 
   // Delegate all /api/* routes to the existing Hono app
@@ -647,6 +646,19 @@ const server = mainServer = serve<WsData>({
 console.log(`🚀 Server running at ${server.url}`);
 
 let consoleServer: ReturnType<typeof startConsoleServer> | null = null;
+if (process.env.NODE_ENV === "production") {
+  void (async () => {
+    try {
+      await Promise.all([
+        compileTailwindCss('src/index.css'),
+        compileTailwindCss('console/src/index.css'),
+      ]);
+      console.log('[INFO] Tailwind CSS cache primed');
+    } catch (err) {
+      console.warn('[WARN] failed to prime Tailwind CSS cache', err);
+    }
+  })();
+}
 try {
   consoleServer = startConsoleServer({
     broadcastingHost: process.env.BROADCASTING_HOST ?? '127.0.0.1',

--- a/lib/tailwind.test.ts
+++ b/lib/tailwind.test.ts
@@ -1,18 +1,22 @@
 import { test, expect } from "bun:test";
 import { compileTailwindCss } from "./tailwind";
 
-test("compiles main Tailwind CSS without unresolved directives", async () => {
+test("compiles main Tailwind CSS without unresolved directives and includes app utilities", async () => {
   const css = await compileTailwindCss("src/index.css");
   expect(css).not.toContain("@apply");
   expect(css).not.toContain("@theme");
   expect(css).toContain(":root");
   expect(css).toContain("body");
+  expect(css).toContain("bg-emerald-950");
+  expect(css).toContain("grid");
 });
 
-test("compiles console Tailwind CSS without unresolved directives", async () => {
+test("compiles console Tailwind CSS without unresolved directives and includes console utilities", async () => {
   const css = await compileTailwindCss("console/src/index.css");
   expect(css).not.toContain("@apply");
   expect(css).not.toContain("@theme");
   expect(css).toContain(":root");
   expect(css).toContain("body");
+  expect(css).toContain("w-full");
+  expect(css).toContain("max-w-");
 });

--- a/lib/tailwind.test.ts
+++ b/lib/tailwind.test.ts
@@ -1,0 +1,18 @@
+import { test, expect } from "bun:test";
+import { compileTailwindCss } from "./tailwind";
+
+test("compiles main Tailwind CSS without unresolved directives", async () => {
+  const css = await compileTailwindCss("src/index.css");
+  expect(css).not.toContain("@apply");
+  expect(css).not.toContain("@theme");
+  expect(css).toContain(":root");
+  expect(css).toContain("body");
+});
+
+test("compiles console Tailwind CSS without unresolved directives", async () => {
+  const css = await compileTailwindCss("console/src/index.css");
+  expect(css).not.toContain("@apply");
+  expect(css).not.toContain("@theme");
+  expect(css).toContain(":root");
+  expect(css).toContain("body");
+});

--- a/lib/tailwind.ts
+++ b/lib/tailwind.ts
@@ -1,9 +1,49 @@
 import { compile } from "tailwindcss";
-import { readFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { createHash } from "node:crypto";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, extname, join, resolve } from "node:path";
 
 const TAILWIND_CSS_PATH = resolve(process.cwd(), "node_modules/tailwindcss/index.css");
 const compiledCssCache = new Map<string, Promise<string>>();
+const candidateExtensions = new Set([".ts", ".tsx", ".js", ".jsx", ".html"]);
+const excludedDirectories = new Set(["node_modules", ".git", "dist", "build"]);
+
+function extractCandidatesFromContent(content: string): Set<string> {
+  const candidates = new Set<string>();
+  const classAttributeRegex = /(?:class|className)\s*=\s*(?:\{\s*)?(?:`([^`]+)`|(['"])(.*?)\2)\s*(?:\})?/gs;
+  for (const match of content.matchAll(classAttributeRegex)) {
+    const raw = match[1] ?? match[3] ?? "";
+    for (const candidate of raw.trim().split(/\s+/)) {
+      if (candidate) candidates.add(candidate);
+    }
+  }
+  return candidates;
+}
+
+function walkFiles(directory: string, candidates: Set<string>) {
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    if (entry.name.startsWith('.') || excludedDirectories.has(entry.name)) continue;
+    const fullPath = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      walkFiles(fullPath, candidates);
+      continue;
+    }
+    if (!candidateExtensions.has(extname(entry.name))) continue;
+    const content = readFileSync(fullPath, "utf-8");
+    for (const candidate of extractCandidatesFromContent(content)) {
+      candidates.add(candidate);
+    }
+  }
+}
+
+function gatherCandidatesForSource(sourcePath: string): string[] {
+  const rootDirectory = sourcePath.startsWith("console/") ? resolve(process.cwd(), "console/src") : resolve(process.cwd(), "src");
+  const candidates = new Set<string>();
+  if (statSync(rootDirectory).isDirectory()) {
+    walkFiles(rootDirectory, candidates);
+  }
+  return [...candidates];
+}
 
 async function loadStylesheet(id: string, base: string) {
   if (id === "tailwindcss" || id === "tailwindcss/index.css") {
@@ -28,13 +68,38 @@ async function loadStylesheet(id: string, base: string) {
 async function compileTailwindCssFromPath(sourcePath: string): Promise<string> {
   const absoluteSourcePath = resolve(process.cwd(), sourcePath);
   const source = readFileSync(absoluteSourcePath, "utf-8");
+  const candidates = gatherCandidatesForSource(sourcePath);
 
   const result = await compile(source, {
     from: absoluteSourcePath,
     loadStylesheet,
   });
 
-  return result.build([]);
+  return result.build(candidates);
+}
+
+function buildCssHeaders(css: string): Record<string, string> {
+  const headers: Record<string, string> = {
+    "Content-Type": "text/css; charset=utf-8",
+  };
+
+  if (process.env.NODE_ENV === "production") {
+    const etag = `"${createHash("sha256").update(css).digest("hex")}"`;
+    headers["Cache-Control"] = "public, max-age=0, s-maxage=31536000, stale-while-revalidate=86400";
+    headers["ETag"] = etag;
+  } else {
+    headers["Cache-Control"] = "no-cache";
+  }
+
+  return headers;
+}
+
+export function createCssResponse(css: string, req?: Request): Response {
+  const headers = buildCssHeaders(css);
+  if (process.env.NODE_ENV === "production" && req?.headers.get("if-none-match") === headers["ETag"]) {
+    return new Response(null, { status: 304, headers });
+  }
+  return new Response(css, { headers });
 }
 
 export async function compileTailwindCss(sourcePath: string): Promise<string> {
@@ -42,7 +107,10 @@ export async function compileTailwindCss(sourcePath: string): Promise<string> {
   if (process.env.NODE_ENV === "production") {
     let cached = compiledCssCache.get(absoluteSourcePath);
     if (!cached) {
-      cached = compileTailwindCssFromPath(sourcePath);
+      cached = compileTailwindCssFromPath(sourcePath).catch((err) => {
+        compiledCssCache.delete(absoluteSourcePath);
+        throw err;
+      });
       compiledCssCache.set(absoluteSourcePath, cached);
     }
     return cached;

--- a/lib/tailwind.ts
+++ b/lib/tailwind.ts
@@ -1,0 +1,52 @@
+import { compile } from "tailwindcss";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+const TAILWIND_CSS_PATH = resolve(process.cwd(), "node_modules/tailwindcss/index.css");
+const compiledCssCache = new Map<string, Promise<string>>();
+
+async function loadStylesheet(id: string, base: string) {
+  if (id === "tailwindcss" || id === "tailwindcss/index.css") {
+    return {
+      path: TAILWIND_CSS_PATH,
+      base: dirname(TAILWIND_CSS_PATH),
+      content: readFileSync(TAILWIND_CSS_PATH, "utf-8"),
+    };
+  }
+
+  const resolvedPath = id.startsWith("/")
+    ? resolve(process.cwd(), `.${id}`)
+    : resolve(dirname(base), id);
+
+  return {
+    path: resolvedPath,
+    base: dirname(resolvedPath),
+    content: readFileSync(resolvedPath, "utf-8"),
+  };
+}
+
+async function compileTailwindCssFromPath(sourcePath: string): Promise<string> {
+  const absoluteSourcePath = resolve(process.cwd(), sourcePath);
+  const source = readFileSync(absoluteSourcePath, "utf-8");
+
+  const result = await compile(source, {
+    from: absoluteSourcePath,
+    loadStylesheet,
+  });
+
+  return result.build([]);
+}
+
+export async function compileTailwindCss(sourcePath: string): Promise<string> {
+  const absoluteSourcePath = resolve(process.cwd(), sourcePath);
+  if (process.env.NODE_ENV === "production") {
+    let cached = compiledCssCache.get(absoluteSourcePath);
+    if (!cached) {
+      cached = compileTailwindCssFromPath(sourcePath);
+      compiledCssCache.set(absoluteSourcePath, cached);
+    }
+    return cached;
+  }
+
+  return compileTailwindCssFromPath(sourcePath);
+}

--- a/routes/console/index.ts
+++ b/routes/console/index.ts
@@ -13,7 +13,7 @@ export { setBroadcastingTarget } from "../../lib/console-proxy";
 import * as agentState from "./api/agent-state";
 import * as speechHistory from "./api/speech-history";
 import robotsTxt from "./robots.txt";
-import { compileTailwindCss } from "../../lib/tailwind";
+import { compileTailwindCss, createCssResponse } from "../../lib/tailwind";
 import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { relative, resolve } from "node:path";
 
@@ -190,10 +190,9 @@ export const app = new Hono()
   .get('/console/robots.txt', () => robotsTxt.clone())
   .get('/console/api/agent-state', () => agentState.GET())
   .get('/console/api/speech-history', (c) => speechHistory.GET(c.req.raw))
-  .get('/console/index.css', async () => {
-    return new Response(await compileTailwindCss('console/src/index.css'), {
-      headers: { 'Content-Type': 'text/css; charset=utf-8' },
-    });
+  .get('/console/index.css', async (c) => {
+    const css = await compileTailwindCss('console/src/index.css');
+    return createCssResponse(css, c.req.raw);
   })
   .get('/console/frontend.js', async (c) => await serveConsoleAsset(c.req.raw) ?? new Response('Not Found', { status: 404 }))
   .get('/console/frontend.css', async (c) => await serveConsoleAsset(c.req.raw) ?? new Response('Not Found', { status: 404 }))

--- a/routes/console/index.ts
+++ b/routes/console/index.ts
@@ -13,6 +13,7 @@ export { setBroadcastingTarget } from "../../lib/console-proxy";
 import * as agentState from "./api/agent-state";
 import * as speechHistory from "./api/speech-history";
 import robotsTxt from "./robots.txt";
+import { compileTailwindCss } from "../../lib/tailwind";
 import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { relative, resolve } from "node:path";
 
@@ -156,7 +157,6 @@ export const app = new Hono()
             try { console.log('[DEBUG] opening upstream SSE fetch ->', sseUrl); } catch {}
             const res = await fetch(sseUrl, { headers: { accept: 'text/event-stream' } });
             try { console.log('[DEBUG] upstream SSE response ->', { status: res.status, contentType: res.headers.get('content-type') }); } catch {}
-
             try {
               const metaJson = await fetchMetaSnapshot(proxyBase);
               try { ws.send(JSON.stringify(metaJson)); } catch {}
@@ -190,6 +190,11 @@ export const app = new Hono()
   .get('/console/robots.txt', () => robotsTxt.clone())
   .get('/console/api/agent-state', () => agentState.GET())
   .get('/console/api/speech-history', (c) => speechHistory.GET(c.req.raw))
+  .get('/console/index.css', async () => {
+    return new Response(await compileTailwindCss('console/src/index.css'), {
+      headers: { 'Content-Type': 'text/css; charset=utf-8' },
+    });
+  })
   .get('/console/frontend.js', async (c) => await serveConsoleAsset(c.req.raw) ?? new Response('Not Found', { status: 404 }))
   .get('/console/frontend.css', async (c) => await serveConsoleAsset(c.req.raw) ?? new Response('Not Found', { status: 404 }))
   .get('/console/*', () => serveConsoleAppHtml());

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,6 @@ import { Box, Container, Layout } from "./agt-compat";
 import { GamePanel } from "./components/GamePanel";
 import { StreamerPanel } from "./components/StreamerPanel";
 import { AgentProvider } from "./contexts/AgentContext";
-import "./index.css";
 
 export function App() {
   return (

--- a/src/index.html
+++ b/src/index.html
@@ -9,7 +9,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="./frontend.css" />
+    <link rel="stylesheet" href="/index.css" />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
- Add server-side Tailwind CSS compilation routes for /index.css and /console/index.css
- Load compiled CSS via HTML stylesheet links instead of direct CSS imports in React entry components
- Add helper module lib/tailwind.ts and tests for compile correctness
- Update main and console routing to serve compiled CSS assets