### PR TITLE
fix(css): restore Tailwind UI styles after Hono migration

### DIFF
--- a/lib/tailwind.test.ts
+++ b/lib/tailwind.test.ts
@@ -7,6 +7,10 @@ test("compiles main Tailwind CSS without unresolved directives and includes app 
   expect(css).not.toContain("@theme");
   expect(css).toContain(":root");
   expect(css).toContain("body");
+  expect(css).toContain("bg-black");
+  expect(css).toContain("min-h-screen");
+  expect(css).toContain(".min-w-\\[320px\\]");
+  expect(css).toContain("overflow-hidden");
   expect(css).toContain("bg-emerald-950");
   expect(css).toContain("grid");
 });
@@ -17,6 +21,9 @@ test("compiles console Tailwind CSS without unresolved directives and includes c
   expect(css).not.toContain("@theme");
   expect(css).toContain(":root");
   expect(css).toContain("body");
+  expect(css).toContain("bg-gradient-to-b");
+  expect(css).toContain("h-dvh");
+  expect(css).toContain("overflow-hidden");
   expect(css).toContain("w-full");
   expect(css).toContain("max-w-");
 });

--- a/lib/tailwind.ts
+++ b/lib/tailwind.ts
@@ -5,10 +5,20 @@ import { dirname, extname, join, resolve } from "node:path";
 
 const TAILWIND_CSS_PATH = resolve(process.cwd(), "node_modules/tailwindcss/index.css");
 const compiledCssCache = new Map<string, Promise<string>>();
-const candidateExtensions = new Set([".ts", ".tsx", ".js", ".jsx", ".html"]);
+const candidateExtensions = new Set([".ts", ".tsx", ".js", ".jsx", ".html", ".css"]);
 const excludedDirectories = new Set(["node_modules", ".git", "dist", "build"]);
 
-function extractCandidatesFromContent(content: string): Set<string> {
+function tokenizeCandidates(source: string): Set<string> {
+  const candidates = new Set<string>();
+  const tokenRegex = /[A-Za-z][A-Za-z0-9_\-:\/\[\]]{0,99}/g;
+  for (const token of source.match(tokenRegex) ?? []) {
+    if (token.includes("class=") || token.includes("className=")) continue;
+    candidates.add(token);
+  }
+  return candidates;
+}
+
+function extractCandidatesFromContent(content: string, extension: string): Set<string> {
   const candidates = new Set<string>();
   const classAttributeRegex = /(?:class|className)\s*=\s*(?:\{\s*)?(?:`([^`]+)`|(['"])(.*?)\2)\s*(?:\})?/gs;
   for (const match of content.matchAll(classAttributeRegex)) {
@@ -17,6 +27,20 @@ function extractCandidatesFromContent(content: string): Set<string> {
       if (candidate) candidates.add(candidate);
     }
   }
+
+  if (extension === ".css") {
+    const applyRegex = /@apply\s+([^;]+);/g;
+    for (const match of content.matchAll(applyRegex)) {
+      for (const candidate of match[1].trim().split(/\s+/)) {
+        if (candidate) candidates.add(candidate);
+      }
+    }
+  }
+
+  for (const token of tokenizeCandidates(content)) {
+    candidates.add(token);
+  }
+
   return candidates;
 }
 
@@ -28,9 +52,10 @@ function walkFiles(directory: string, candidates: Set<string>) {
       walkFiles(fullPath, candidates);
       continue;
     }
-    if (!candidateExtensions.has(extname(entry.name))) continue;
+    const extension = extname(entry.name);
+    if (!candidateExtensions.has(extension)) continue;
     const content = readFileSync(fullPath, "utf-8");
-    for (const candidate of extractCandidatesFromContent(content)) {
+    for (const candidate of extractCandidatesFromContent(content, extension)) {
       candidates.add(candidate);
     }
   }

--- a/lib/tailwind.ts
+++ b/lib/tailwind.ts
@@ -31,7 +31,8 @@ function extractCandidatesFromContent(content: string, extension: string): Set<s
   if (extension === ".css") {
     const applyRegex = /@apply\s+([^;]+);/g;
     for (const match of content.matchAll(applyRegex)) {
-      for (const candidate of match[1].trim().split(/\s+/)) {
+      const raw = match[1] ?? "";
+      for (const candidate of raw.trim().split(/\s+/)) {
         if (candidate) candidates.add(candidate);
       }
     }

--- a/lib/tailwind.ts
+++ b/lib/tailwind.ts
@@ -52,6 +52,7 @@ function walkFiles(directory: string, candidates: Set<string>) {
       walkFiles(fullPath, candidates);
       continue;
     }
+
     const extension = extname(entry.name);
     if (!candidateExtensions.has(extension)) continue;
     const content = readFileSync(fullPath, "utf-8");


### PR DESCRIPTION
This PR rebases `fix/css` onto the latest `main` and restores Tailwind CSS compilation for both the main app and admin console. It strengthens candidate extraction for @apply usage, adds HTTP caching/ETag support, and includes regression coverage for compiled CSS output.