### PR TITLE
refactor/whole

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -37,8 +37,14 @@
 
 - [x] [MUST] Fix OBS browser syntax error — Tightened navigation detection in `src/catchAll.ts` to avoid serving `index.html` for module/file requests (fixes syntax error in old OBS browser).
 
-- [x] [MUST] Fix console SSE reconnect handling — Allow EventSource to auto-reconnect and avoid forcing immediate closure on transient SSE errors.- [x] [MUST] Bypass management console IP restriction in development mode — Allow `bun run dev` to access the management console without the production-only IP allowlist.- [x] [SHOULD] Add regression test for SSE EventSource error handling — Verify console status error only appears when the stream is fully closed.
+- [x] [MUST] Fix console SSE reconnect handling — Allow EventSource to auto-reconnect and avoid forcing immediate closure on transient SSE errors.
+- [x] [MUST] Bypass management console IP restriction in development mode — Allow `bun run dev` to access the management console without the production-only IP allowlist.
+- [x] [SHOULD] Add regression test for SSE EventSource error handling — Verify console status error only appears when the stream is fully closed.
 - [x] [MUST] Refactor AgentStatus component — Reorganize `console/src/AgentStatus/index.tsx` and split AgentStatus logic into reusable submodules.
+- [x] [MUST] Audit core server state and extract streaming helpers — Make `index.ts` easier to inspect and test by moving payload normalization into reusable modules.
+- [x] [MUST] Add unit tests for stream payload normalization — Test `normalizePublishedStreamState`, `normalizeSpeechText`, and current payload shaping.
+- [x] [MUST] Add unit tests for console proxy header and redirect utilities — Cover `createLoopbackProxyHeaders` and `createAccessDeniedRedirectResponse`.
+- [x] [MUST] Refactor root server event handling and remove duplicate handlers — Improve startup and error handling clarity in `index.ts`.
 
 - [x] [MUST] Issue #225: 管理コンソール - これまでの発話の改善 — 読了、テスト追加、実装（単語ごとにカード表示、非マルコフ文言の除去）を行いました。
 - [ ] [MUST] Commit changes and open PR for branch `225-管理コンソール-これまでの発話の改善` — Pending: create PR with description and attach screenshots if needed.

--- a/TODO.md
+++ b/TODO.md
@@ -10,45 +10,10 @@
 ## 現在のチェックリスト
 以下のタスクはリポジトリ内での作業チェックリストです。完了済みはチェック済みになっています。
 
-- [x] [MUST] Fetch issue #202 and summarize — Retrieved issue content and inspected the issue.
-- [x] [MUST] Analyze repository for affected code — Inspected `lib/Agent/index.ts` and `lib/TTS` implementations.
-- [x] [SHOULD] Propose or implement fix — Implemented a small fix to reset the prompt flag on TTS failure; further verification recommended.
-
-- [x] [MUST] Add unit test for TTS failure reset — Added/updated tests to verify queued prompt behavior and TTS failure handling.
-
-- [x] [MUST] Install Bun in container — Installed Bun to `~/.bun` and added to PATH for this session.
-- [x] [MUST] Run `bun ci` to install dependencies — Completed (no dependency changes).
-- [x] [MUST] Run typecheck and unit tests — Completed; all tests passing.
-
-- [x] [MUST] Create DevContainer files (`.devcontainer/Dockerfile` and `.devcontainer/devcontainer.json`) — Added Debian 12 base image, installed Bun, configured features for Git and GitHub CLI, and set workspace mount.
-- [x] [MUST] Copy `package.json` and `bun.lock*` into image for build caching — `Dockerfile` copies `package.json` and `bun.lock*`.
-- [x] [MUST] Run `bun ci` after container creation — `devcontainer.json` has `postCreateCommand` set to `bun ci`.
-- [x] [MUST] Mount local repository root into container workspace folder — `devcontainer.json` sets `workspaceMount` to bind the local repo into `/workspace`.
-
-<!-- 対応すべきタスクは以上です。 -->
-
-## Current Work (added by automated agent)
-
-- [x] [MUST] Analyze failing e2e console WS proxy test — Located failing E2E test and inspected proxy code.
-- [x] [MUST] Reproduce failing test and collect logs — Reproduced integration behavior locally and collected logs.
-- [x] [MUST] Implement fix in console WS proxy bridging — Added HTTP /api/meta fallback on upstream WS error in routes/console/index.ts.
 - [ ] [MUST] Run E2E Playwright test to verify fix — Pending; Playwright browser run not executed in this session.
 - [ ] [MUST] Update PR with patch and summary — Pending: prepare PR comment with explanation.
-
-- [x] [MUST] Fix OBS browser syntax error — Tightened navigation detection in `src/catchAll.ts` to avoid serving `index.html` for module/file requests (fixes syntax error in old OBS browser).
-
-- [x] [MUST] Fix console SSE reconnect handling — Allow EventSource to auto-reconnect and avoid forcing immediate closure on transient SSE errors.
-- [x] [MUST] Bypass management console IP restriction in development mode — Allow `bun run dev` to access the management console without the production-only IP allowlist.
-- [x] [SHOULD] Add regression test for SSE EventSource error handling — Verify console status error only appears when the stream is fully closed.
-- [x] [MUST] Refactor AgentStatus component — Reorganize `console/src/AgentStatus/index.tsx` and split AgentStatus logic into reusable submodules.
-- [x] [MUST] Audit core server state and extract streaming helpers — Make `index.ts` easier to inspect and test by moving payload normalization into reusable modules.
-- [x] [MUST] Add unit tests for stream payload normalization — Test `normalizePublishedStreamState`, `normalizeSpeechText`, and current payload shaping.
-- [x] [MUST] Add unit tests for console proxy header and redirect utilities — Cover `createLoopbackProxyHeaders` and `createAccessDeniedRedirectResponse`.
-- [x] [MUST] Refactor root server event handling and remove duplicate handlers — Improve startup and error handling clarity in `index.ts`.
-
-- [x] [MUST] Issue #225: 管理コンソール - これまでの発話の改善 — 読了、テスト追加、実装（単語ごとにカード表示、非マルコフ文言の除去）を行いました。
 - [ ] [MUST] Commit changes and open PR for branch `225-管理コンソール-これまでの発話の改善` — Pending: create PR with description and attach screenshots if needed.
- - [ ] [SHOULD] Propose AGT library enhancement — create an issue requesting generation trace (node path) or API to return nodes visited during generation.
+- [ ] [SHOULD] Propose AGT library enhancement — create an issue requesting generation trace (node path) or API to return nodes visited during generation.
 
 ## 注意
 このファイルを編集したら、対応する全てのタスクを `manage_todo_list` ツールに送ってください。

--- a/console/src/AgentStatus/agentStatusUtils.tsx
+++ b/console/src/AgentStatus/agentStatusUtils.tsx
@@ -1,4 +1,6 @@
 /** @jsxImportSource hono/jsx */
+import { normalizeSpeechText } from "../../../src/lib/streamState";
+export { normalizeSpeechText };
 import type { AgentStateResponse } from "./types";
 import type { Child, CSSProperties } from "hono/jsx";
 
@@ -57,33 +59,6 @@ export const formatNGramValue = (nGram: number | undefined, nGramRaw: number | u
   }
   const formattedRaw = Number(nGramRaw).toFixed(2);
   return `${nGramValue} (${formattedRaw})`;
-};
-
-type SpeechPayload =
-  | string
-  | { text?: string; nodes?: readonly string[] }
-  | ({ speech?: string | { text?: string; nodes?: readonly string[] } | { speech?: string; text?: string; nodes?: readonly string[] }; silent?: boolean })
-  | undefined;
-
-export const normalizeSpeechText = (speech: SpeechPayload): string | undefined => {
-  if (typeof speech === "string") {
-    return speech.trim() || undefined;
-  }
-
-  if (speech && typeof speech === "object") {
-    const textValue = typeof (speech as any).text === "string"
-      ? (speech as any).text
-      : typeof (speech as any).speech === "string"
-        ? (speech as any).speech
-        : typeof (speech as any).speech === "object"
-          ? typeof (speech as any).speech.text === "string"
-            ? (speech as any).speech.text
-            : undefined
-          : undefined;
-    return typeof textValue === "string" ? textValue.trim() || undefined : undefined;
-  }
-
-  return undefined;
 };
 
 const createHighlightedCommentLines = (commentText: string, pickedTopic: string) => {

--- a/console/src/consoleIndex.test.ts
+++ b/console/src/consoleIndex.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'bun:test';
+import { createAccessDeniedRedirectResponse, createLoopbackProxyHeaders, isConsoleIPRestrictionEnabled } from '../../console/index.ts';
+
+describe('createAccessDeniedRedirectResponse', () => {
+  it('redirects /console/ requests to the external console redirect URL', () => {
+    const url = new URL('https://example.com/console/hello');
+    const response = createAccessDeniedRedirectResponse(url);
+    expect(response.status).toBe(303);
+    expect(response.headers.get('location')).toBe('https://live.nicovideo.jp/watch/user/14171889');
+  });
+
+  it('redirects non-console requests to /console/ with status 308', () => {
+    const url = new URL('https://example.com/foo/bar');
+    const response = createAccessDeniedRedirectResponse(url);
+    expect(response.status).toBe(308);
+    expect(response.headers.get('location')).toBe('/console/');
+  });
+});
+
+describe('createLoopbackProxyHeaders', () => {
+  it('removes hop-by-hop and origin-specific headers', () => {
+    const original = new Headers({
+      connection: 'keep-alive, Upgrade',
+      host: 'evil.example.com',
+      origin: 'https://evil.example.com',
+      referer: 'https://evil.example.com',
+      'proxy-authorization': 'secret',
+      'keep-alive': 'timeout=5',
+      'upgrade': 'websocket',
+      'sec-websocket-protocol': 'foo',
+      'content-type': 'application/json',
+    });
+
+    const headers = createLoopbackProxyHeaders(original);
+    expect(headers.get('connection')).toBeNull();
+    expect(headers.get('host')).toBeNull();
+    expect(headers.get('origin')).toBeNull();
+    expect(headers.get('referer')).toBeNull();
+    expect(headers.get('proxy-authorization')).toBeNull();
+    expect(headers.get('keep-alive')).toBeNull();
+    expect(headers.get('upgrade')).toBeNull();
+    expect(headers.get('sec-websocket-protocol')).toBe('foo');
+    expect(headers.get('content-type')).toBe('application/json');
+  });
+});
+
+describe('isConsoleIPRestrictionEnabled', () => {
+  it('returns true only in production', () => {
+    const original = process.env.NODE_ENV;
+    try {
+      process.env.NODE_ENV = 'production';
+      expect(isConsoleIPRestrictionEnabled()).toBe(true);
+      process.env.NODE_ENV = 'development';
+      expect(isConsoleIPRestrictionEnabled()).toBe(false);
+      delete process.env.NODE_ENV;
+      expect(isConsoleIPRestrictionEnabled()).toBe(false);
+    } finally {
+      if (original === undefined) {
+        delete process.env.NODE_ENV;
+      } else {
+        process.env.NODE_ENV = original;
+      }
+    }
+  });
+});

--- a/index.ts
+++ b/index.ts
@@ -14,6 +14,7 @@ import { resolve } from "node:path";
 import { parseArgs } from "node:util";
 import { startConsoleServer } from "./console/index";
 import { FallbackTTS, MakaMujo, MarkovChainModel, TTS } from "./lib/server";
+import { normalizePublishedStreamState, normalizeSpeechText } from "./src/lib/streamState";
 import * as index from "./routes/index";
 import * as speechHistoryRoute from "./routes/api/speech-history";
 import type { SpeechHistoryEntry } from "./routes/api/speech-history";
@@ -24,25 +25,12 @@ process.on('exit', exitHandler.bind(null, { cleanup: true }));
 process.on('SIGINT', signalHandler.bind(null, { exit: true }));
 process.on('SIGUSR1', signalHandler.bind(null, { exit: true }));
 process.on('SIGUSR2', signalHandler.bind(null, { exit: true }));
-// Log uncaught exceptions for better diagnostics before invoking the
-// existing exit handler which terminates the process.
 process.on('uncaughtException', (err) => {
   try {
     console.error('[UNCAUGHT_EXCEPTION]', err instanceof Error ? err.stack ?? err.message : String(err));
   } catch {
     // ignore logging failures
   }
-});
-process.on('unhandledRejection', (reason) => {
-  try {
-    console.error('[UNHANDLED_REJECTION]', reason instanceof Error ? reason.stack ?? reason.message : String(reason));
-  } catch { }
-});
-process.on('uncaughtException', (err) => {
-  try {
-    // Log the exception for diagnostics
-    console.error('[UNCAUGHT_EXCEPTION]', err instanceof Error ? err.stack ?? err.message : String(err));
-  } catch { }
 
   // Do not terminate the process for transient IPC listen failures
   // (e.g., EADDRINUSE on Windows named pipes) so tests can recover.
@@ -52,8 +40,12 @@ process.on('uncaughtException', (err) => {
     return;
   }
 
-  // For other uncaught exceptions, perform the existing exit behavior.
   exitHandler({ exit: true }, 1);
+});
+process.on('unhandledRejection', (reason) => {
+  try {
+    console.error('[UNHANDLED_REJECTION]', reason instanceof Error ? reason.stack ?? reason.message : String(reason));
+  } catch { }
 });
 
 const { values: {
@@ -179,52 +171,6 @@ const broadcastCurrentPayload = (context: string) => {
   }
 };
 
-const normalizePublishedStreamState = (state: unknown): unknown => {
-  if (!state || typeof state !== 'object') {
-    return state;
-  }
-
-  const rawState = state as Record<string, unknown>;
-
-  if (rawState.type === 'niconama') {
-    const data = rawState.data as Record<string, unknown> | undefined;
-    const total: Record<string, unknown> = {};
-    if (typeof data?.total === 'number') {
-      total.listeners = data.total;
-    }
-    if (data?.points && typeof (data.points as Record<string, unknown>).gift !== 'undefined') {
-      total.gift = (data.points as Record<string, unknown>).gift;
-    }
-    if (data?.points && typeof (data.points as Record<string, unknown>).ad !== 'undefined') {
-      total.ad = (data.points as Record<string, unknown>).ad;
-    }
-
-    return {
-      niconama: {
-        type: data?.isLive ? 'live' : 'offline',
-        meta: {
-          title: data?.title ?? undefined,
-          url: data?.url ?? undefined,
-          start: data?.startTime ?? undefined,
-          total: Object.keys(total).length > 0 ? total : undefined,
-        },
-      },
-    };
-  }
-
-  if ('niconama' in rawState && rawState.niconama && typeof rawState.niconama === 'object') {
-    return rawState;
-  }
-
-  if (rawState.type === 'live' || rawState.type === 'offline') {
-    return {
-      niconama: rawState,
-    };
-  }
-
-  return rawState;
-};
-
 const getCurrentStreamPayload = () => {
   const agentStreamState = agent.getStreamState?.();
   const streamState = (lastPublishedStreamState === undefined || lastPublishedStreamState === null)
@@ -247,26 +193,6 @@ const getCurrentStreamPayload = () => {
     replyTargetComment,
     commentCount: base.commentCount ?? streamer.streamState?.meta?.total?.comments,
   } as const;
-};
-
-const normalizeSpeechText = (speech: unknown): string | undefined => {
-  if (typeof speech === 'string') {
-    return speech;
-  }
-
-  if (!speech || typeof speech !== 'object') {
-    return undefined;
-  }
-
-  if (typeof (speech as any).text === 'string') {
-    return (speech as any).text;
-  }
-
-  if (typeof (speech as any).speech === 'string') {
-    return (speech as any).speech;
-  }
-
-  return undefined;
 };
 
 let agent: any = {

--- a/lib/streamState.test.ts
+++ b/lib/streamState.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'bun:test';
+import { normalizePublishedStreamState, normalizeSpeechText } from '../src/lib/streamState';
+
+describe('normalizePublishedStreamState', () => {
+  it('normalizes legacy niconama payload to niconama meta format', () => {
+    const result = normalizePublishedStreamState({
+      type: 'niconama',
+      data: {
+        isLive: true,
+        title: 'test stream',
+        url: 'https://example.com',
+        startTime: '2025-05-06T00:00:00Z',
+        total: 123,
+        points: { gift: 10, ad: 2 },
+      },
+    });
+
+    expect(result).toEqual({
+      niconama: {
+        type: 'live',
+        meta: {
+          title: 'test stream',
+          url: 'https://example.com',
+          start: '2025-05-06T00:00:00Z',
+          total: { listeners: 123, gift: 10, ad: 2 },
+        },
+      },
+    });
+  });
+
+  it('returns unchanged object when niconama is already normalized', () => {
+    const input = { niconama: { type: 'offline' } };
+    expect(normalizePublishedStreamState(input)).toBe(input);
+  });
+
+  it('wraps legacy live/offline state in niconama', () => {
+    expect(normalizePublishedStreamState({ type: 'live', foo: 'bar' })).toEqual({
+      niconama: { type: 'live', foo: 'bar' },
+    });
+
+    expect(normalizePublishedStreamState({ type: 'offline' })).toEqual({
+      niconama: { type: 'offline' },
+    });
+  });
+
+  it('returns non-object values untouched', () => {
+    expect(normalizePublishedStreamState(null)).toBeNull();
+    expect(normalizePublishedStreamState('test')).toBe('test');
+    expect(normalizePublishedStreamState(42)).toBe(42);
+  });
+});
+
+describe('normalizeSpeechText', () => {
+  it('returns plain strings as-is', () => {
+    expect(normalizeSpeechText('hello')).toBe('hello');
+  });
+
+  it('returns text field when present', () => {
+    expect(normalizeSpeechText({ text: 'こんにちは' })).toBe('こんにちは');
+  });
+
+  it('returns speech field when present', () => {
+    expect(normalizeSpeechText({ speech: 'hello' })).toBe('hello');
+  });
+
+  it('returns nested speech.text values', () => {
+    expect(normalizeSpeechText({ speech: { text: ' nested ' } })).toBe('nested');
+  });
+
+  it('prefers text over speech when both exist', () => {
+    expect(normalizeSpeechText({ text: 'text', speech: 'speech' })).toBe('text');
+  });
+
+  it('returns undefined for unsupported values', () => {
+    expect(normalizeSpeechText(undefined)).toBeUndefined();
+    expect(normalizeSpeechText({})).toBeUndefined();
+    expect(normalizeSpeechText({ text: 1 })).toBeUndefined();
+  });
+});

--- a/src/catchAll.test.ts
+++ b/src/catchAll.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "bun:test";
 
-import { handleCatchAll } from "./catchAll";
+import { handleCatchAll, getContentType, normalizeMainHtml } from "./frontendServer";
 
 test("serves frontend.js as built JavaScript module", async () => {
   const req = new Request("http://localhost/frontend.js", { headers: { accept: '*/*' } });
@@ -21,4 +21,25 @@ test("serves index.html for navigation requests", async () => {
   expect(ct).toMatch(/text\/html/);
   const body = await res.text();
   expect(body).toContain('<div id="root"></div>');
+});
+
+test('getContentType returns the correct content type for known assets', () => {
+  expect(getContentType('/frontend.js')).toBe('application/javascript; charset=utf-8');
+  expect(getContentType('/frontend.css')).toBe('text/css; charset=utf-8');
+  expect(getContentType('/index.html')).toBe('text/html; charset=utf-8');
+  expect(getContentType('/image.png')).toBeUndefined();
+});
+
+test('normalizeMainHtml rewrites the entrypoint and injects frontend.css when missing', () => {
+  const input = '<html><head><script src="./frontend.tsx"></script></head><body></body></html>';
+  const output = normalizeMainHtml(input);
+  expect(output).toContain('src="./frontend.js"');
+  expect(output).toContain('<link rel="stylesheet" href="./frontend.css" />');
+});
+
+test('normalizeMainHtml preserves an existing frontend.css link', () => {
+  const input = '<html><head><script src="./frontend.tsx"></script><link rel="stylesheet" href="./frontend.css" /></head><body></body></html>';
+  const output = normalizeMainHtml(input);
+  expect(output).toContain('src="./frontend.js"');
+  expect(output.match(/<link rel="stylesheet" href="\.\/frontend\.css" \/>/g)?.length).toBe(1);
 });

--- a/src/catchAll.ts
+++ b/src/catchAll.ts
@@ -1,3 +1,0 @@
-// Legacy compatibility shim: preserved on disk only.
-// New code should import handleCatchAll directly from ./frontendServer.
-export { handleCatchAll } from "./frontendServer";

--- a/src/catchAll.ts
+++ b/src/catchAll.ts
@@ -1,1 +1,3 @@
+// Legacy compatibility shim: preserved on disk only.
+// New code should import handleCatchAll directly from ./frontendServer.
 export { handleCatchAll } from "./frontendServer";

--- a/src/contexts/speechState.ts
+++ b/src/contexts/speechState.ts
@@ -1,3 +1,5 @@
+import { normalizeSpeechText } from "../lib/streamState";
+
 /**
  * Update `speech` and `silent` state from a `/api/speech` response.
  * `speech` is only replaced when the response contains a non-empty string, so
@@ -7,26 +9,6 @@ type SpeechPayload =
   | string
   | { text?: string; nodes?: readonly string[] }
   | { speech?: string; text?: string; nodes?: readonly string[] };
-
-const normalizeSpeechText = (speech: SpeechPayload | undefined): string | undefined => {
-  if (typeof speech === 'string') {
-    return speech;
-  }
-
-  if (!speech || typeof speech !== 'object') {
-    return undefined;
-  }
-
-  if ('text' in speech && typeof speech.text === 'string') {
-    return speech.text;
-  }
-
-  if ('speech' in speech && typeof speech.speech === 'string') {
-    return speech.speech;
-  }
-
-  return undefined;
-};
 
 export function updateSpeechState(
   res: { speech?: SpeechPayload; silent?: boolean },

--- a/src/frontendServer.test.ts
+++ b/src/frontendServer.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'bun:test';
+import { getMainFrontendAssetPath } from './frontendServer';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+describe('getMainFrontendAssetPath', () => {
+  it('resolves existing build assets within the build directory', () => {
+    const tempBuildPath = mkdtempSync(join(tmpdir(), 'frontend-server-test-'));
+    const assetPath = join(tempBuildPath, 'frontend.js');
+    writeFileSync(assetPath, 'console.log("ok");');
+
+    try {
+      expect(getMainFrontendAssetPath('/frontend.js', tempBuildPath)).toBe(assetPath);
+    } finally {
+      rmSync(tempBuildPath, { recursive: true, force: true });
+    }
+  });
+
+  it('returns null for paths outside the build directory', () => {
+    const tempBuildPath = mkdtempSync(join(tmpdir(), 'frontend-server-test-'));
+    try {
+      expect(getMainFrontendAssetPath('/../frontend.js', tempBuildPath)).toBeNull();
+      expect(getMainFrontendAssetPath('/safe/../../etc/passwd', tempBuildPath)).toBeNull();
+    } finally {
+      rmSync(tempBuildPath, { recursive: true, force: true });
+    }
+  });
+
+  it('returns null for directory-style requests and non-existent files', () => {
+    const tempBuildPath = mkdtempSync(join(tmpdir(), 'frontend-server-test-'));
+    try {
+      expect(getMainFrontendAssetPath('/assets/', tempBuildPath)).toBeNull();
+      expect(getMainFrontendAssetPath('/missing.js', tempBuildPath)).toBeNull();
+    } finally {
+      rmSync(tempBuildPath, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/frontendServer.ts
+++ b/src/frontendServer.ts
@@ -7,14 +7,14 @@ const MAIN_SOURCE_HTML_PATH = resolve(process.cwd(), 'src/index.html');
 let mainBuildPromise: Promise<void> | null = null;
 let builtMainHtml: string | null = null;
 
-function getContentType(filePath: string): string | undefined {
+export function getContentType(filePath: string): string | undefined {
   if (filePath.endsWith('.js')) return 'application/javascript; charset=utf-8';
   if (filePath.endsWith('.css')) return 'text/css; charset=utf-8';
   if (filePath.endsWith('.html')) return 'text/html; charset=utf-8';
   return undefined;
 }
 
-function normalizeMainHtml(source: string): string {
+export function normalizeMainHtml(source: string): string {
   const rewrittenHtml = source.replace(/src=(['"])\.\/frontend\.tsx\1/, 'src=$1./frontend.js$1');
   if (rewrittenHtml.match(/<link[^>]+href=(['"])\.\/frontend\.css\1/)) {
     return rewrittenHtml;

--- a/src/frontendServer.ts
+++ b/src/frontendServer.ts
@@ -59,16 +59,16 @@ function ensureMainFrontendBuilt(): Promise<void> {
   return mainBuildPromise;
 }
 
-function getMainFrontendAssetPath(pathname: string): string | null {
+export function getMainFrontendAssetPath(pathname: string, buildPath: string = MAIN_BUILD_PATH): string | null {
   if (!pathname.includes('.') || pathname.endsWith('/')) return null;
 
-  const resolved = resolve(MAIN_BUILD_PATH, pathname.slice(1));
-  const normalizedBuildPath = resolve(MAIN_BUILD_PATH);
-  const normalizedResolved = resolve(resolved);
-  const relativePath = relative(normalizedBuildPath, normalizedResolved);
+  const resolvedCandidate = resolve(buildPath, pathname.slice(1));
+  const normalizedBuildPath = resolve(buildPath);
+  const normalizedResolvedCandidate = resolve(resolvedCandidate);
+  const relativePath = relative(normalizedBuildPath, normalizedResolvedCandidate);
   if (relativePath.startsWith('..')) return null;
-  if (!existsSync(normalizedResolved)) return null;
-  return normalizedResolved;
+  if (!existsSync(normalizedResolvedCandidate)) return null;
+  return normalizedResolvedCandidate;
 }
 
 export async function handleCatchAll(req: Request): Promise<Response> {

--- a/src/lib/streamState.ts
+++ b/src/lib/streamState.ts
@@ -1,0 +1,79 @@
+const normalizeSpeechString = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed === '' ? undefined : trimmed;
+};
+
+export const normalizePublishedStreamState = (rawState: unknown): unknown => {
+  if (!rawState || typeof rawState !== 'object') {
+    return rawState;
+  }
+
+  const state = rawState as Record<string, unknown>;
+
+  if (state.type === 'niconama') {
+    const data = state.data as Record<string, unknown> | undefined;
+    const total: Record<string, unknown> = {};
+    if (typeof data?.total === 'number') {
+      total.listeners = data.total;
+    }
+    if (data?.points && typeof (data.points as Record<string, unknown>).gift !== 'undefined') {
+      total.gift = (data.points as Record<string, unknown>).gift;
+    }
+    if (data?.points && typeof (data.points as Record<string, unknown>).ad !== 'undefined') {
+      total.ad = (data.points as Record<string, unknown>).ad;
+    }
+    return {
+      niconama: {
+        type: data?.isLive ? 'live' : 'offline',
+        meta: {
+          title: data?.title ?? undefined,
+          url: data?.url ?? undefined,
+          start: data?.startTime ?? undefined,
+          total: Object.keys(total).length > 0 ? total : undefined,
+        },
+      },
+    };
+  }
+
+  if ('niconama' in state && state.niconama && typeof state.niconama === 'object') {
+    return state;
+  }
+
+  if (state.type === 'live' || state.type === 'offline') {
+    return {
+      niconama: state,
+    };
+  }
+
+  return state;
+};
+
+export const normalizeSpeechText = (speech: unknown): string | undefined => {
+  if (typeof speech === 'string') {
+    return normalizeSpeechString(speech);
+  }
+
+  if (!speech || typeof speech !== 'object') {
+    return undefined;
+  }
+
+  const record = speech as Record<string, unknown>;
+  const textValue = normalizeSpeechString(record.text);
+  if (textValue !== undefined) {
+    return textValue;
+  }
+
+  const speechValue = record.speech;
+  if (typeof speechValue === 'string') {
+    return normalizeSpeechString(speechValue);
+  }
+
+  if (speechValue && typeof speechValue === 'object') {
+    return normalizeSpeechText(speechValue);
+  }
+
+  return undefined;
+};


### PR DESCRIPTION
- **refactor: remove old streamState helper and centralize stream state normalization**
- **chore: clean up completed TODO tasks**
- **refactor(frontend): expose frontendServer helpers and migrate catchAll tests to new entrypoint**
- **refactor(frontend): remove unused legacy catchAll shim and add frontend asset path tests**
- **test(frontend): add asset path coverage and refactor frontend asset resolver**
