### PR TITLE
fix(reply-target-comment): preserve replyTargetComment through legacy stream state normalization

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -19,6 +19,7 @@ import * as speechHistoryRoute from "./routes/api/speech-history";
 import type { SpeechHistoryEntry } from "./routes/api/speech-history";
 import { handleCatchAll } from "./src/frontendServer";
 import { compileTailwindCss, createCssResponse } from "./lib/tailwind";
+import { normalizePublishedStreamState } from "./lib/streamState";
 
 process.on('exit', exitHandler.bind(null, { cleanup: true }));
 process.on('SIGINT', signalHandler.bind(null, { exit: true }));
@@ -179,51 +180,6 @@ const broadcastCurrentPayload = (context: string) => {
   }
 };
 
-const normalizePublishedStreamState = (state: unknown): unknown => {
-  if (!state || typeof state !== 'object') {
-    return state;
-  }
-
-  const rawState = state as Record<string, unknown>;
-
-  if (rawState.type === 'niconama') {
-    const data = rawState.data as Record<string, unknown> | undefined;
-    const total: Record<string, unknown> = {};
-    if (typeof data?.total === 'number') {
-      total.listeners = data.total;
-    }
-    if (data?.points && typeof (data.points as Record<string, unknown>).gift !== 'undefined') {
-      total.gift = (data.points as Record<string, unknown>).gift;
-    }
-    if (data?.points && typeof (data.points as Record<string, unknown>).ad !== 'undefined') {
-      total.ad = (data.points as Record<string, unknown>).ad;
-    }
-
-    return {
-      niconama: {
-        type: data?.isLive ? 'live' : 'offline',
-        meta: {
-          title: data?.title ?? undefined,
-          url: data?.url ?? undefined,
-          start: data?.startTime ?? undefined,
-          total: Object.keys(total).length > 0 ? total : undefined,
-        },
-      },
-    };
-  }
-
-  if ('niconama' in rawState && rawState.niconama && typeof rawState.niconama === 'object') {
-    return rawState;
-  }
-
-  if (rawState.type === 'live' || rawState.type === 'offline') {
-    return {
-      niconama: rawState,
-    };
-  }
-
-  return rawState;
-};
 
 const getCurrentStreamPayload = () => {
   const agentStreamState = agent.getStreamState?.();

--- a/lib/streamState.test.ts
+++ b/lib/streamState.test.ts
@@ -50,4 +50,29 @@ describe("normalizePublishedStreamState", () => {
     expect((normalized.niconama as Record<string, unknown>).type).toBe("live");
     expect((normalized.niconama as Record<string, unknown>).title).toBe("live state");
   });
+
+  it("preserves additional top-level fields for legacy payloads", () => {
+    const legacyState = {
+      type: "niconama",
+      data: {
+        isLive: false,
+        title: "legacy",
+        startTime: 0,
+        total: 1,
+        points: { gift: 0, ad: 0 },
+        url: "https://example.com",
+      },
+      replyTargetComment: {
+        text: "返信対象コメントです",
+        pickedTopic: "返信",
+      },
+      commentCount: 7,
+    };
+
+    const normalized = normalizePublishedStreamState(legacyState) as Record<string, unknown>;
+
+    expect(normalized.replyTargetComment).toEqual(legacyState.replyTargetComment);
+    expect(normalized.commentCount).toBe(7);
+    expect(normalized).toHaveProperty("niconama");
+  });
 });

--- a/lib/streamState.test.ts
+++ b/lib/streamState.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "bun:test";
+import { normalizePublishedStreamState } from "./streamState";
+
+describe("normalizePublishedStreamState", () => {
+  it("preserves replyTargetComment for legacy niconama payloads", () => {
+    const legacyState = {
+      type: "niconama",
+      data: {
+        title: "legacy",
+        isLive: true,
+        startTime: 1234567890,
+        total: 42,
+        points: { gift: 5, ad: 1 },
+        url: "https://example.com",
+      },
+      replyTargetComment: {
+        text: "返信対象コメントです",
+        pickedTopic: "返信",
+      },
+    };
+
+    const normalized = normalizePublishedStreamState(legacyState) as Record<string, unknown>;
+
+    expect(normalized.replyTargetComment).toEqual(legacyState.replyTargetComment);
+    expect(normalized).toHaveProperty("niconama");
+    expect((normalized.niconama as Record<string, unknown>).type).toBe("live");
+    expect((normalized.niconama as Record<string, unknown>).meta).toEqual({
+      title: "legacy",
+      url: "https://example.com",
+      start: 1234567890,
+      total: { listeners: 42, gift: 5, ad: 1 },
+    });
+  });
+
+  it("preserves replyTargetComment for raw live payloads", () => {
+    const legacyState = {
+      type: "live",
+      title: "live state",
+      total: 7,
+      replyTargetComment: {
+        text: "返信対象コメントです",
+        pickedTopic: "返信",
+      },
+    };
+
+    const normalized = normalizePublishedStreamState(legacyState) as Record<string, unknown>;
+
+    expect(normalized.replyTargetComment).toEqual(legacyState.replyTargetComment);
+    expect(normalized).toHaveProperty("niconama");
+    expect((normalized.niconama as Record<string, unknown>).type).toBe("live");
+    expect((normalized.niconama as Record<string, unknown>).title).toBe("live state");
+  });
+});

--- a/lib/streamState.ts
+++ b/lib/streamState.ts
@@ -1,0 +1,48 @@
+export const normalizePublishedStreamState = (state: unknown): unknown => {
+  if (!state || typeof state !== 'object') {
+    return state;
+  }
+
+  const rawState = state as Record<string, unknown>;
+
+  if (rawState.type === 'niconama') {
+    const data = rawState.data as Record<string, unknown> | undefined;
+    const total: Record<string, unknown> = {};
+    if (typeof data?.total === 'number') {
+      total.listeners = data.total;
+    }
+    if (data?.points && typeof (data.points as Record<string, unknown>).gift !== 'undefined') {
+      total.gift = (data.points as Record<string, unknown>).gift;
+    }
+    if (data?.points && typeof (data.points as Record<string, unknown>).ad !== 'undefined') {
+      total.ad = (data.points as Record<string, unknown>).ad;
+    }
+
+    const normalizedState: Record<string, unknown> = { ...rawState };
+    delete normalizedState.type;
+    delete normalizedState.data;
+    normalizedState.niconama = {
+      type: data?.isLive ? 'live' : 'offline',
+      meta: {
+        title: data?.title ?? undefined,
+        url: data?.url ?? undefined,
+        start: data?.startTime ?? undefined,
+        total: Object.keys(total).length > 0 ? total : undefined,
+      },
+    };
+    return normalizedState;
+  }
+
+  if ('niconama' in rawState && rawState.niconama && typeof rawState.niconama === 'object') {
+    return rawState;
+  }
+
+  if (rawState.type === 'live' || rawState.type === 'offline') {
+    const normalizedState: Record<string, unknown> = { ...rawState };
+    delete normalizedState.type;
+    normalizedState.niconama = rawState;
+    return normalizedState;
+  }
+
+  return rawState;
+};

--- a/lib/streamState.ts
+++ b/lib/streamState.ts
@@ -5,6 +5,9 @@ export const normalizePublishedStreamState = (state: unknown): unknown => {
 
   const rawState = state as Record<string, unknown>;
 
+  // Preserve any top-level custom fields while normalizing legacy payloads.
+  // This is important for values like replyTargetComment, commentCount, and
+  // speechHistory that are not part of the legacy `type/data` structure.
   if (rawState.type === 'niconama') {
     const data = rawState.data as Record<string, unknown> | undefined;
     const total: Record<string, unknown> = {};

--- a/tests/e2e/server.test.ts
+++ b/tests/e2e/server.test.ts
@@ -155,6 +155,36 @@ test.describe("server", () => {
     expect(metaJson.niconama.meta.total).not.toHaveProperty('comments');
   });
 
+  test("preserves replyTargetComment when normalizing legacy /api/meta payload", async ({ request }) => {
+    const legacyRes = await request.post(`${BASE_URL}/api/meta`, {
+      data: {
+        type: 'niconama',
+        data: {
+          isLive: true,
+          title: 'legacy reply target',
+          startTime: 0,
+          total: 1,
+          points: { gift: 0, ad: 0 },
+          url: 'https://example.com/legacy-reply',
+        },
+        replyTargetComment: {
+          text: 'Legacy 返信先コメント',
+          pickedTopic: '返信',
+        },
+      },
+    });
+    expect(legacyRes.ok()).toBeTruthy();
+
+    const metaRes = await request.get(`${BASE_URL}/api/meta`);
+    expect(metaRes.ok()).toBeTruthy();
+    const metaJson = await metaRes.json();
+    expect(metaJson).toHaveProperty('replyTargetComment');
+    expect(metaJson.replyTargetComment).toEqual({
+      text: 'Legacy 返信先コメント',
+      pickedTopic: '返信',
+    });
+  });
+
   test("accepts PUT / via comment route", async ({ request }) => {
     const postRes = await request.post(`${BASE_URL}/`);
     expect(postRes.ok()).toBeTruthy();


### PR DESCRIPTION
Ensure legacy /api/meta stream payload normalization preserves replyTargetComment so the admin console can display the reply target comment and picked topic. Includes new unit tests for legacy payload handling.