### PR TITLE
fix(comment-count): use latest comment number for current program

### DIFF
--- a/lib/Agent/index.test.ts
+++ b/lib/Agent/index.test.ts
@@ -70,8 +70,8 @@ const viewerComment = {
   },
 };
 
-describe('per-program comment counting', () => {
-  it('initializes comments to 0 and increments for user comments', () => {
+describe('per-program comment tracking', () => {
+  it('initializes comments to 0 and sets the latest comment number for user comments', () => {
     const agent = new MakaMujo(stubTalkModel, stubTts);
     agent.onAir(niconamaLive(10));
 
@@ -79,6 +79,15 @@ describe('per-program comment counting', () => {
 
     agent.listen([viewerComment]);
     expect(agent.streamState?.meta?.total?.comments ?? 0).toBe(1);
+  });
+
+  it('updates to the latest comment number when new comments arrive', () => {
+    const agent = new MakaMujo(stubTalkModel, stubTts);
+    agent.onAir(niconamaLive(10));
+    agent.listen([viewerComment]);
+
+    agent.listen([{ data: { comment: 'こんにちは', no: 3, anonymity: false, hasGift: false } } as any]);
+    expect(agent.streamState?.meta?.total?.comments ?? 0).toBe(3);
   });
 
   it('does not count system messages as user comments', () => {

--- a/lib/Agent/index.ts
+++ b/lib/Agent/index.ts
@@ -60,10 +60,10 @@ export class MakaMujo {
   #lastListenerCount?: number;
   #listenersStaleSince?: Date;
   #lastCommentAt?: Date;
-  // The URL of the currently active program. Used to scope comment counting
+  // The URL of the currently active program. Used to scope comment tracking.
   #currentProgramUrl?: string;
-  // Count of user comments received for the current program URL
-  #currentProgramCommentCount = 0;
+  // Latest comment number observed for the current program URL.
+  #currentProgramLatestCommentNo = 0;
   #currentNGramSize = inferNGramSize(INITIAL_COMMENT_NUMBER);
   #currentNGramSizeRaw = inferNGramSizeRaw(INITIAL_COMMENT_NUMBER);
   #hasPromptedCommentForViewerIncrease = false;
@@ -272,12 +272,12 @@ export class MakaMujo {
       // Count user comments for the current program URL. We treat comments
       // with a numeric `no` > 0 as user comments and ignore system messages.
       if (typeof commentData.no === 'number' && commentData.no > 0 && this.#currentProgramUrl) {
-        this.#currentProgramCommentCount += 1;
+        this.#currentProgramLatestCommentNo = commentData.no;
         if (this.#streamState && this.#streamState.meta) {
           const existingTotal = this.#streamState.meta.total ?? { listeners: 0, gift: 0, ad: 0 };
           this.#streamState.meta = {
             ...this.#streamState.meta,
-            total: { ...existingTotal, comments: this.#currentProgramCommentCount },
+            total: { ...existingTotal, comments: this.#currentProgramLatestCommentNo },
           };
         }
       }
@@ -316,7 +316,7 @@ export class MakaMujo {
           // If the program URL changes, reset the per-program comment counter.
           if (this.#currentProgramUrl !== url) {
             this.#currentProgramUrl = url;
-            this.#currentProgramCommentCount = 0;
+            this.#currentProgramLatestCommentNo = 0;
             this.#hasPromptedCommentForViewerIncrease = false;
           }
 
@@ -358,7 +358,7 @@ export class MakaMujo {
           this.#listenersStaleSince = undefined;
           // Clear current program tracking when offline
           this.#currentProgramUrl = undefined;
-          this.#currentProgramCommentCount = 0;
+          this.#currentProgramLatestCommentNo = 0;
         }
 
         this.#streamState = isLive ? {
@@ -371,7 +371,7 @@ export class MakaMujo {
               listeners,
               gift: typeof points?.gift === 'string' ? Number.parseFloat(points.gift) : points?.gift,
               ad: typeof points?.ad === 'string' ? Number.parseFloat(points.ad) : points?.ad,
-              comments: this.#currentProgramCommentCount,
+              comments: this.#currentProgramLatestCommentNo,
             },
           },
         } : undefined;

--- a/tests/integration/console-proxy.test.ts
+++ b/tests/integration/console-proxy.test.ts
@@ -184,7 +184,16 @@ test("comment count in /api/meta reflects PUT comments after POST /api/meta stre
     body: JSON.stringify([{ data: { comment: 'こんにちは', no: 1, anonymity: false, hasGift: false } }]),
   });
 
-  // The comment count should now be 1.
-  const updatedMeta = await (await fetch(`${BROADCASTING_BASE_URL}/api/meta`)).json() as any;
+  // The comment count should now reflect the latest comment number.
+  let updatedMeta = await (await fetch(`${BROADCASTING_BASE_URL}/api/meta`)).json() as any;
   expect(updatedMeta.commentCount).toBe(1);
+
+  await fetch(`${BROADCASTING_BASE_URL}/`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify([{ data: { comment: 'こんばんは', no: 3, anonymity: false, hasGift: false } }]),
+  });
+
+  updatedMeta = await (await fetch(`${BROADCASTING_BASE_URL}/api/meta`)).json() as any;
+  expect(updatedMeta.commentCount).toBe(3);
 });


### PR DESCRIPTION
Update the management console comment display so it reports the latest comment no for the current program URL. Added regression coverage for latest comment number tracking in the streaming state and console proxy integration tests.