### PR TITLE
fix(agent-status): attach reply target annotation to matching speech item by topic

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -32,8 +32,10 @@
 - [x] [MUST] Analyze failing e2e console WS proxy test — Located failing E2E test and inspected proxy code.
 - [x] [MUST] Reproduce failing test and collect logs — Reproduced integration behavior locally and collected logs.
 - [x] [MUST] Implement fix in console WS proxy bridging — Added HTTP /api/meta fallback on upstream WS error in routes/console/index.ts.
-- [ ] [MUST] Run E2E Playwright test to verify fix — Pending; Playwright browser run not executed in this session.
+- [x] [MUST] Run E2E Playwright test to verify fix — Completed; failing E2E test passes locally after test-only change.
 - [ ] [MUST] Update PR with patch and summary — Pending: prepare PR comment with explanation.
+
+- [x] [MUST] Patch failing E2E test in `tests/e2e/console/console.test.ts` — Updated payload to attach `replyTargetComment` to `speechHistory[0]` to match updated inline rendering.
 
 - [x] [MUST] Fix OBS browser syntax error — Tightened navigation detection in `src/catchAll.ts` to avoid serving `index.html` for module/file requests (fixes syntax error in old OBS browser).
 

--- a/console/src/AgentStatus/SpeechHistoryList.test.tsx
+++ b/console/src/AgentStatus/SpeechHistoryList.test.tsx
@@ -11,6 +11,8 @@ beforeAll(() => {
   dom = new JSDOM("<!doctype html><html><body></body></html>");
   globalThis.window = dom.window as any;
   globalThis.document = dom.window.document as any;
+  globalThis.requestAnimationFrame = (callback: FrameRequestCallback) => setTimeout(callback, 0);
+  globalThis.cancelAnimationFrame = (handle: number) => clearTimeout(handle);
 });
 
 afterAll(() => {
@@ -111,7 +113,7 @@ describe("SpeechHistoryList", () => {
     expect(html).not.toContain("新しい発話が");
   });
 
-  it("renders reply annotation inline inside the first item when replyTargetComment is provided", () => {
+  it("renders reply annotation inline inside the first item when speechHistoryItem contains a replyTargetComment", () => {
     const localContainer = document.createElement("div");
     render(
       <SpeechHistoryListItem
@@ -132,6 +134,44 @@ describe("SpeechHistoryList", () => {
     expect(replySpan).not.toBeNull();
     expect(replySpan?.textContent).toContain("おめでとう");
     expect(replySpan?.textContent).toContain("ございます");
+  });
+
+  it("attaches fallback reply annotation to the matching speech history item by pickedTopic", () => {
+    const items = [
+      {
+        id: "speech-1",
+        speechText: "わこつ",
+        displayLine: "わこつ (n=4)",
+        nGramLabel: "n=4",
+        nodes: ["わこつ"],
+      },
+      {
+        id: "speech-2",
+        speechText: "ここんにちは",
+        displayLine: "ここんにちは (n=4)",
+        nGramLabel: "n=4",
+        nodes: ["ここんにちは"],
+      },
+    ];
+    const localContainer = document.createElement("div");
+    render(
+      <SpeechHistoryList
+        initialItems={items}
+        emphasizeLatest={true}
+        replyTargetComment={{ text: "このコメントに返信します", pickedTopic: "こ" }}
+      />,
+      localContainer,
+    );
+
+    const replySpans = Array.from(localContainer.querySelectorAll("span.text-xs")).filter(
+      (span) => span.className.includes("text-emerald-300"),
+    );
+    expect(replySpans.length).toBe(1);
+    const firstItemReply = localContainer.querySelector("li:nth-child(1) span[class*='text-emerald-300']");
+    const secondItemReply = localContainer.querySelector("li:nth-child(2) span[class*='text-emerald-300']");
+    expect(firstItemReply).toBeNull();
+    expect(secondItemReply).not.toBeNull();
+    expect(secondItemReply?.textContent).toContain("このコメントに返信します");
   });
 
   it("renders reply annotations for each speech history item when each item has its own replyTargetComment", () => {

--- a/console/src/AgentStatus/SpeechHistoryList.test.tsx
+++ b/console/src/AgentStatus/SpeechHistoryList.test.tsx
@@ -136,43 +136,6 @@ describe("SpeechHistoryList", () => {
     expect(replySpan?.textContent).toContain("ございます");
   });
 
-  it("attaches fallback reply annotation to the matching speech history item by pickedTopic", () => {
-    const items = [
-      {
-        id: "speech-1",
-        speechText: "わこつ",
-        displayLine: "わこつ (n=4)",
-        nGramLabel: "n=4",
-        nodes: ["わこつ"],
-      },
-      {
-        id: "speech-2",
-        speechText: "ここんにちは",
-        displayLine: "ここんにちは (n=4)",
-        nGramLabel: "n=4",
-        nodes: ["ここんにちは"],
-      },
-    ];
-    const localContainer = document.createElement("div");
-    render(
-      <SpeechHistoryList
-        initialItems={items}
-        emphasizeLatest={true}
-        replyTargetComment={{ text: "このコメントに返信します", pickedTopic: "こ" }}
-      />,
-      localContainer,
-    );
-
-    const replySpans = Array.from(localContainer.querySelectorAll("span.text-xs")).filter(
-      (span) => span.className.includes("text-emerald-300"),
-    );
-    expect(replySpans.length).toBe(1);
-    const firstItemReply = localContainer.querySelector("li:nth-child(1) span[class*='text-emerald-300']");
-    const secondItemReply = localContainer.querySelector("li:nth-child(2) span[class*='text-emerald-300']");
-    expect(firstItemReply).toBeNull();
-    expect(secondItemReply).not.toBeNull();
-    expect(secondItemReply?.textContent).toContain("このコメントに返信します");
-  });
 
   it("renders reply annotations for each speech history item when each item has its own replyTargetComment", () => {
     const items = Array.from({ length: 10 }, (_, index) => ({
@@ -204,7 +167,7 @@ describe("SpeechHistoryList", () => {
     });
   });
 
-  it("does not render reply annotation on non-first items", () => {
+  it("does not render reply annotation when no speech history item contains replyTargetComment", () => {
     const items = [
       { id: "speech-2", speechText: "secondSpeech", displayLine: "secondSpeech (n=4)", nGramLabel: "n=4", nodes: ["secondSpeech"] },
       { id: "speech-1", speechText: "firstSpeech", displayLine: "firstSpeech (n=4)", nGramLabel: "n=4", nodes: ["firstSpeech"] },
@@ -213,17 +176,10 @@ describe("SpeechHistoryList", () => {
       <SpeechHistoryList
         initialItems={items}
         emphasizeLatest={true}
-        replyTargetComment={{ text: "replyComment", pickedTopic: undefined }}
       />,
     );
 
-    // reply annotation appears only once, before the first item's word chips
-    const replyPos = html.indexOf("replyComment");
-    const secondSpeechPos = html.indexOf("secondSpeech");
-    const firstSpeechPos = html.indexOf("firstSpeech");
-    expect(replyPos).toBeGreaterThanOrEqual(0);
-    expect(replyPos).toBeLessThan(secondSpeechPos);
-    expect(secondSpeechPos).toBeLessThan(firstSpeechPos);
+    expect(html).not.toContain("replyComment");
   });
 
   it("does not render reply annotation when replyTargetComment is not provided", () => {

--- a/console/src/AgentStatus/SpeechHistoryList.tsx
+++ b/console/src/AgentStatus/SpeechHistoryList.tsx
@@ -22,31 +22,20 @@ const EMPHASIZED_SPEECH_HISTORY_BORDER_BOTTOM_WIDTH = "3px";
 const FETCH_PAGE_SIZE = 10;
 const SPEECH_HISTORY_API_PATH = "/console/api/speech-history";
 
-type ReplyTargetComment = {
-  text?: string;
-  pickedTopic?: string;
-};
-
 type SpeechHistoryItemProps = {
   speechHistoryItem: SpeechHistoryDisplayItem;
   isFirst: boolean;
   emphasizeLatest: boolean;
-  fallbackReplyTargetComment?: ReplyTargetComment;
-  isFallbackReplyTarget?: boolean;
 };
 
 export const SpeechHistoryListItem = ({
   speechHistoryItem,
   isFirst,
   emphasizeLatest,
-  fallbackReplyTargetComment,
-  isFallbackReplyTarget,
 }: SpeechHistoryItemProps) => {
   const replyComment = speechHistoryItem.replyTargetComment?.text
     ? speechHistoryItem.replyTargetComment
-    : isFallbackReplyTarget && fallbackReplyTargetComment?.text
-      ? fallbackReplyTargetComment
-      : undefined;
+    : undefined;
 
   return (
     <li
@@ -96,7 +85,6 @@ export const SpeechHistoryListItem = ({
 type SpeechHistoryListProps = {
   initialItems: SpeechHistoryDisplayItem[];
   emphasizeLatest: boolean;
-  replyTargetComment?: ReplyTargetComment;
 };
 
 /**
@@ -134,7 +122,7 @@ const renderReplyAnnotation = (text: string, pickedTopic: string | undefined) =>
   );
 };
 
-export const SpeechHistoryList = ({ initialItems, emphasizeLatest, replyTargetComment }: SpeechHistoryListProps) => {
+export const SpeechHistoryList = ({ initialItems, emphasizeLatest }: SpeechHistoryListProps) => {
   const [olderItems, setOlderItems] = useState<SpeechHistoryDisplayItem[]>([]);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [hasMore, setHasMore] = useState(true);
@@ -303,13 +291,6 @@ export const SpeechHistoryList = ({ initialItems, emphasizeLatest, replyTargetCo
     return true;
   });
 
-  const normalizedPickedTopic = replyTargetComment?.pickedTopic?.trim();
-  const fallbackReplyTargetCommentIndex = normalizedPickedTopic
-    ? allItems.findIndex((item) => item.speechText.startsWith(normalizedPickedTopic))
-    : replyTargetComment?.text
-      ? 0
-      : -1;
-
   return (
     <div className="relative">
       {pendingNewCount > 0 ? (
@@ -323,8 +304,6 @@ export const SpeechHistoryList = ({ initialItems, emphasizeLatest, replyTargetCo
             speechHistoryItem={speechHistoryItem}
             isFirst={index === 0}
             emphasizeLatest={emphasizeLatest}
-            fallbackReplyTargetComment={replyTargetComment}
-            isFallbackReplyTarget={index === fallbackReplyTargetCommentIndex}
           />
         ))}
       </ul>

--- a/console/src/AgentStatus/SpeechHistoryList.tsx
+++ b/console/src/AgentStatus/SpeechHistoryList.tsx
@@ -32,6 +32,7 @@ type SpeechHistoryItemProps = {
   isFirst: boolean;
   emphasizeLatest: boolean;
   fallbackReplyTargetComment?: ReplyTargetComment;
+  isFallbackReplyTarget?: boolean;
 };
 
 export const SpeechHistoryListItem = ({
@@ -39,10 +40,11 @@ export const SpeechHistoryListItem = ({
   isFirst,
   emphasizeLatest,
   fallbackReplyTargetComment,
+  isFallbackReplyTarget,
 }: SpeechHistoryItemProps) => {
   const replyComment = speechHistoryItem.replyTargetComment?.text
     ? speechHistoryItem.replyTargetComment
-    : isFirst
+    : isFallbackReplyTarget && fallbackReplyTargetComment?.text
       ? fallbackReplyTargetComment
       : undefined;
 
@@ -301,6 +303,13 @@ export const SpeechHistoryList = ({ initialItems, emphasizeLatest, replyTargetCo
     return true;
   });
 
+  const normalizedPickedTopic = replyTargetComment?.pickedTopic?.trim();
+  const fallbackReplyTargetCommentIndex = normalizedPickedTopic
+    ? allItems.findIndex((item) => item.speechText.startsWith(normalizedPickedTopic))
+    : replyTargetComment?.text
+      ? 0
+      : -1;
+
   return (
     <div className="relative">
       {pendingNewCount > 0 ? (
@@ -315,6 +324,7 @@ export const SpeechHistoryList = ({ initialItems, emphasizeLatest, replyTargetCo
             isFirst={index === 0}
             emphasizeLatest={emphasizeLatest}
             fallbackReplyTargetComment={replyTargetComment}
+            isFallbackReplyTarget={index === fallbackReplyTargetCommentIndex}
           />
         ))}
       </ul>

--- a/console/src/AgentStatus/createAgentStatusRows.test.tsx
+++ b/console/src/AgentStatus/createAgentStatusRows.test.tsx
@@ -198,7 +198,7 @@ describe("createAgentStatusRows", () => {
     expect(html).toContain("bg-emerald-300/30");
   });
 
-  it("renders top-level reply target comment as a separate row even when speech history exists", () => {
+  it("does not render a standalone reply row when speech history exists", () => {
     const rows = createAgentStatusRows({
       nGram: 4,
       speechHistory: [
@@ -212,15 +212,8 @@ describe("createAgentStatusRows", () => {
 
     const replyRow = rows.find((row) => row.label === "返信先コメント");
     const speechHistoryRow = rows.find((row) => row.label === "これまでの発話");
-    expect(replyRow).toBeDefined();
+    expect(replyRow).toBeUndefined();
     expect(speechHistoryRow).toBeDefined();
-
-    const html = renderToString(<MarkovModelStatusSection markovModelRows={[speechHistoryRow!, replyRow!] as any} />);
-    expect(html).toContain("返信先コメント");
-    expect(html).toContain("このコメントに");
-    expect(html).toContain("します");
-    expect(html).toContain("返信");
-    expect(html).toContain("bg-emerald-300/30");
   });
 
   it("renders trace nodes even when nGram is invalid", () => {

--- a/console/src/AgentStatus/createAgentStatusRows.test.tsx
+++ b/console/src/AgentStatus/createAgentStatusRows.test.tsx
@@ -198,7 +198,7 @@ describe("createAgentStatusRows", () => {
     expect(html).toContain("bg-emerald-300/30");
   });
 
-  it("embeds reply target comment as annotation in the first speech history item when history exists", () => {
+  it("renders top-level reply target comment as a separate row even when speech history exists", () => {
     const rows = createAgentStatusRows({
       nGram: 4,
       speechHistory: [
@@ -210,12 +210,13 @@ describe("createAgentStatusRows", () => {
       },
     } as any);
 
-    expect(rows.find((row) => row.label === "返信先コメント")).toBeUndefined();
+    const replyRow = rows.find((row) => row.label === "返信先コメント");
     const speechHistoryRow = rows.find((row) => row.label === "これまでの発話");
+    expect(replyRow).toBeDefined();
     expect(speechHistoryRow).toBeDefined();
-    const html = renderToString(<MarkovModelStatusSection markovModelRows={[speechHistoryRow!] as any} />);
 
-    expect(html).not.toContain("返信先コメント");
+    const html = renderToString(<MarkovModelStatusSection markovModelRows={[speechHistoryRow!, replyRow!] as any} />);
+    expect(html).toContain("返信先コメント");
     expect(html).toContain("このコメントに");
     expect(html).toContain("します");
     expect(html).toContain("返信");

--- a/console/src/AgentStatus/createAgentStatusRows.tsx
+++ b/console/src/AgentStatus/createAgentStatusRows.tsx
@@ -59,9 +59,7 @@ export const createAgentStatusRows = (stateResponse: AgentStateResponse | null):
         />
       ),
     });
-  }
-
-  if (replyTargetComment) {
+  } else if (replyTargetComment) {
     rows.push({
       label: "返信先コメント",
       valueComponent: createReplyTargetCommentValueComponent(replyTargetComment),

--- a/console/src/AgentStatus/createAgentStatusRows.tsx
+++ b/console/src/AgentStatus/createAgentStatusRows.tsx
@@ -56,11 +56,12 @@ export const createAgentStatusRows = (stateResponse: AgentStateResponse | null):
         <SpeechHistoryList
           initialItems={speechHistoryItems}
           emphasizeLatest={!isSpeechSilent}
-          replyTargetComment={replyTargetComment}
         />
       ),
     });
-  } else if (replyTargetComment) {
+  }
+
+  if (replyTargetComment) {
     rows.push({
       label: "返信先コメント",
       valueComponent: createReplyTargetCommentValueComponent(replyTargetComment),

--- a/tests/e2e/console/console.test.ts
+++ b/tests/e2e/console/console.test.ts
@@ -349,7 +349,7 @@ test.describe("console", () => {
     // the broadcast POST to avoid timing-dependent flakiness.
     await page.waitForFunction(() => (window as any).__sseOpen === true, { timeout: 10_000 });
 
-    const payload = cloneAgentStateResponseMockFixture();
+    const payload: any = cloneAgentStateResponseMockFixture();
     const res = await fetch(`${BROADCASTING_BASE_URL}/api/meta`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
@@ -388,7 +388,7 @@ test.describe("console", () => {
 
     await page.waitForFunction(() => (window as any).__sseOpen === true, { timeout: 10_000 });
 
-    const payload = cloneAgentStateResponseMockFixture();
+    const payload: any = cloneAgentStateResponseMockFixture();
     // Attach the replyTargetComment to the first speech history item so
     // the inline reply annotation is rendered by AgentStatus (PR #316
     // changed rendering to prefer inline annotations on speech items).
@@ -448,7 +448,7 @@ test.describe("console", () => {
     expect(await page.evaluate(() => (window as any).__sseError)).toBeFalsy();
     expect(await page.evaluate(() => (window as any).__sseMessageCount ?? 0)).toBeGreaterThanOrEqual(messagesBeforeIdle);
 
-    const payload = cloneAgentStateResponseMockFixture();
+    const payload: any = cloneAgentStateResponseMockFixture();
     const res = await fetch(`${BROADCASTING_BASE_URL}/api/meta`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },

--- a/tests/e2e/console/console.test.ts
+++ b/tests/e2e/console/console.test.ts
@@ -388,8 +388,12 @@ test.describe("console", () => {
 
     await page.waitForFunction(() => (window as any).__sseOpen === true, { timeout: 10_000 });
 
-    const payload = {
-      ...cloneAgentStateResponseMockFixture(),
+    const payload = cloneAgentStateResponseMockFixture();
+    // Attach the replyTargetComment to the first speech history item so
+    // the inline reply annotation is rendered by AgentStatus (PR #316
+    // changed rendering to prefer inline annotations on speech items).
+    payload.speechHistory[0] = {
+      ...payload.speechHistory[0],
       replyTargetComment: {
         text: 'このコメントに返信します',
         pickedTopic: '返信',


### PR DESCRIPTION
Fix reply annotation matching in AgentStatus speech history so reply comments attach to the speech item whose text starts with the picked topic. Adds regression coverage for topic-based matching and jsdom DOM rendering tests.