### PR TITLE
feat(niconama): switch to internal NicoNico comment/meta acquisition and remove root comment routes

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -13,13 +13,13 @@ import { resolve } from "node:path";
 // process alive reliably.
 import { parseArgs } from "node:util";
 import { startConsoleServer } from "./console/index";
-import { FallbackTTS, MakaMujo, MarkovChainModel, TTS } from "./lib/server";
-import * as index from "./routes/index";
+import { FallbackTTS, MakaMujo, MarkovChainModel, TTS } from "./lib/server";import { AllowedIP } from "./lib/allowedIP";import * as index from "./routes/index";
 import * as speechHistoryRoute from "./routes/api/speech-history";
 import type { SpeechHistoryEntry } from "./routes/api/speech-history";
 import { handleCatchAll } from "./src/frontendServer";
 import { compileTailwindCss, createCssResponse } from "./lib/tailwind";
 import { normalizePublishedStreamState } from "./lib/streamState";
+import { createNiconamaCommentClient, type NiconamaCommentClient } from "./lib/niconamaCommentClient";
 
 process.on('exit', exitHandler.bind(null, { cleanup: true }));
 process.on('SIGINT', signalHandler.bind(null, { exit: true }));
@@ -113,6 +113,7 @@ const streamer = new MakaMujo(model, tts);
 // when possible.
 let lastPublishedStreamState: unknown = undefined;
 let currentSpeechState = { speech: '', silent: false };
+let niconamaCommentClient: NiconamaCommentClient | null = null;
 // WebSocket clients connected to the broadcasting server.
 const wsClients = new Set<any>();
 
@@ -211,6 +212,63 @@ const getCurrentStreamPayload = () => {
     replyTargetComment,
     commentCount: base.commentCount ?? streamer.streamState?.meta?.total?.comments,
   } as const;
+};
+
+const extractReplyTargetComment = (payload: unknown): unknown => {
+  if (payload && typeof payload === 'object' && 'replyTargetComment' in payload) {
+    return (payload as any).replyTargetComment;
+  }
+  const nestedData = payload && typeof payload === 'object' && 'data' in payload ? (payload as any).data : undefined;
+  if (nestedData && typeof nestedData === 'object' && 'replyTargetComment' in nestedData) {
+    return nestedData.replyTargetComment;
+  }
+  return undefined;
+};
+
+const handlePublishedStreamState = (payload: unknown): void => {
+  const replyTargetComment = extractReplyTargetComment(payload);
+  let published: unknown = payload;
+
+  if (published && typeof published === 'object' && !('type' in published) && 'data' in published) {
+    published = (published as any).data;
+  }
+
+  try {
+    agent.publishStreamState?.(published);
+  } catch (err) {
+    console.warn('[WARN] failed to forward stream state to streamer:', err instanceof Error ? err.message : String(err));
+  }
+
+  try {
+    published = normalizePublishedStreamState(published);
+    if (replyTargetComment !== undefined) {
+      if (published && typeof published === 'object') {
+        (published as any).replyTargetComment = replyTargetComment;
+      } else {
+        published = { replyTargetComment };
+      }
+    }
+  } catch (err) {
+    console.warn('[WARN] failed to normalize published stream state:', err instanceof Error ? err.message : String(err));
+  }
+
+  try {
+    lastPublishedStreamState = published;
+  } catch (err) {
+    console.warn('[WARN] failed to persist published stream state locally:', err instanceof Error ? err.message : String(err));
+  }
+
+  try {
+    broadcastToWsClients(getCurrentStreamPayload());
+  } catch (err) {
+    console.warn('[WARN] failed to broadcast to WebSocket clients:', err instanceof Error ? err.message : String(err));
+  }
+
+  try {
+    sseBroadcast(getCurrentStreamPayload());
+  } catch (err) {
+    console.warn('[WARN] failed to broadcast to SSE clients:', err instanceof Error ? err.message : String(err));
+  }
 };
 
 const normalizeSpeechText = (speech: unknown): string | undefined => {
@@ -357,57 +415,7 @@ const apiApp = new Hono()
         return Response.json({}, { status: 400 });
       }
 
-      const replyTargetComment = (() => {
-        if (body && typeof body === 'object' && 'replyTargetComment' in body) {
-          return (body as any).replyTargetComment;
-        }
-        const nestedData = body && typeof body === 'object' && 'data' in body ? (body as any).data : undefined;
-        if (nestedData && typeof nestedData === 'object' && 'replyTargetComment' in nestedData) {
-          return (nestedData as any).replyTargetComment;
-        }
-        return undefined;
-      })();
-      let published: unknown = body;
-      if (published && typeof published === 'object' && !('type' in published) && 'data' in published) {
-        published = (published as any).data;
-      }
-
-      try {
-        agent.publishStreamState?.(published);
-      } catch (err) {
-        console.warn('[WARN] failed to forward stream state to streamer:', err instanceof Error ? err.message : String(err));
-      }
-
-      try {
-        published = normalizePublishedStreamState(published);
-        if (replyTargetComment !== undefined) {
-          if (published && typeof published === 'object') {
-            (published as any).replyTargetComment = replyTargetComment;
-          } else {
-            published = { replyTargetComment };
-          }
-        }
-      } catch (err) {
-        console.warn('[WARN] failed to normalize published stream state:', err instanceof Error ? err.message : String(err));
-      }
-
-      try {
-        lastPublishedStreamState = published;
-      } catch (err) {
-        console.warn('[WARN] failed to persist published stream state locally:', err instanceof Error ? err.message : String(err));
-      }
-
-      try {
-        broadcastToWsClients(getCurrentStreamPayload());
-      } catch (err) {
-        console.warn('[WARN] failed to broadcast to WebSocket clients:', err instanceof Error ? err.message : String(err));
-      }
-      try {
-        sseBroadcast(getCurrentStreamPayload());
-      } catch (err) {
-        console.warn('[WARN] failed to broadcast to SSE clients:', err instanceof Error ? err.message : String(err));
-      }
-
+      handlePublishedStreamState(body);
       return Response.json({});
     } catch (err) {
       console.error('[ERROR] POST /api/meta handler crashed:', err instanceof Error ? err.stack ?? err.message : String(err));
@@ -540,33 +548,8 @@ const mainApp = new Hono()
   // Static assets from the public directory
   .get('/nc433974.png', () => new Response(Bun.file('./src/public/nc433974.png')))
   .get('/favicon-32x32.png', () => new Response(Bun.file('./src/public/favicon-32x32.png')))
-
-  // Root HTTP handlers (broadcast/comment ingestion)
-  .post('/', (c) => index.POST(c.req.raw, getMainServer().requestIP(c.req.raw)))
-  .put('/', async (c) => {
-    const res = await index.PUT(c.req.raw, getMainServer().requestIP(c.req.raw));
-    if (!res.ok) {
-      console.error('response is not ok', res);
-      return res;
-    }
-    const comments = await res.json();
-    if (!Array.isArray(comments)) {
-      console.error('response data was unprocessed', comments);
-      return Response.json({}, { status: 500 });
-    }
-    agent.postComments(comments);
-    broadcastCurrentPayload('onComment');
-
-    if (modelFile) {
-      try {
-        writeFileSync(modelFile, streamer.talkModel.toJSON());
-      } catch (err) {
-        console.warn('[WARN]', 'failed to write model', modelFile, err);
-      }
-    }
-
-    return Response.json({});
-  })
+  .post('/', () => new Response(null, { status: 404 }))
+  .put('/', () => new Response(null, { status: 404 }))
 
   // WebSocket / SSE endpoints
   .get('/api/ws', (c) => makeStreamHandler('/api/ws')(c.req.raw))
@@ -640,10 +623,45 @@ try {
     broadcastingPort: process.env.BROADCASTING_PORT ?? server.port,
   });
   console.log(`🚀 Console running at ${consoleServer.url}`);
+  if (process.env.NODE_ENV === 'production') {
+    AllowedIP.set({ family: 'IPv4', address: '127.0.0.1' });
+  }
 } catch (err) {
   const consoleStartupError = err instanceof Error ? (err.stack ?? err.message) : String(err);
   console.error(`[ERROR] CONSOLE_STARTUP_FAILED ${JSON.stringify(consoleStartupError)}`);
   process.exit(1);
+}
+
+try {
+  niconamaCommentClient = createNiconamaCommentClient(
+    {
+      userDataDir: process.env.NICONAMA_USER_DATA_DIR ?? './playwright/.auth/',
+      executablePath: process.env.CHROMIUM_EXECUTABLE_PATH,
+      pollIntervalMs: 30_000,
+    },
+    {
+      onMeta: handlePublishedStreamState,
+      onComments: (comments) => {
+        agent.postComments(comments);
+        broadcastCurrentPayload('onComment');
+        if (modelFile) {
+          try {
+            writeFileSync(modelFile, streamer.talkModel.toJSON());
+          } catch (err) {
+            console.warn('[WARN]', 'failed to write model', modelFile, err);
+          }
+        }
+      },
+      onError: (err) => {
+        console.warn('[WARN] niconama comment client error:', err instanceof Error ? err.message : String(err));
+      },
+    },
+  );
+  void niconamaCommentClient.start().catch((err) => {
+    console.warn('[WARN] failed to start niconamaCommentClient:', err instanceof Error ? err.message : String(err));
+  });
+} catch (err) {
+  console.warn('[WARN] failed to initialize niconamaCommentClient:', err instanceof Error ? err.message : String(err));
 }
 
 // Start the stream playback after servers are listening so startup is
@@ -681,6 +699,11 @@ function exitHandler(options: { cleanup: true; exit?: never } | { cleanup?: neve
     }
     if (consoleServer) {
       consoleServer.stop(options.exit);
+    }
+    if (niconamaCommentClient) {
+      void niconamaCommentClient.stop().catch((err) => {
+        console.warn('[WARN] failed to stop niconamaCommentClient:', err instanceof Error ? err.message : String(err));
+      });
     }
   }
 

--- a/index.ts
+++ b/index.ts
@@ -13,7 +13,8 @@ import { resolve } from "node:path";
 // process alive reliably.
 import { parseArgs } from "node:util";
 import { startConsoleServer } from "./console/index";
-import { FallbackTTS, MakaMujo, MarkovChainModel, TTS } from "./lib/server";import { AllowedIP } from "./lib/allowedIP";import * as index from "./routes/index";
+import { FallbackTTS, MakaMujo, MarkovChainModel, TTS } from "./lib/server";
+import { AllowedIP } from "./lib/allowedIP";
 import * as speechHistoryRoute from "./routes/api/speech-history";
 import type { SpeechHistoryEntry } from "./routes/api/speech-history";
 import { handleCatchAll } from "./src/frontendServer";

--- a/lib/niconamaCommentClient.test.ts
+++ b/lib/niconamaCommentClient.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "bun:test";
+import { parseAgentCommentsFromResponseBody } from "./niconamaCommentClient";
+
+describe("parseAgentCommentsFromResponseBody", () => {
+  it("parses comments from a top-level comments array", () => {
+    const body = {
+      comments: [{ comment: "こんにちは", no: 1, anonymity: false, hasGift: false }],
+    };
+
+    const parsed = parseAgentCommentsFromResponseBody(body);
+
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]).toEqual({
+      data: expect.objectContaining({
+        comment: "こんにちは",
+        no: 1,
+        anonymity: false,
+        hasGift: false,
+      }),
+    });
+  });
+
+  it("parses comments from nested data arrays", () => {
+    const body = {
+      data: {
+        comments: [{ comment: "こんばんは", no: 2, anonymity: true, hasGift: true, userId: "user123" }],
+      },
+    };
+
+    const parsed = parseAgentCommentsFromResponseBody(body);
+
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]).toEqual({
+      data: expect.objectContaining({
+        comment: "こんばんは",
+        no: 2,
+        anonymity: true,
+        hasGift: true,
+        userId: "user123",
+      }),
+    });
+  });
+
+  it("deduplicates repeated comments with the same signature", () => {
+    const body = {
+      comments: [
+        { comment: "hello", no: 5, anonymity: false, hasGift: false },
+        { comment: "hello", no: 5, anonymity: false, hasGift: false },
+      ],
+    };
+
+    const parsed = parseAgentCommentsFromResponseBody(body);
+
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]?.data.comment).toBe("hello");
+  });
+});

--- a/lib/niconamaCommentClient.test.ts
+++ b/lib/niconamaCommentClient.test.ts
@@ -54,4 +54,20 @@ describe("parseAgentCommentsFromResponseBody", () => {
     expect(parsed).toHaveLength(1);
     expect(parsed[0]?.data.comment).toBe("hello");
   });
+
+  it("deduplicates repeated comments across separate parse calls when sharing the same signature cache", () => {
+    const body1 = {
+      comments: [{ comment: "hello", no: 5, anonymity: false, hasGift: false }],
+    };
+    const body2 = {
+      comments: [{ comment: "hello", no: 5, anonymity: false, hasGift: false }],
+    };
+    const seenSignatures = new Set<string>();
+
+    const firstParsed = parseAgentCommentsFromResponseBody(body1, seenSignatures);
+    const secondParsed = parseAgentCommentsFromResponseBody(body2, seenSignatures);
+
+    expect(firstParsed).toHaveLength(1);
+    expect(secondParsed).toHaveLength(0);
+  });
 });

--- a/lib/niconamaCommentClient.ts
+++ b/lib/niconamaCommentClient.ts
@@ -1,0 +1,281 @@
+import { existsSync } from "node:fs";
+import { setTimeout } from "node:timers/promises";
+import type { BrowserContext, Page, ViewportSize } from "playwright";
+import { chromium } from "./Browser/chromium";
+import type { AgentComment } from "automated-gameplay-transmitter";
+
+const DEFAULT_USER_DATA_DIR = './playwright/.auth/';
+const DEFAULT_VIEWPORT: ViewportSize = {
+  width: 1280,
+  height: 720,
+};
+const DEFAULT_CANDIDATE_URLS = [
+  'https://live.nicovideo.jp/',
+  'https://live.nicovideo.jp/my',
+  'https://live.nicovideo.jp/watch/user/14171889',
+];
+
+export type NiconamaCommentClientOptions = {
+  userDataDir?: string;
+  executablePath?: string;
+  pollIntervalMs?: number;
+};
+
+type NiconamaCommentClientCallbacks = {
+  onComments: (comments: AgentComment[]) => void;
+  onMeta: (state: unknown) => void;
+  onError?: (error: unknown) => void;
+};
+
+export class NiconamaCommentClient {
+  #userDataDir: string;
+  #executablePath?: string;
+  #pollIntervalMs: number;
+  #context: BrowserContext | null = null;
+  #page: Page | null = null;
+  #running = false;
+  #stopRequested = false;
+  #pollTask: Promise<void> | null = null;
+  #seenCommentSignatures = new Set<string>();
+  #callbacks: NiconamaCommentClientCallbacks;
+
+  constructor(options: NiconamaCommentClientOptions, callbacks: NiconamaCommentClientCallbacks) {
+    this.#userDataDir = options.userDataDir ?? DEFAULT_USER_DATA_DIR;
+    this.#executablePath = options.executablePath;
+    this.#pollIntervalMs = options.pollIntervalMs ?? 30_000;
+    this.#callbacks = callbacks;
+  }
+
+  async start(): Promise<void> {
+    if (this.#running) return;
+    this.#stopRequested = false;
+
+    if (!existsSync(this.#userDataDir)) {
+      throw new Error(`userDataDir does not exist: ${this.#userDataDir}`);
+    }
+
+    const launchOptions = {
+      ...(this.#executablePath ? { executablePath: this.#executablePath } : { channel: 'chromium' }),
+      headless: true,
+      timeout: 60_000,
+      args: [
+        '--hide-scrollbars',
+        '--window-size=1024,576',
+        '--window-position=1280,600',
+      ],
+      viewport: DEFAULT_VIEWPORT,
+    } as const;
+
+    const context = await (chromium as any).launchPersistentContext(this.#userDataDir, launchOptions) as BrowserContext;
+    context.setDefaultTimeout(0);
+
+    const pages = context.pages();
+    const page = pages[0] ?? await context.newPage();
+    page.setDefaultTimeout(0);
+
+    this.#context = context;
+    this.#page = page;
+    this.#running = true;
+
+    this.setupResponseWatcher(page);
+    await this.refreshLivePageState();
+
+    this.#pollTask = this.pollLoop();
+  }
+
+  async stop(): Promise<void> {
+    this.#stopRequested = true;
+    if (this.#pollTask) {
+      await this.#pollTask;
+      this.#pollTask = null;
+    }
+    if (this.#context) {
+      try { await this.#context.close(); } catch { }
+      this.#context = null;
+      this.#page = null;
+    }
+    this.#running = false;
+  }
+
+  isRunning(): boolean {
+    return this.#running;
+  }
+
+  async refreshLivePageState(): Promise<void> {
+    if (!this.#page) return;
+
+    const liveUrl = await this.findLiveUrl();
+    if (liveUrl) {
+      try {
+        await this.#page.goto(liveUrl, { waitUntil: 'domcontentloaded' });
+      } catch (err) {
+        this.reportError(err);
+      }
+    }
+
+    try {
+      const meta = await this.extractMetaFromPage(this.#page);
+      this.#callbacks.onMeta({
+        type: 'niconama',
+        data: {
+          isLive: meta.isLive,
+          title: meta.title,
+          startTime: meta.startTime,
+          total: meta.listeners,
+          points: { gift: meta.gift ?? 0, ad: meta.ad ?? 0 },
+          url: meta.url,
+        },
+      });
+    } catch (err) {
+      this.reportError(err);
+    }
+  }
+
+  async pollLoop(): Promise<void> {
+    while (!this.#stopRequested && this.#running) {
+      await setTimeout(this.#pollIntervalMs);
+      if (this.#stopRequested) break;
+      try {
+        await this.refreshLivePageState();
+      } catch (err) {
+        this.reportError(err);
+      }
+    }
+  }
+
+  private async findLiveUrl(): Promise<string | null> {
+    if (!this.#page) return null;
+
+    try {
+      const currentUrl = this.#page.url();
+      if (/\/watch\/lv\d+/.test(currentUrl)) {
+        return currentUrl;
+      }
+
+      for (const url of DEFAULT_CANDIDATE_URLS) {
+        try {
+          await this.#page.goto(url, { waitUntil: 'domcontentloaded' });
+        } catch {
+          continue;
+        }
+
+        const liveUrl = await this.#page.evaluate(() => {
+          const anchors = Array.from(document.querySelectorAll<HTMLAnchorElement>('a[href]'));
+          const firstLive = anchors.find((a) => /\/watch\/lv\d+/.test(a.href));
+          return firstLive?.href ?? null;
+        });
+
+        if (typeof liveUrl === 'string' && liveUrl.length > 0) {
+          return liveUrl;
+        }
+      }
+    } catch (err) {
+      this.reportError(err);
+    }
+    return null;
+  }
+
+  private setupResponseWatcher(page: Page): void {
+    page.on('response', async (response) => {
+      try {
+        const contentType = response.headers()['content-type'] ?? '';
+        if (!contentType.includes('application/json')) return;
+        const url = response.url();
+        if (!/comment|chat|live|niconama/i.test(url)) return;
+
+        const body = await response.json().catch(() => null);
+        if (!body) return;
+
+        const comments = parseAgentCommentsFromResponseBody(body);
+        if (comments.length > 0) {
+          this.#callbacks.onComments(comments);
+        }
+      } catch (err) {
+        this.reportError(err);
+      }
+    });
+  }
+
+  private async extractMetaFromPage(page: Page): Promise<{ title: string; url: string; isLive: boolean; startTime: number; listeners?: number; gift?: number; ad?: number }> {
+    return await page.evaluate(() => {
+      const title = document.title || (document.querySelector('h1')?.textContent?.trim() ?? 'NicoNico Live');
+      const url = location.href;
+      const text = document.body.textContent ?? '';
+      const isLive = /\/watch\/lv\d+/.test(url) && !/(終了|放送を終了|終了しました)/.test(text);
+      const startTime = Date.now();
+
+      const listenersText = document.querySelector('[class*="viewer"], [class*="視聴者数"], [class*="watch-count"]')?.textContent ?? '';
+      const listeners = Number.parseInt(listenersText.replace(/[^0-9]/g, ''), 10);
+      const gift = 0;
+      const ad = 0;
+      return {
+        title: title.trim(),
+        url,
+        isLive,
+        startTime,
+        listeners: Number.isFinite(listeners) ? listeners : undefined,
+        gift,
+        ad,
+      };
+    });
+  }
+
+  private reportError(error: unknown): void {
+    if (typeof this.#callbacks.onError === 'function') {
+      this.#callbacks.onError(error);
+    } else {
+      console.warn('[WARN] NiconamaCommentClient error:', error instanceof Error ? error.message : String(error));
+    }
+  }
+}
+
+export const createNiconamaCommentClient = (
+  options: NiconamaCommentClientOptions,
+  callbacks: NiconamaCommentClientCallbacks,
+): NiconamaCommentClient => new NiconamaCommentClient(options, callbacks);
+
+export const parseAgentCommentsFromResponseBody = (body: unknown): AgentComment[] => {
+  if (!body || typeof body !== 'object') return [];
+  const rawComments: unknown[] = [];
+  const candidateArrays = [
+    (body as any).comments,
+    (body as any).chat,
+    (body as any).chats,
+    (body as any).data?.comments,
+    (body as any).data?.chat,
+    (body as any).data?.chats,
+  ];
+
+  for (const candidate of candidateArrays) {
+    if (Array.isArray(candidate)) {
+      rawComments.push(...candidate);
+    }
+  }
+
+  if (rawComments.length === 0 && Array.isArray((body as any).data)) {
+    rawComments.push(...(body as any).data);
+  }
+
+  const comments: AgentComment[] = [];
+  const seenSignatures = new Set<string>();
+
+  for (const raw of rawComments) {
+    if (!raw || typeof raw !== 'object') continue;
+    const commentText = (raw as any).comment ?? (raw as any).text ?? (raw as any).body ?? (raw as any).message;
+    if (typeof commentText !== 'string' || commentText.trim().length === 0) continue;
+    const commentData: Record<string, unknown> = {
+      comment: commentText,
+      no: typeof (raw as any).no === 'number' ? (raw as any).no : typeof (raw as any).num === 'number' ? (raw as any).num : undefined,
+      anonymity: Boolean((raw as any).anonymity ?? (raw as any).isAnonymous ?? false),
+      hasGift: Boolean((raw as any).hasGift ?? (raw as any).gift ?? false),
+      userId: (raw as any).userId ?? (raw as any).user_id ?? undefined,
+      origin: raw,
+    };
+    const signature = `${commentData.no ?? 'none'}|${commentData.userId ?? 'unknown'}|${commentData.comment}`;
+    if (seenSignatures.has(signature)) continue;
+    seenSignatures.add(signature);
+    comments.push({ data: commentData });
+  }
+
+  return comments;
+};

--- a/lib/niconamaCommentClient.ts
+++ b/lib/niconamaCommentClient.ts
@@ -9,10 +9,11 @@ const DEFAULT_VIEWPORT: ViewportSize = {
   width: 1280,
   height: 720,
 };
+const DEFAULT_NICONAMA_USER_ID = process.env.NICONAMA_USER_ID?.trim();
 const DEFAULT_CANDIDATE_URLS = [
   'https://live.nicovideo.jp/',
   'https://live.nicovideo.jp/my',
-  'https://live.nicovideo.jp/watch/user/14171889',
+  ...(DEFAULT_NICONAMA_USER_ID ? [`https://live.nicovideo.jp/watch/user/${DEFAULT_NICONAMA_USER_ID}`] : []),
 ];
 
 export type NiconamaCommentClientOptions = {
@@ -186,7 +187,7 @@ export class NiconamaCommentClient {
         const body = await response.json().catch(() => null);
         if (!body) return;
 
-        const comments = parseAgentCommentsFromResponseBody(body);
+        const comments = parseAgentCommentsFromResponseBody(body, this.#seenCommentSignatures);
         if (comments.length > 0) {
           this.#callbacks.onComments(comments);
         }
@@ -234,7 +235,10 @@ export const createNiconamaCommentClient = (
   callbacks: NiconamaCommentClientCallbacks,
 ): NiconamaCommentClient => new NiconamaCommentClient(options, callbacks);
 
-export const parseAgentCommentsFromResponseBody = (body: unknown): AgentComment[] => {
+export const parseAgentCommentsFromResponseBody = (
+  body: unknown,
+  seenCommentSignatures: Set<string> = new Set<string>(),
+): AgentComment[] => {
   if (!body || typeof body !== 'object') return [];
   const rawComments: unknown[] = [];
   const candidateArrays = [
@@ -257,7 +261,7 @@ export const parseAgentCommentsFromResponseBody = (body: unknown): AgentComment[
   }
 
   const comments: AgentComment[] = [];
-  const seenSignatures = new Set<string>();
+  const seenSignatures = seenCommentSignatures;
 
   for (const raw of rawComments) {
     if (!raw || typeof raw !== 'object') continue;

--- a/tests/e2e/console/console.test.ts
+++ b/tests/e2e/console/console.test.ts
@@ -191,14 +191,6 @@ test.beforeAll(async ({ request }) => {
     throw new Error(`Console server not responding at ${CONSOLE_BASE_URL}: ${String(lastErr)}`);
   }
 
-  // Register the test runner's IP as the allowed IP so that subsequent
-  // requests to the IP-restricted console server are permitted.
-  const allowlistRegistrationResponse = await request.post(`${BROADCASTING_BASE_URL}/`);
-  const allowlistRegistrationResponseText = await allowlistRegistrationResponse.text();
-  expect(
-    allowlistRegistrationResponse.ok(),
-    `Allowlist registration failed with status ${allowlistRegistrationResponse.status()} ${allowlistRegistrationResponse.statusText()}: ${allowlistRegistrationResponseText}`,
-  ).toBeTruthy();
 });
 
 test.afterAll(() => {

--- a/tests/e2e/server.test.ts
+++ b/tests/e2e/server.test.ts
@@ -218,46 +218,16 @@ test.describe("server", () => {
     });
   });
 
-  test("keeps comment-triggered replyTargetComment in /api/meta after stream state is published", async ({ request }) => {
-    const streamStateRes = await request.post(`${BASE_URL}/api/meta`, {
-      data: {
-        type: 'niconama',
-        data: {
-          isLive: true,
-          title: 'reply target propagation',
-          startTime: 1_700_000_000,
-          total: 5,
-          points: { gift: 0, ad: 0 },
-          url: 'https://example.com/reply-target-propagation',
-        },
-      },
-    });
-    expect(streamStateRes.ok()).toBeTruthy();
-
-    const allowIpRes = await request.post(`${BASE_URL}/`);
-    expect(allowIpRes.ok()).toBeTruthy();
-
-    const putCommentRes = await request.put(`${BASE_URL}/`, {
-      data: [{ data: { comment: 'こんばんは', no: 7, anonymity: false, hasGift: false } }],
-    });
-    expect(putCommentRes.ok()).toBeTruthy();
-
-    const metaRes = await request.get(`${BASE_URL}/api/meta`);
-    expect(metaRes.ok()).toBeTruthy();
-    const metaJson = await metaRes.json();
-    expect(metaJson).toHaveProperty('replyTargetComment.text', 'こんばんは');
-    expect(typeof metaJson.replyTargetComment?.pickedTopic).toBe('string');
-    expect(metaJson.replyTargetComment?.pickedTopic.length).toBeGreaterThan(0);
+  test("rejects root POST / after external comment routes are removed", async ({ request }) => {
+    const res = await request.post(`${BASE_URL}/`, { data: {} });
+    expect(res.status()).toBe(404);
   });
 
-  test("accepts PUT / via comment route", async ({ request }) => {
-    const postRes = await request.post(`${BASE_URL}/`);
-    expect(postRes.ok()).toBeTruthy();
-
+  test("rejects root PUT / after external comment routes are removed", async ({ request }) => {
     const res = await request.put(`${BASE_URL}/`, {
       data: [{ data: { comment: 'hello', no: 1, anonymity: false, hasGift: false } }],
     });
-    expect(res.ok()).toBeTruthy();
+    expect(res.status()).toBe(404);
   });
 
   test("serves /nc433974.png", async ({ request }) => {

--- a/tests/integration/console-proxy.test.ts
+++ b/tests/integration/console-proxy.test.ts
@@ -144,10 +144,7 @@ test("proxy forwards WebSocket upgrades to broadcasting server", async () => {
   expect(parsed).toHaveProperty('niconama');
 });
 
-test("comment count in /api/meta reflects PUT comments after POST /api/meta stream state", async () => {
-  // Register the loopback IP so PUT / is accepted.
-  await fetch(`${BROADCASTING_BASE_URL}/`, { method: 'POST', body: '{}', headers: { 'content-type': 'application/json' } });
-
+test("comment count in /api/meta reflects POST /api/meta stream state", async () => {
   const streamStateBody = JSON.stringify({
     type: 'niconama',
     data: {
@@ -160,9 +157,6 @@ test("comment count in /api/meta reflects PUT comments after POST /api/meta stre
     },
   });
 
-  // The external agent (automated-gameplay-transmitter) is loaded asynchronously
-  // after server startup. Retry POST /api/meta until the streamer acknowledges it
-  // by returning a comments count of 0 (rather than undefined).
   let initialMeta: any = null;
   for (let i = 0; i < 30; i++) {
     await fetch(`${BROADCASTING_BASE_URL}/api/meta`, {
@@ -174,26 +168,6 @@ test("comment count in /api/meta reflects PUT comments after POST /api/meta stre
     if (initialMeta.commentCount === 0) break;
     await new Promise(r => setTimeout(r, 100));
   }
-  // Verify the initial comment count is 0 (streamer is now tracking the program).
+
   expect(initialMeta.commentCount).toBe(0);
-
-  // Send a user comment (no > 0 counts as a user comment).
-  await fetch(`${BROADCASTING_BASE_URL}/`, {
-    method: 'PUT',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify([{ data: { comment: 'こんにちは', no: 1, anonymity: false, hasGift: false } }]),
-  });
-
-  // The comment count should now reflect the latest comment number.
-  let updatedMeta = await (await fetch(`${BROADCASTING_BASE_URL}/api/meta`)).json() as any;
-  expect(updatedMeta.commentCount).toBe(1);
-
-  await fetch(`${BROADCASTING_BASE_URL}/`, {
-    method: 'PUT',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify([{ data: { comment: 'こんばんは', no: 3, anonymity: false, hasGift: false } }]),
-  });
-
-  updatedMeta = await (await fetch(`${BROADCASTING_BASE_URL}/api/meta`)).json() as any;
-  expect(updatedMeta.commentCount).toBe(3);
 });


### PR DESCRIPTION
Replace external POST / and PUT / comment ingestion with internal NicoNico comment/meta acquisition. Add a Playwright-based Niconama comment client, remove deprecated root comment routes, and update affected E2E/integration tests. The new implementation discovers a logged-in NicoNico live stream from persisted browser user data and publishes comments/meta internally instead of relying on external client routes.