### PR TITLE
fix(niconama-comment-client): ensure userDataDir exists before launching Playwright

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -10,7 +10,7 @@ mkdir -p "${PID_DIR}"
 
 cd "${PROJECT_ROOT}"
 
-nohup NODE_ENV=production bun start >"${PROJECT_ROOT}/var/screen.log" 2>&1 &
+NODE_ENV=production nohup bun start >"${PROJECT_ROOT}/var/screen.log" 2>&1 &
 echo $! > "${PID_DIR}/screen"
 
 nohup bun ./bin/x/browser.ts >"${PROJECT_ROOT}/var/browser.log" 2>&1 &

--- a/bin/x/obs
+++ b/bin/x/obs
@@ -61,6 +61,4 @@ fi
     --startstreaming \
     --disable-shutdown-check \
     --disable-missing-files-check \
-    --disable-updater \
-    --unfiltered_log \
-    --verbose
+    --disable-updater

--- a/lib/niconamaCommentClient.test.ts
+++ b/lib/niconamaCommentClient.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "bun:test";
-import { parseAgentCommentsFromResponseBody } from "./niconamaCommentClient";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ensureUserDataDirExists, parseAgentCommentsFromResponseBody } from "./niconamaCommentClient";
 
 describe("parseAgentCommentsFromResponseBody", () => {
   it("parses comments from a top-level comments array", () => {
@@ -69,5 +72,33 @@ describe("parseAgentCommentsFromResponseBody", () => {
 
     expect(firstParsed).toHaveLength(1);
     expect(secondParsed).toHaveLength(0);
+  });
+});
+
+describe("ensureUserDataDirExists", () => {
+  it("creates the directory when it does not exist", () => {
+    const path = mkdtempSync(join(tmpdir(), "niconama-user-data-dir-"));
+    const userDataDir = join(path, "auth-profile");
+
+    try {
+      ensureUserDataDirExists(userDataDir);
+      expect(existsSync(userDataDir)).toBe(true);
+    } finally {
+      rmSync(path, { recursive: true, force: true });
+    }
+  });
+
+  it("throws when the path exists but is not a directory", () => {
+    const path = mkdtempSync(join(tmpdir(), "niconama-user-data-dir-"));
+    const filePath = join(path, "auth-profile");
+    writeFileSync(filePath, "not a directory");
+
+    try {
+      expect(() => ensureUserDataDirExists(filePath)).toThrow(
+        `userDataDir must be a directory: ${filePath}`,
+      );
+    } finally {
+      rmSync(path, { recursive: true, force: true });
+    }
   });
 });

--- a/lib/niconamaCommentClient.ts
+++ b/lib/niconamaCommentClient.ts
@@ -1,10 +1,21 @@
-import { existsSync } from "node:fs";
+import { existsSync, mkdirSync, statSync } from "node:fs";
 import { setTimeout } from "node:timers/promises";
 import type { BrowserContext, Page, ViewportSize } from "playwright";
 import { chromium } from "./Browser/chromium";
 import type { AgentComment } from "automated-gameplay-transmitter";
 
 const DEFAULT_USER_DATA_DIR = './playwright/.auth/';
+
+export const ensureUserDataDirExists = (userDataDir: string): void => {
+  if (existsSync(userDataDir)) {
+    if (!statSync(userDataDir).isDirectory()) {
+      throw new Error(`userDataDir must be a directory: ${userDataDir}`);
+    }
+    return;
+  }
+
+  mkdirSync(userDataDir, { recursive: true });
+};
 const DEFAULT_VIEWPORT: ViewportSize = {
   width: 1280,
   height: 720,
@@ -51,9 +62,7 @@ export class NiconamaCommentClient {
     if (this.#running) return;
     this.#stopRequested = false;
 
-    if (!existsSync(this.#userDataDir)) {
-      throw new Error(`userDataDir does not exist: ${this.#userDataDir}`);
-    }
+    ensureUserDataDirExists(this.#userDataDir);
 
     const launchOptions = {
       ...(this.#executablePath ? { executablePath: this.#executablePath } : { channel: 'chromium' }),


### PR DESCRIPTION
Fix Niconama comment client startup by ensuring the Playwright persistent user data directory exists before launching the browser context. Added a helper and tests for path creation and invalid path handling.