### PR TITLE
fix(niconama-comment-client): use reserve.ts Chromium executable path semantics for startup

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -640,7 +640,7 @@ try {
   niconamaCommentClient = createNiconamaCommentClient(
     {
       userDataDir: process.env.NICONAMA_USER_DATA_DIR ?? './playwright/.auth/',
-      executablePath: process.env.CHROMIUM_EXECUTABLE_PATH,
+      executablePath: process.env.CHROMIUM_EXECUTABLE_PATH ?? '/usr/bin/chromium',
       pollIntervalMs: 30_000,
     },
     {

--- a/lib/niconamaCommentClient.ts
+++ b/lib/niconamaCommentClient.ts
@@ -5,6 +5,7 @@ import { chromium } from "./Browser/chromium";
 import type { AgentComment } from "automated-gameplay-transmitter";
 
 const DEFAULT_USER_DATA_DIR = './playwright/.auth/';
+const DEFAULT_CHROMIUM_EXECUTABLE_PATH = '/usr/bin/chromium';
 
 export const ensureUserDataDirExists = (userDataDir: string): void => {
   if (existsSync(userDataDir)) {
@@ -64,8 +65,9 @@ export class NiconamaCommentClient {
 
     ensureUserDataDirExists(this.#userDataDir);
 
+    const executablePath = this.#executablePath ?? DEFAULT_CHROMIUM_EXECUTABLE_PATH;
     const launchOptions = {
-      ...(this.#executablePath ? { executablePath: this.#executablePath } : { channel: 'chromium' }),
+      executablePath,
       headless: true,
       timeout: 60_000,
       args: [


### PR DESCRIPTION
Align Niconama comment client Chromium startup with bin/x/reserve.ts by defaulting to /usr/bin/chromium for persistent Playwright contexts. This avoids Playwright browser cache failures when system Chromium is available.