### PR TITLE
fix: use getByText and nested hover menu lookup for Niconama live page

### DIFF
--- a/lib/niconamaCommentClient.test.ts
+++ b/lib/niconamaCommentClient.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { ensureUserDataDirExists, parseAgentCommentsFromResponseBody } from "./niconamaCommentClient";
+import { ensureUserDataDirExists, findNiconamaLiveUrlByHovering, parseAgentCommentsFromResponseBody } from "./niconamaCommentClient";
 
 describe("parseAgentCommentsFromResponseBody", () => {
   it("parses comments from a top-level comments array", () => {
@@ -100,5 +100,50 @@ describe("ensureUserDataDirExists", () => {
     } finally {
       rmSync(path, { recursive: true, force: true });
     }
+  });
+});
+
+describe("findNiconamaLiveUrlByHovering", () => {
+  it("uses exact 馬可無序 and 放送中のページ text selectors to resolve the live URL", async () => {
+    const livePageLocator = {
+      waitFor: async ({ state }: { state: string }) => {
+        expect(state).toBe("visible");
+      },
+      getAttribute: async (name: string) => {
+        expect(name).toBe("href");
+        return "/watch/lv350505943";
+      },
+      first: function () { return this; },
+    } as any;
+
+    const userAnchor = {
+      waitFor: async ({ state }: { state: string }) => {
+        expect(state).toBe("visible");
+      },
+      hover: async () => undefined,
+      getByText: (text: string, options: { exact: boolean }) => {
+        expect(options.exact).toBe(true);
+        if (text === "放送中のページ") {
+          return livePageLocator;
+        }
+        throw new Error(`Unexpected nested getByText text: ${text}`);
+      },
+      first: function () { return this; },
+    } as any;
+
+    const page = {
+      url: () => "https://live.nicovideo.jp/",
+      getByText: (text: string, options: { exact: boolean }) => {
+        expect(options.exact).toBe(true);
+        if (text === "馬可無序") {
+          return userAnchor;
+        }
+        throw new Error(`Unexpected page getByText text: ${text}`);
+      },
+    } as any;
+
+    const liveUrl = await findNiconamaLiveUrlByHovering(page);
+
+    expect(liveUrl).toBe("/watch/lv350505943");
   });
 });

--- a/lib/niconamaCommentClient.ts
+++ b/lib/niconamaCommentClient.ts
@@ -166,16 +166,9 @@ export class NiconamaCommentClient {
 
       await this.#page.goto('https://live.nicovideo.jp/', { waitUntil: 'domcontentloaded' });
 
-      const userAnchor = this.#page.locator('text=馬可無序').first();
-      await userAnchor.waitFor({ state: 'visible', timeout: 15_000 });
-      await userAnchor.hover();
-
-      const livePageLocator = this.#page.locator('text=放送中のページ').first();
-      await livePageLocator.waitFor({ state: 'visible', timeout: 15_000 });
-
-      const livePageUrl = await livePageLocator.getAttribute('href');
+      const livePageUrl = await findNiconamaLiveUrlByHovering(this.#page);
       if (!livePageUrl) {
-        throw new Error('Could not find 放送中のページ href after hovering 馬可無序');
+        return null;
       }
 
       const absoluteLivePageUrl = new URL(livePageUrl, this.#page.url()).href;
@@ -261,6 +254,22 @@ export class NiconamaCommentClient {
     }
   }
 }
+
+export const findNiconamaLiveUrlByHovering = async (page: Page): Promise<string> => {
+  const userAnchor = page.getByText('馬可無序', { exact: true }).first();
+  await userAnchor.waitFor({ state: 'visible', timeout: 15_000 });
+  await userAnchor.hover();
+
+  const livePageLocator = userAnchor.getByText('放送中のページ', { exact: true }).first();
+  await livePageLocator.waitFor({ state: 'visible', timeout: 15_000 });
+
+  const livePageUrl = await livePageLocator.getAttribute('href');
+  if (!livePageUrl) {
+    throw new Error('Could not find 放送中のページ href after hovering 馬可無序');
+  }
+
+  return livePageUrl;
+};
 
 export const createNiconamaCommentClient = (
   options: NiconamaCommentClientOptions,


### PR DESCRIPTION
- Refactor Niconama root page selection to use Playwright getByText with exact text matching\n- Search for '放送中のページ' within the hovered '馬可無序' anchor menu\n- Add unit test for nested getByText locator behavior\n- Verified with bun test and typecheck