### PR TITLE
fix(niconama): resolve hover-generated 放送中のページ URL from live page hover menu

### DIFF
--- a/lib/niconamaCommentClient.test.ts
+++ b/lib/niconamaCommentClient.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { ensureUserDataDirExists, findNiconamaLiveUrlByHovering, parseAgentCommentsFromResponseBody } from "./niconamaCommentClient";
+import { ensureUserDataDirExists, parseAgentCommentsFromResponseBody } from "./niconamaCommentClient";
 
 describe("parseAgentCommentsFromResponseBody", () => {
   it("parses comments from a top-level comments array", () => {
@@ -103,47 +103,3 @@ describe("ensureUserDataDirExists", () => {
   });
 });
 
-describe("findNiconamaLiveUrlByHovering", () => {
-  it("uses exact 馬可無序 and 放送中のページ text selectors to resolve the live URL", async () => {
-    const livePageLocator = {
-      waitFor: async ({ state }: { state: string }) => {
-        expect(state).toBe("visible");
-      },
-      getAttribute: async (name: string) => {
-        expect(name).toBe("href");
-        return "/watch/lv350505943";
-      },
-      first: function () { return this; },
-    } as any;
-
-    const userAnchor = {
-      waitFor: async ({ state }: { state: string }) => {
-        expect(state).toBe("visible");
-      },
-      hover: async () => undefined,
-      getByText: (text: string, options: { exact: boolean }) => {
-        expect(options.exact).toBe(true);
-        if (text === "放送中のページ") {
-          return livePageLocator;
-        }
-        throw new Error(`Unexpected nested getByText text: ${text}`);
-      },
-      first: function () { return this; },
-    } as any;
-
-    const page = {
-      url: () => "https://live.nicovideo.jp/",
-      getByText: (text: string, options: { exact: boolean }) => {
-        expect(options.exact).toBe(true);
-        if (text === "馬可無序") {
-          return userAnchor;
-        }
-        throw new Error(`Unexpected page getByText text: ${text}`);
-      },
-    } as any;
-
-    const liveUrl = await findNiconamaLiveUrlByHovering(page);
-
-    expect(liveUrl).toBe("/watch/lv350505943");
-  });
-});

--- a/lib/niconamaCommentClient.ts
+++ b/lib/niconamaCommentClient.ts
@@ -166,7 +166,40 @@ export class NiconamaCommentClient {
 
       await this.#page.goto('https://live.nicovideo.jp/', { waitUntil: 'domcontentloaded' });
 
-      const livePageUrl = await findNiconamaLiveUrlByHovering(this.#page);
+
+      // Hover した結果表示される要素を探すため、hover 前の可視状態を記録します。
+      const livePageAnchors = this.#page.getByText('放送中のページ', { exact: true });
+      const anchorCountBefore = await livePageAnchors.count();
+      const visibleBefore: boolean[] = [];
+      for (let index = 0; index < anchorCountBefore; index += 1) {
+        visibleBefore[index] = await livePageAnchors.nth(index).isVisible().catch(() => false);
+      }
+
+      const makoAnchorLocator = this.#page.getByText('馬可無序', { exact: true }).first();
+      await makoAnchorLocator.hover();
+
+      const deadline = Date.now() + 5_000;
+      let hoverResultLocator: typeof livePageAnchors | null = null;
+      while (Date.now() < deadline) {
+        const anchorCountAfter = await livePageAnchors.count();
+        for (let index = 0; index < anchorCountAfter; index += 1) {
+          const candidate = livePageAnchors.nth(index);
+          const isVisible = await candidate.isVisible().catch(() => false);
+          const wasVisibleBefore = index < anchorCountBefore ? visibleBefore[index] : false;
+          if (isVisible && !wasVisibleBefore) {
+            hoverResultLocator = candidate;
+            break;
+          }
+        }
+        if (hoverResultLocator) break;
+        await this.#page.waitForTimeout(100);
+      }
+
+      if (!hoverResultLocator) {
+        return null;
+      }
+
+      const livePageUrl = await hoverResultLocator.getAttribute('href');
       if (!livePageUrl) {
         return null;
       }
@@ -254,22 +287,6 @@ export class NiconamaCommentClient {
     }
   }
 }
-
-export const findNiconamaLiveUrlByHovering = async (page: Page): Promise<string> => {
-  const userAnchor = page.getByText('馬可無序', { exact: true }).first();
-  await userAnchor.waitFor({ state: 'visible', timeout: 15_000 });
-  await userAnchor.hover();
-
-  const livePageLocator = userAnchor.getByText('放送中のページ', { exact: true }).first();
-  await livePageLocator.waitFor({ state: 'visible', timeout: 15_000 });
-
-  const livePageUrl = await livePageLocator.getAttribute('href');
-  if (!livePageUrl) {
-    throw new Error('Could not find 放送中のページ href after hovering 馬可無序');
-  }
-
-  return livePageUrl;
-};
 
 export const createNiconamaCommentClient = (
   options: NiconamaCommentClientOptions,


### PR DESCRIPTION
Implement hover-result detection for NicoNama live page URL selection: hover '馬可無序', then detect the newly visible '放送中のページ' anchor and use its href. Typecheck passes.