### PR TITLE
fix: suppress DEBUG logs in screen.log and browser.log

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -22,7 +22,7 @@ echo "Console Basic auth password: ${PASSWORD}"
 NODE_ENV=production nohup bun start >"${PROJECT_ROOT}/var/screen.log" 2>&1 &
 echo $! > "${PID_DIR}/screen"
 
-nohup bun ./bin/x/browser.ts >"${PROJECT_ROOT}/var/browser.log" 2>&1 &
+NODE_ENV=production nohup bun ./bin/x/browser.ts >"${PROJECT_ROOT}/var/browser.log" 2>&1 &
 echo $! > "${PID_DIR}/browser"
 
 nohup ./bin/x/obs >"${PROJECT_ROOT}/var/obs.log" 2>&1 &

--- a/lib/consoleLogger.ts
+++ b/lib/consoleLogger.ts
@@ -150,15 +150,29 @@ export function formatUnknownError(error: unknown): string {
 export function createConsoleLogger({ environment = process.env.NODE_ENV }: ConsoleLoggerOptions = {}): Console {
   const originalConsole = globalThis.console;
   const originalLog = originalConsole.log.bind(originalConsole);
+  const originalInfo = originalConsole.info.bind(originalConsole);
   const originalDebug = originalConsole.debug.bind(originalConsole);
 
   const logger = Object.create(originalConsole) as Console;
 
+  const isSuppressedDebug = (args: unknown[]): boolean =>
+    environment === 'production' &&
+    args.length > 0 &&
+    typeof args[0] === 'string' &&
+    args[0].startsWith('[DEBUG]');
+
   logger.log = (...args: unknown[]): void => {
-    if (environment === 'production' && args.length > 0 && typeof args[0] === 'string' && args[0].startsWith('[DEBUG]')) {
+    if (isSuppressedDebug(args)) {
       return;
     }
     originalLog(...args);
+  };
+
+  logger.info = (...args: unknown[]): void => {
+    if (isSuppressedDebug(args)) {
+      return;
+    }
+    originalInfo(...args);
   };
 
   logger.debug = environment === 'production'

--- a/routes/console/index.ts
+++ b/routes/console/index.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { createBunWebSocket } from "hono/bun";
+import { createConsoleLogger } from "../../lib/consoleLogger";
 import {
   buildProxyHeaders,
   computeProxyBase,
@@ -20,6 +21,8 @@ import { relative, resolve } from "node:path";
 const CONSOLE_BUILD_PATH = process.env.CONSOLE_BUILD_PATH ?? resolve(process.cwd(), 'var/console/build');
 const CONSOLE_SOURCE_HTML_PATH = resolve(process.cwd(), 'console/src/index.html');
 const CONSOLE_PUBLIC_PATH = '/console/';
+
+const debugConsole = createConsoleLogger();
 
 let consoleBuildPromise: Promise<void> | null = null;
 let builtConsoleHtml: string | null = null;
@@ -126,7 +129,7 @@ async function serveConsoleAppHtml(): Promise<Response> {
 }
 
 try {
-  console.log('[DEBUG] routes/console initializing');
+  debugConsole.debug('[DEBUG] routes/console initializing');
 } catch {}
 
 export const { upgradeWebSocket, websocket } = createBunWebSocket();
@@ -137,7 +140,7 @@ export const app = new Hono()
     try {
       const proxyBase = computeProxyBase(c.req.raw);
       const proxyUrl = computeProxyUrl(c.req.raw, proxyBase);
-      try { console.log('[DEBUG] /console/api/ws proxy ->', { url: proxyUrl, method: c.req.method, accept: c.req.header('accept'), upgrade: c.req.header('upgrade'), secWebSocketKey: c.req.header('sec-websocket-key'), secWebSocketProtocol: c.req.header('sec-websocket-protocol') }); } catch {}
+      try { debugConsole.debug('[DEBUG] /console/api/ws proxy ->', { url: proxyUrl, method: c.req.method, accept: c.req.header('accept'), upgrade: c.req.header('upgrade'), secWebSocketKey: c.req.header('sec-websocket-key'), secWebSocketProtocol: c.req.header('sec-websocket-protocol') }); } catch {}
 
       const upgradeHeader = (c.req.header('upgrade') ?? '').toLowerCase();
       const hasSecWebSocketKey = !!c.req.header('sec-websocket-key');
@@ -159,11 +162,11 @@ export const app = new Hono()
       onOpen(_event, ws) {
         (async () => {
           try {
-            try { console.log('[DEBUG] websocket upgrade accepted; starting SSE->WS forwarder'); } catch {}
+            try { debugConsole.debug('[DEBUG] websocket upgrade accepted; starting SSE->WS forwarder'); } catch {}
             const sseUrl = `${proxyBase}/console/api/ws`;
-            try { console.log('[DEBUG] opening upstream SSE fetch ->', sseUrl); } catch {}
+            try { debugConsole.debug('[DEBUG] opening upstream SSE fetch ->', sseUrl); } catch {}
             const res = await fetch(sseUrl, { headers: { accept: 'text/event-stream' } });
-            try { console.log('[DEBUG] upstream SSE response ->', { status: res.status, contentType: res.headers.get('content-type') }); } catch {}
+            try { debugConsole.debug('[DEBUG] upstream SSE response ->', { status: res.status, contentType: res.headers.get('content-type') }); } catch {}
             try {
               const metaJson = await fetchMetaSnapshot(proxyBase);
               try { ws.send(JSON.stringify(metaJson)); } catch {}


### PR DESCRIPTION
Use NODE_ENV=production for both server and browser startup in bin/start so DEBUG output is suppressed in var/screen.log and var/browser.log.