### PR TITLE
fix: suppress DEBUG logs in screen.log and browser.log

### DIFF
--- a/bootstrap.ts
+++ b/bootstrap.ts
@@ -1,0 +1,8 @@
+import { installConsoleLogger } from "./lib/consoleLogger";
+
+installConsoleLogger();
+
+// Ensure the main server entrypoint is loaded after the global console has
+// been replaced so that all modules and runtime code in this process use the
+// production-suppressed console implementation.
+import "./index.ts";

--- a/index.ts
+++ b/index.ts
@@ -21,9 +21,9 @@ import { handleCatchAll } from "./src/frontendServer";
 import { compileTailwindCss, createCssResponse } from "./lib/tailwind";
 import { normalizePublishedStreamState } from "./lib/streamState";
 import { createNiconamaCommentClient, type NiconamaCommentClient } from "./lib/niconamaCommentClient";
-import { createConsoleLogger } from "./lib/consoleLogger";
+import { installConsoleLogger } from "./lib/consoleLogger";
 
-const console = createConsoleLogger();
+const console = installConsoleLogger();
 
 process.on('exit', exitHandler.bind(null, { cleanup: true }));
 process.on('SIGINT', signalHandler.bind(null, { exit: true }));
@@ -537,12 +537,10 @@ const makeStreamHandler = (label: string) =>
     return new Response('websocket upgrade unavailable', { status: 501 });
   };
 
-// mainServer is assigned synchronously via `const server = mainServer = serve(...)`
-// below. Route handlers only run when requests arrive (after the event-loop
-// yields), so mainServer is always defined by the time a handler executes.
-// The non-null assertion (!) is therefore safe; the runtime check below
-// provides an extra guard for unexpected scenarios.
-let mainServer!: Bun.Server<WsData>;
+// mainServer is assigned synchronously after `serve()` returns.
+// The runtime check below guards against uninitialized access when startup
+// fails before the server is fully constructed.
+let mainServer: Bun.Server<WsData> | null = null;
 
 const getMainServer = (): Bun.Server<WsData> => {
   if (!mainServer) throw new Error('Server not yet initialized');
@@ -570,7 +568,7 @@ const mainApp = new Hono()
   // Serve the built frontend (HTML + JS/CSS assets)
   .all('*', async (c) => handleCatchAll(c.req.raw));
 
-const server = mainServer = serve<WsData>({
+const server = serve<WsData>({
   port: portNumber,
   async fetch(req: Request, server: Bun.Server<WsData>) {
     const url = new URL(req.url);

--- a/lib/consoleLogger.ts
+++ b/lib/consoleLogger.ts
@@ -183,3 +183,9 @@ export function createConsoleLogger({ environment = process.env.NODE_ENV }: Cons
 
   return logger;
 }
+
+export function installConsoleLogger(options: ConsoleLoggerOptions = {}): Console {
+  const logger = createConsoleLogger(options);
+  globalThis.console = logger;
+  return logger;
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "dev": "bun --hot index.ts --port=8777",
     "setup": "bun --version && bun ci && bun run typecheck",
-    "start": "NODE_ENV=production bun index.ts --port=7777",
+    "start": "NODE_ENV=production bun bootstrap.ts --port=7777",
     "typecheck": "tsc --noEmit",
     "test": "bun test lib/ src/ routes/ console/src/",
     "test:integration": "bun test tests/integration/",

--- a/routes/console/index.ts
+++ b/routes/console/index.ts
@@ -1,6 +1,5 @@
 import { Hono } from "hono";
 import { createBunWebSocket } from "hono/bun";
-import { createConsoleLogger } from "../../lib/consoleLogger";
 import {
   buildProxyHeaders,
   computeProxyBase,
@@ -21,8 +20,6 @@ import { relative, resolve } from "node:path";
 const CONSOLE_BUILD_PATH = process.env.CONSOLE_BUILD_PATH ?? resolve(process.cwd(), 'var/console/build');
 const CONSOLE_SOURCE_HTML_PATH = resolve(process.cwd(), 'console/src/index.html');
 const CONSOLE_PUBLIC_PATH = '/console/';
-
-const debugConsole = createConsoleLogger();
 
 let consoleBuildPromise: Promise<void> | null = null;
 let builtConsoleHtml: string | null = null;
@@ -129,7 +126,7 @@ async function serveConsoleAppHtml(): Promise<Response> {
 }
 
 try {
-  debugConsole.debug('[DEBUG] routes/console initializing');
+  console.debug('[DEBUG] routes/console initializing');
 } catch {}
 
 export const { upgradeWebSocket, websocket } = createBunWebSocket();
@@ -140,7 +137,7 @@ export const app = new Hono()
     try {
       const proxyBase = computeProxyBase(c.req.raw);
       const proxyUrl = computeProxyUrl(c.req.raw, proxyBase);
-      try { debugConsole.debug('[DEBUG] /console/api/ws proxy ->', { url: proxyUrl, method: c.req.method, accept: c.req.header('accept'), upgrade: c.req.header('upgrade'), secWebSocketKey: c.req.header('sec-websocket-key'), secWebSocketProtocol: c.req.header('sec-websocket-protocol') }); } catch {}
+      try { console.debug('[DEBUG] /console/api/ws proxy ->', { url: proxyUrl, method: c.req.method, accept: c.req.header('accept'), upgrade: c.req.header('upgrade'), secWebSocketKey: c.req.header('sec-websocket-key'), secWebSocketProtocol: c.req.header('sec-websocket-protocol') }); } catch {}
 
       const upgradeHeader = (c.req.header('upgrade') ?? '').toLowerCase();
       const hasSecWebSocketKey = !!c.req.header('sec-websocket-key');
@@ -162,11 +159,11 @@ export const app = new Hono()
       onOpen(_event, ws) {
         (async () => {
           try {
-            try { debugConsole.debug('[DEBUG] websocket upgrade accepted; starting SSE->WS forwarder'); } catch {}
+            try { console.debug('[DEBUG] websocket upgrade accepted; starting SSE->WS forwarder'); } catch {}
             const sseUrl = `${proxyBase}/console/api/ws`;
-            try { debugConsole.debug('[DEBUG] opening upstream SSE fetch ->', sseUrl); } catch {}
+            try { console.debug('[DEBUG] opening upstream SSE fetch ->', sseUrl); } catch {}
             const res = await fetch(sseUrl, { headers: { accept: 'text/event-stream' } });
-            try { debugConsole.debug('[DEBUG] upstream SSE response ->', { status: res.status, contentType: res.headers.get('content-type') }); } catch {}
+            try { console.debug('[DEBUG] upstream SSE response ->', { status: res.status, contentType: res.headers.get('content-type') }); } catch {}
             try {
               const metaJson = await fetchMetaSnapshot(proxyBase);
               try { ws.send(JSON.stringify(metaJson)); } catch {}


### PR DESCRIPTION
Rebased onto origin/main and installed the global production console logger before loading index.ts so DEBUG logs are suppressed across all modules.