### PR TITLE
fix(niconama): log initial websocket establish event at INFO

### DIFF
--- a/lib/niconamaCommentClient.ts
+++ b/lib/niconamaCommentClient.ts
@@ -178,7 +178,7 @@ export class NiconamaCommentClient {
       this.#directWebSocket = ws;
 
       ws.onopen = () => {
-        console.debug('[DEBUG] direct websocket open', webSocketUrl);
+        console.info('[INFO] direct websocket established', webSocketUrl);
       };
 
       ws.onmessage = (event: { data: unknown }) => {


### PR DESCRIPTION
Add INFO-level logging for the initial direct NicoNico websocket establishment in lib/niconamaCommentClient.ts. This makes successful initial websocket connections visible while retaining WARN logging for errors and close events.