### PR TITLE
fix: resolve NicoNico watch URL from top page via Playwright

### DIFF
--- a/bin/x/reserve.ts
+++ b/bin/x/reserve.ts
@@ -2,7 +2,7 @@
 
 import { statSync } from "node:fs";
 import { parseArgs } from "node:util";
-import { chromium } from "../../lib/Browser/chromium";
+import { DEFAULT_PLAYWRIGHT_USER_DATA_DIR, DEFAULT_CHROMIUM_EXECUTABLE_PATH, launchPersistentContext } from "../../lib/Browser/chromium";
 
 const { values: {
   'user-data-dir': userDataDir,
@@ -12,11 +12,11 @@ const { values: {
   options: {
     'user-data-dir': {
       type: 'string',
-      default: './playwright/.auth/',
+      default: DEFAULT_PLAYWRIGHT_USER_DATA_DIR,
     },
     'exec-path': {
       type: 'string',
-      default: '/usr/bin/chromium',
+      default: DEFAULT_CHROMIUM_EXECUTABLE_PATH,
     },
     headless: {
       short: 'y',
@@ -30,7 +30,7 @@ if (!statSync(userDataDir).isDirectory()) {
   throw new Error('--user-data-dir must be a directory path');
 }
 
-const ctx = await chromium.launchPersistentContext(userDataDir, {
+const ctx = await launchPersistentContext(userDataDir, {
   executablePath,
   headless,
 });

--- a/lib/Browser/chromium.ts
+++ b/lib/Browser/chromium.ts
@@ -8,6 +8,33 @@ import StealthPlugin from "puppeteer-extra-plugin-stealth";
 
 export const chromium = $_.use(StealthPlugin());
 
+export const DEFAULT_PLAYWRIGHT_USER_DATA_DIR = './playwright/.auth/';
+export const DEFAULT_CHROMIUM_EXECUTABLE_PATH = '/usr/bin/chromium';
+
+export const launchPersistentContext = async (
+  userDataDir: string,
+  options: Record<string, unknown> = {},
+) => {
+  const launchTimeout = Number.parseInt(process.env.CHROMIUM_LAUNCH_TIMEOUT ?? '60000', 10);
+  const args = [
+    '--hide-scrollbars',
+    '--window-size=1024,576',
+    '--window-position=1280,600',
+    '--no-sandbox',
+    '--disable-setuid-sandbox',
+    ...(Array.isArray(options.args) ? (options.args as string[]) : []),
+  ];
+  const launchOpts = {
+    ...options,
+    executablePath: options.executablePath ?? DEFAULT_CHROMIUM_EXECUTABLE_PATH,
+    headless: options.headless ?? process.env.CHROMIUM_HEADLESS === '1',
+    timeout: launchTimeout,
+    args,
+  };
+
+  return chromium.launchPersistentContext(userDataDir, launchOpts as any);
+};
+
 export const create = async (
   executablePath?: string,
   viewport: ViewportSize = {

--- a/lib/niconamaCommentClient.test.ts
+++ b/lib/niconamaCommentClient.test.ts
@@ -2,7 +2,35 @@ import { describe, expect, it } from "bun:test";
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { ensureUserDataDirExists, hasCommentArrayStructure, parseAgentCommentsFromResponseBody } from "./niconamaCommentClient";
+import {
+  ensureUserDataDirExists,
+  extractWatchUrlFromHtml,
+  hasCommentArrayStructure,
+  parseAgentCommentsFromResponseBody,
+} from "./niconamaCommentClient";
+
+describe("extractWatchUrlFromHtml", () => {
+  it("extracts relative /watch URLs from anchor tags", () => {
+    const html = '<a href="/watch/lv123456">Watch</a>';
+    expect(extractWatchUrlFromHtml(html, 'https://live.nicovideo.jp/')).toBe(
+      'https://live.nicovideo.jp/watch/lv123456',
+    );
+  });
+
+  it("extracts watchPageUrl values from JSON-like HTML", () => {
+    const html = '...&quot;watchPageUrl&quot;:&quot;https://live.nicovideo.jp/watch/lv350350266?ref=TopPage-RecommendedProgramListSection-PlayerProgramCard&quot;...';
+    expect(extractWatchUrlFromHtml(html, 'https://live.nicovideo.jp/')).toBe(
+      'https://live.nicovideo.jp/watch/lv350350266?ref=TopPage-RecommendedProgramListSection-PlayerProgramCard',
+    );
+  });
+
+  it("extracts watchPageUrlAtExtPlayer values from JSON-like HTML", () => {
+    const html = '..."watchPageUrlAtExtPlayer":"https://ext.live.nicovideo.jp/watch/lv350350266"...';
+    expect(extractWatchUrlFromHtml(html, 'https://live.nicovideo.jp/')).toBe(
+      'https://ext.live.nicovideo.jp/watch/lv350350266',
+    );
+  });
+});
 
 describe("parseAgentCommentsFromResponseBody", () => {
   it("parses comments from a top-level comments array", () => {

--- a/lib/niconamaCommentClient.ts
+++ b/lib/niconamaCommentClient.ts
@@ -1,8 +1,8 @@
 import { existsSync, mkdirSync, statSync } from "node:fs";
 import { setTimeout } from "node:timers/promises";
 import type { AgentComment } from "automated-gameplay-transmitter";
+import { DEFAULT_PLAYWRIGHT_USER_DATA_DIR, DEFAULT_CHROMIUM_EXECUTABLE_PATH, launchPersistentContext } from "./Browser/chromium";
 
-const DEFAULT_USER_DATA_DIR = './niconama/.auth/';
 const DEFAULT_POLL_INTERVAL_MS = 30_000;
 const DEFAULT_WATCH_PAGE_BASE_URL = 'https://live.nicovideo.jp/';
 
@@ -69,6 +69,7 @@ type NiconamaCommentClientCallbacks = {
 export class NiconamaCommentClient {
   #userDataDir: string;
   #watchUrl?: string;
+  #executablePath?: string;
   #pollIntervalMs: number;
   #running = false;
   #stopRequested = false;
@@ -79,8 +80,9 @@ export class NiconamaCommentClient {
   #callbacks: NiconamaCommentClientCallbacks;
 
   constructor(options: NiconamaCommentClientOptions, callbacks: NiconamaCommentClientCallbacks) {
-    this.#userDataDir = options.userDataDir ?? DEFAULT_USER_DATA_DIR;
+    this.#userDataDir = options.userDataDir ?? DEFAULT_PLAYWRIGHT_USER_DATA_DIR;
     this.#watchUrl = options.watchUrl;
+    this.#executablePath = options.executablePath ?? DEFAULT_CHROMIUM_EXECUTABLE_PATH;
     this.#pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
     this.#callbacks = callbacks;
   }
@@ -139,6 +141,13 @@ export class NiconamaCommentClient {
       return candidateUrl;
     }
 
+    if (candidateUrl === DEFAULT_WATCH_PAGE_BASE_URL) {
+      const watchUrl = await this.resolveWatchUrlFromNiconamaTopPage();
+      if (watchUrl) {
+        return watchUrl;
+      }
+    }
+
     console.debug('[DEBUG] resolveWatchUrl fetching candidate page', candidateUrl);
     try {
       const html = await this.fetchHtml(candidateUrl);
@@ -165,6 +174,58 @@ export class NiconamaCommentClient {
       throw new Error(`failed to fetch ${url}: ${response.status}`);
     }
     return await response.text();
+  }
+
+  private async resolveWatchUrlFromNiconamaTopPage(): Promise<string | null> {
+    console.debug('[DEBUG] resolveWatchUrlWithPlaywright opening Niconama top page', DEFAULT_WATCH_PAGE_BASE_URL);
+    const context = await launchPersistentContext(this.#userDataDir, {
+      executablePath: this.#executablePath,
+      headless: true,
+      ignoreHTTPSErrors: true,
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+    });
+
+    try {
+      const page = context.pages()[0] ?? await context.newPage();
+      await page.goto(DEFAULT_WATCH_PAGE_BASE_URL, { waitUntil: 'networkidle', timeout: 60_000 });
+      const target = page.getByText('馬可無序').first();
+      try {
+        await target.waitFor({ state: 'visible', timeout: 15_000 });
+        await target.hover({ timeout: 15_000 });
+      } catch (hoverErr) {
+        console.warn('[WARN] failed to hover target element', hoverErr);
+      }
+      await page.waitForTimeout(1_500);
+
+      const broadcastLink = page.locator('a:has-text("放送中のページ")').first();
+      if (await broadcastLink.count() > 0) {
+        const href = await broadcastLink.getAttribute('href');
+        if (href) {
+          return new URL(href, DEFAULT_WATCH_PAGE_BASE_URL).href;
+        }
+      }
+
+      const fallbackLink = page.locator('a[href*="/watch/"]', { hasText: '放送中のページ' }).first();
+      if (await fallbackLink.count() > 0) {
+        const href = await fallbackLink.getAttribute('href');
+        if (href) {
+          return new URL(href, DEFAULT_WATCH_PAGE_BASE_URL).href;
+        }
+      }
+
+      const anyWatchLink = page.locator('a[href*="/watch/"]').first();
+      if (await anyWatchLink.count() > 0) {
+        const href = await anyWatchLink.getAttribute('href');
+        if (href) {
+          return new URL(href, DEFAULT_WATCH_PAGE_BASE_URL).href;
+        }
+      }
+
+      console.warn('[WARN] failed to resolve watch URL via Playwright', DEFAULT_WATCH_PAGE_BASE_URL);
+      return null;
+    } finally {
+      await context.close();
+    }
   }
 
   private async fetchEmbeddedDataFromPage(watchUrl: string): Promise<unknown | null> {

--- a/lib/niconamaCommentClient.ts
+++ b/lib/niconamaCommentClient.ts
@@ -21,6 +21,38 @@ export const ensureUserDataDirExists = (userDataDir: string): void => {
   mkdirSync(userDataDir, { recursive: true });
 };
 
+export const normalizeHtmlForUrlExtraction = (html: string): string =>
+  html
+    .replace(/&quot;/g, '"')
+    .replace(/&amp;/g, '&')
+    .replace(/&#x2F;/g, '/')
+    .replace(/&#x27;/g, "'")
+    .replace(/&#34;/g, '"')
+    .replace(/&#39;/g, "'");
+
+export const extractWatchUrlFromHtml = (html: string, baseUrl: string): string | null => {
+  const normalizedHtml = normalizeHtmlForUrlExtraction(html);
+  const patterns = [
+    /["'](https?:\/\/(?:ext\.)?live\.nicovideo\.jp\/watch\/(?:lv|user)[^"']+)["']/i,
+    /["'](\/watch\/(?:lv|user)[^"']+)["']/i,
+    /watchPageUrl[^"']*["']([^"']*\/watch\/(?:lv|user)[^"']*)["']/i,
+    /programWatchPageUrl[^"']*["']([^"']*\/watch\/(?:lv|user)[^"']*)["']/i,
+    /watchPageUrlAtExtPlayer[^"']*["']([^"']*\/watch\/(?:lv|user)[^"']*)["']/i,
+  ] as const;
+
+  for (const pattern of patterns) {
+    const match = normalizedHtml.match(pattern);
+    if (!match) continue;
+    try {
+      return new URL(match[1]!, baseUrl).href;
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+};
+
 export type NiconamaCommentClientOptions = {
   userDataDir?: string;
   executablePath?: string;
@@ -110,12 +142,12 @@ export class NiconamaCommentClient {
     console.debug('[DEBUG] resolveWatchUrl fetching candidate page', candidateUrl);
     try {
       const html = await this.fetchHtml(candidateUrl);
-      const match = html.match(/href=["'](\/watch\/(?:lv|user)[^"']+)["']/i);
-      if (!match) {
+      const watchUrl = extractWatchUrlFromHtml(html, candidateUrl);
+      if (!watchUrl) {
         console.warn('[WARN] failed to resolve watch URL from HTML', candidateUrl);
         return null;
       }
-      return new URL(match[1]!, candidateUrl).href;
+      return watchUrl;
     } catch (err) {
       this.reportError(err);
       return null;


### PR DESCRIPTION
Use Playwright in lib/niconamaCommentClient.ts to resolve the NicoNico watch URL from the live.nicovideo.jp top page by hovering 馬可無序 and extracting the 放送中のページ link. Also share Chromium launch defaults and persistent context creation in lib/Browser/chromium.ts with bin/x/reserve.ts.