### PR TITLE
fix: change TRACE logs to DEBUG logs

### DIFF
--- a/console/src/AgentStatus/AgentStatus.tsx
+++ b/console/src/AgentStatus/AgentStatus.tsx
@@ -71,7 +71,7 @@ export const AgentStatus = () => {
     (async () => {
       const sseUrl = "/console/api/ws";
       try { (window as any).__sseUrl = sseUrl; } catch {}
-      try { console.log("[TRACE] AgentStatus connecting EventSource ->", sseUrl); } catch {}
+      try { console.debug("[DEBUG] AgentStatus connecting EventSource ->", sseUrl); } catch {}
       try {
         es = new EventSource(sseUrl);
       } catch {

--- a/index.ts
+++ b/index.ts
@@ -581,6 +581,7 @@ const server = serve<WsData>({
       const label = url.pathname;
       try { console.debug(`[DEBUG] ${label} handler invoked, accept=`, accept, 'upgrade=', req.headers.get('upgrade')); } catch { }
       const upgraded = server.upgrade(req, { data: { label } satisfies WsData });
+      if (upgraded) {
         // undefined signals Bun that the connection was upgraded to WebSocket
         // and no HTTP response should be sent back.
         return undefined;

--- a/index.ts
+++ b/index.ts
@@ -523,7 +523,7 @@ function getMainAssetContentType(filePath: string): string | undefined {
 const makeStreamHandler = (label: string) =>
   (req: Request): Response => {
     const accept = req.headers.get('accept') ?? '';
-    try { console.log(`[TRACE] ${label} handler invoked, accept=`, accept, 'upgrade=', req.headers.get('upgrade')); } catch { }
+    try { console.debug(`[DEBUG] ${label} handler invoked, accept=`, accept, 'upgrade=', req.headers.get('upgrade')); } catch { }
     if (accept.includes('text/event-stream')) {
       return new Response(createSseStream(label), {
         headers: {
@@ -579,9 +579,8 @@ const server = serve<WsData>({
 
     if (isWsEndpoint && !accept.includes('text/event-stream') && !forceDisableWs) {
       const label = url.pathname;
-      try { console.log(`[TRACE] ${label} handler invoked, accept=`, accept, 'upgrade=', req.headers.get('upgrade')); } catch { }
+      try { console.debug(`[DEBUG] ${label} handler invoked, accept=`, accept, 'upgrade=', req.headers.get('upgrade')); } catch { }
       const upgraded = server.upgrade(req, { data: { label } satisfies WsData });
-      if (upgraded) {
         // undefined signals Bun that the connection was upgraded to WebSocket
         // and no HTTP response should be sent back.
         return undefined;

--- a/routes/console/index.ts
+++ b/routes/console/index.ts
@@ -133,7 +133,7 @@ export const { upgradeWebSocket, websocket } = createBunWebSocket();
 
 export const app = new Hono()
   .get('/console/api/ws', async (c, next) => {
-    try { console.log('[TRACE] incoming request headers ->', Object.fromEntries(c.req.raw.headers)); } catch {}
+    try { console.debug('[DEBUG] incoming request headers ->', Object.fromEntries(c.req.raw.headers)); } catch {}
     try {
       const proxyBase = computeProxyBase(c.req.raw);
       const proxyUrl = computeProxyUrl(c.req.raw, proxyBase);


### PR DESCRIPTION
Converted console TRACE log messages to DEBUG log messages in routes/console/index.ts, index.ts, and console/src/AgentStatus/AgentStatus.tsx.