### PR TITLE
Add systemd unit and XAUTHORITY-aware start wrapper

### DIFF
--- a/bin/start-with-xauth.sh
+++ b/bin/start-with-xauth.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ORIG_START="/workspaces/makamujo/bin/start"
+ARGS=("$@")
+log() { echo "[start-wrapper] $*" >&2; }
+
+if [ ! -e "$ORIG_START" ]; then
+  log "Warning: original start not found: $ORIG_START"
+fi
+
+# Ensure DISPLAY set (can also be provided via systemd Environment=DISPLAY=:0)
+if [ -z "${DISPLAY:-}" ]; then
+  DISPLAY=":0"
+fi
+export DISPLAY
+
+# If XAUTHORITY already present and valid, use it
+if [ -n "${XAUTHORITY:-}" ] && [ -e "$XAUTHORITY" ]; then
+  log "Using XAUTHORITY from environment: $XAUTHORITY"
+  exec "$ORIG_START" "${ARGS[@]}"
+fi
+
+# Try to discover a graphical session via loginctl
+if command -v loginctl >/dev/null 2>&1; then
+  while read -r sid; do
+    active=$(loginctl show-session "$sid" -p Active --value 2>/dev/null || true)
+    if [ "$active" != "yes" ]; then
+      continue
+    fi
+    type=$(loginctl show-session "$sid" -p Type --value 2>/dev/null || true)
+    display_loginctl=$(loginctl show-session "$sid" -p Display --value 2>/dev/null || true)
+    user=$(loginctl show-session "$sid" -p Name --value 2>/dev/null || true)
+    uid=$(id -u "$user" 2>/dev/null || true)
+    if [ -n "$display_loginctl" ]; then
+      DISPLAY="$display_loginctl"
+      export DISPLAY
+    fi
+    if [ -n "$user" ] && [ -n "$uid" ] && [ "$uid" != "0" ]; then
+      home=$(getent passwd "$user" | cut -d: -f6)
+      candidates=("$home/.Xauthority" "/run/user/$uid/gdm/Xauthority" "/run/user/$uid/.Xauthority")
+      for c in "${candidates[@]}"; do
+        if [ -e "$c" ]; then
+          export XAUTHORITY="$c"
+          log "Found XAUTHORITY via loginctl: $XAUTHORITY (user=$user)"
+          exec "$ORIG_START" "${ARGS[@]}"
+        fi
+      done
+    fi
+  done < <(loginctl list-sessions --no-legend | awk '{print $1}')
+fi
+
+# Search for Xorg/Xwayland/desktop session processes and inspect env/cmdline
+pids=$(pgrep -f 'Xorg|Xwayland|gnome-session|startkde|Xsession' 2>/dev/null || true)
+for pid in $pids; do
+  if [ -r "/proc/$pid/environ" ]; then
+    xauth=$(tr '\0' '\n' < /proc/$pid/environ | awk -F= '$1=="XAUTHORITY"{print $2; exit}')
+    if [ -n "$xauth" ] && [ -e "$xauth" ]; then
+      export XAUTHORITY="$xauth"
+      log "Found XAUTHORITY in /proc/$pid/environ: $XAUTHORITY"
+      exec "$ORIG_START" "${ARGS[@]}"
+    fi
+  fi
+  if [ -r "/proc/$pid/cmdline" ]; then
+    cmd=$(tr '\0' ' ' < /proc/$pid/cmdline)
+    if echo "$cmd" | grep -q -- '-auth'; then
+      xauth=$(echo "$cmd" | sed -n 's/.*-auth \([^ ]*\).*/\1/p' | awk '{print $1}')
+      if [ -n "$xauth" ] && [ -e "$xauth" ]; then
+        export XAUTHORITY="$xauth"
+        log "Found XAUTHORITY from cmdline of pid $pid: $XAUTHORITY"
+        exec "$ORIG_START" "${ARGS[@]}"
+      fi
+    fi
+  fi
+done
+
+# Fallback: pick the most recently modified .Xauthority under /home or /root
+best=""
+for f in /home/*/.Xauthority /root/.Xauthority 2>/dev/null; do
+  if [ -e "$f" ]; then
+    if [ -z "$best" ] || [ "$f" -nt "$best" ]; then
+      best="$f"
+    fi
+  fi
+done
+if [ -n "$best" ]; then
+  export XAUTHORITY="$best"
+  log "Using latest .Xauthority: $XAUTHORITY"
+  exec "$ORIG_START" "${ARGS[@]}"
+fi
+
+# Last resort: try to allow root via xhost (may require existing auth)
+if command -v xhost >/dev/null 2>&1; then
+  log "Attempting to allow root via xhost (may require existing auth)"
+  DISPLAY="$DISPLAY" xhost +SI:localuser:root || true
+fi
+
+log "No XAUTHORITY detected; starting without XAUTHORITY (this may fail). DISPLAY=$DISPLAY"
+exec "$ORIG_START" "${ARGS[@]}"

--- a/bin/start-with-xauth.sh
+++ b/bin/start-with-xauth.sh
@@ -28,7 +28,6 @@ if command -v loginctl >/dev/null 2>&1; then
     if [ "$active" != "yes" ]; then
       continue
     fi
-    type=$(loginctl show-session "$sid" -p Type --value 2>/dev/null || true)
     display_loginctl=$(loginctl show-session "$sid" -p Display --value 2>/dev/null || true)
     user=$(loginctl show-session "$sid" -p Name --value 2>/dev/null || true)
     uid=$(id -u "$user" 2>/dev/null || true)
@@ -51,10 +50,10 @@ if command -v loginctl >/dev/null 2>&1; then
 fi
 
 # Search for Xorg/Xwayland/desktop session processes and inspect env/cmdline
-pids=$(pgrep -f 'Xorg|Xwayland|gnome-session|startkde|Xsession' 2>/dev/null || true)
-for pid in $pids; do
+readarray -t pids < <(pgrep -f 'Xorg|Xwayland|gnome-session|startkde|Xsession' 2>/dev/null || true)
+for pid in "${pids[@]}"; do
   if [ -r "/proc/$pid/environ" ]; then
-    xauth=$(tr '\0' '\n' < /proc/$pid/environ | awk -F= '$1=="XAUTHORITY"{print $2; exit}')
+    xauth=$(tr '\0' '\n' < "/proc/$pid/environ" | awk -F= '$1=="XAUTHORITY"{print $2; exit}')
     if [ -n "$xauth" ] && [ -e "$xauth" ]; then
       export XAUTHORITY="$xauth"
       log "Found XAUTHORITY in /proc/$pid/environ: $XAUTHORITY"
@@ -62,7 +61,7 @@ for pid in $pids; do
     fi
   fi
   if [ -r "/proc/$pid/cmdline" ]; then
-    cmd=$(tr '\0' ' ' < /proc/$pid/cmdline)
+    cmd=$(tr '\0' ' ' < "/proc/$pid/cmdline")
     if echo "$cmd" | grep -q -- '-auth'; then
       xauth=$(echo "$cmd" | sed -n 's/.*-auth \([^ ]*\).*/\1/p' | awk '{print $1}')
       if [ -n "$xauth" ] && [ -e "$xauth" ]; then
@@ -76,13 +75,16 @@ done
 
 # Fallback: pick the most recently modified .Xauthority under /home or /root
 best=""
-for f in /home/*/.Xauthority /root/.Xauthority 2>/dev/null; do
+# Use nullglob so the for-loop doesn't iterate over literal patterns when no files exist
+shopt -s nullglob
+for f in /home/*/.Xauthority /root/.Xauthority; do
   if [ -e "$f" ]; then
     if [ -z "$best" ] || [ "$f" -nt "$best" ]; then
       best="$f"
     fi
   fi
 done
+shopt -u nullglob
 if [ -n "$best" ]; then
   export XAUTHORITY="$best"
   log "Using latest .Xauthority: $XAUTHORITY"

--- a/etc/systemd/README.md
+++ b/etc/systemd/README.md
@@ -1,0 +1,59 @@
+# systemd unit for makamujo
+
+This directory contains a systemd service file to run the application using `bin/start` and `bin/stop`.
+
+## Install (system-wide)
+
+1. Copy the service file to the systemd system directory:
+
+```sh
+sudo cp /workspaces/makamujo/etc/systemd/makamujo.service /etc/systemd/system/makamujo.service
+```
+
+2. Reload systemd and enable/start the service:
+
+```sh
+sudo systemctl daemon-reload
+sudo systemctl enable --now makamujo.service
+```
+
+3. Stop the service:
+
+```sh
+sudo systemctl stop makamujo.service
+```
+
+4. View logs (journalctl):
+
+```sh
+sudo journalctl -u makamujo.service -f
+```
+
+## Notes
+
+- `bin/start` requires an X Window session. The unit is configured to start after `graphical.target` so it will wait for the graphical session.
+- If `bin/start` must run as a non-root user and access the X display, edit the service and add `User=yourusername` and suitable `Environment=` settings (for example `DISPLAY` and `XAUTHORITY`).
+- Adjust `WorkingDirectory` and `ExecStart` paths if you install the application to a different location.
+
+## XAUTHORITY 自動検出ラッパー
+
+このリポジトリには `bin/start-with-xauth.sh` というラッパースクリプトを同梱しています。サービスはこのラッパーを使って起動するようになっており、以下の順で `DISPLAY` / `XAUTHORITY` を自動検出します:
+
+- `loginctl` でアクティブなグラフィカルセッションを調べ、該当ユーザーの `~/.Xauthority` や `/run/user/<UID>/gdm/Xauthority` を探す
+- X サーバ / セッションプロセスの `/proc/<pid>/environ` やコマンドラインに `XAUTHORITY` / `-auth` があればそれを使う
+- `/home/*/.Xauthority` や `/root/.Xauthority` の中で最終更新日時が新しいものを候補にする
+- 最後の手段として `xhost` を使って `root` の接続許可を試みる（環境によって動かない場合があります）
+
+使い方（インストール後）:
+
+```sh
+# ラッパーを実行可能にしてからサービスを有効化/再読み込みしてください
+sudo chmod +x /workspaces/makamujo/bin/start-with-xauth.sh
+sudo cp /workspaces/makamujo/etc/systemd/makamujo.service /etc/systemd/system/makamujo.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now makamujo.service
+sudo journalctl -u makamujo.service -f
+```
+
+もし自動検出で見つからない場合は、ユニットに明示的に `Environment=XAUTHORITY=/home/<user>/.Xauthority` を設定してください。Wayland 環境では XAUTHORITY が無意味な場合がある点にも注意してください。
+

--- a/etc/systemd/makamujo.service
+++ b/etc/systemd/makamujo.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=makamujo service
+After=graphical.target
+Wants=graphical.target
+
+[Service]
+Type=simple
+WorkingDirectory=/workspaces/makamujo
+User=root
+Environment=DISPLAY=:0
+ExecStart=/workspaces/makamujo/bin/start-with-xauth.sh
+ExecStop=/workspaces/makamujo/bin/stop
+Restart=on-failure
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+# If you want to run it as a different user, change `User=` and set `XAUTHORITY` accordingly:
+# User=yourusername
+# Environment=DISPLAY=:0
+# Environment=XAUTHORITY=/home/yourusername/.Xauthority
+
+[Install]
+WantedBy=graphical.target


### PR DESCRIPTION
Adds a systemd service unit, a wrapper script to auto-detect DISPLAY/XAUTHORITY, and documentation under etc/systemd/README.md.