### PR TITLE
Install to /opt and make start wrapper portable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,48 @@
+# Makefile: install makamujo to /opt and manage systemd unit
+
+PREFIX ?= /opt/makamujo
+UNIT_DIR ?= /etc/systemd/system
+INSTALL_BIN = bin/start-with-xauth.sh bin/start bin/stop
+SERVICE = makamujo.service
+UNIT_SRC = etc/systemd/$(SERVICE)
+
+.PHONY: all install install-app install-systemd uninstall uninstall-app uninstall-systemd help
+
+all: install
+
+install: install-app install-systemd
+	@echo "Installed to $(PREFIX)"
+
+install-app:
+	@echo "Installing application files to $(PREFIX)"
+	@if [ "$$(id -u)" -ne 0 ]; then echo "This target requires root: run 'sudo make install'"; exit 1; fi
+	@mkdir -p "$(PREFIX)/bin"
+	@cp -a $(INSTALL_BIN) "$(PREFIX)/bin/"
+	@chown -R root:root "$(PREFIX)"
+	@chmod +x "$(PREFIX)/bin/"*
+
+install-systemd:
+	@echo "Installing systemd unit to $(UNIT_DIR)"
+	@if [ "$$(id -u)" -ne 0 ]; then echo "This target requires root: run 'sudo make install'"; exit 1; fi
+	@cp "$(UNIT_SRC)" "$(UNIT_DIR)/$(SERVICE)"
+	@systemctl daemon-reload
+	@systemctl enable --now "$(SERVICE)"
+
+uninstall: uninstall-systemd uninstall-app
+	@echo "Uninstalled"
+
+uninstall-systemd:
+	@echo "Removing systemd unit"
+	-@systemctl disable --now "$(SERVICE)" 2>/dev/null || true
+	-@rm -f "$(UNIT_DIR)/$(SERVICE)" || true
+	@systemctl daemon-reload
+
+uninstall-app:
+	@echo "Removing installed files from $(PREFIX)"
+	-@rm -rf "$(PREFIX)" || true
+
+help:
+	@echo "Usage:"
+	@echo "  sudo make install          # install to $(PREFIX) and enable service"
+	@echo "  sudo make uninstall        # remove service and installed files"
+	@echo "  make install PREFIX=/some/path  # install to custom prefix (run as root)"

--- a/bin/start-with-xauth.sh
+++ b/bin/start-with-xauth.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ORIG_START="/workspaces/makamujo/bin/start"
+# Determine repository root relative to this script so installation path can move
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ORIG_START="$REPO_ROOT/bin/start"
 ARGS=("$@")
 log() { echo "[start-wrapper] $*" >&2; }
 

--- a/etc/systemd/README.md
+++ b/etc/systemd/README.md
@@ -4,10 +4,16 @@ This directory contains a systemd service file to run the application using `bin
 
 ## Install (system-wide)
 
-1. Copy the service file to the systemd system directory:
+Recommended (portable): install to `/opt`
+
+1. Copy application files to `/opt` and install the unit:
 
 ```sh
-sudo cp /workspaces/makamujo/etc/systemd/makamujo.service /etc/systemd/system/makamujo.service
+sudo mkdir -p /opt/makamujo/bin
+sudo cp -a ./bin/start-with-xauth.sh ./bin/start ./bin/stop /opt/makamujo/bin/
+sudo chown -R root:root /opt/makamujo
+sudo chmod +x /opt/makamujo/bin/*.sh /opt/makamujo/bin/start /opt/makamujo/bin/stop
+sudo cp ./etc/systemd/makamujo.service /etc/systemd/system/makamujo.service
 ```
 
 2. Reload systemd and enable/start the service:
@@ -28,6 +34,20 @@ sudo systemctl stop makamujo.service
 ```sh
 sudo journalctl -u makamujo.service -f
 ```
+
+Alternative (quick): leave files in the repository
+
+If you already copied the unit from the repo and prefer to keep files in-place under the repository path, update the installed unit to point at `./workspaces/makamujo` before reloading:
+
+```sh
+sudo sed -i 's|ExecStart=.*|ExecStart=/workspaces/makamujo/bin/start-with-xauth.sh|' /etc/systemd/system/makamujo.service
+sudo sed -i 's|ExecStop=.*|ExecStop=/workspaces/makamujo/bin/stop|' /etc/systemd/system/makamujo.service
+sudo systemctl daemon-reload
+sudo systemctl restart makamujo.service
+sudo journalctl -u makamujo.service -f
+```
+
+Note: the version of `makamujo.service` included in this repository has `ExecStart`/`ExecStop` pointing at `/opt/makamujo` by default. If you install to a different path, edit the unit file accordingly before copying it to `/etc/systemd/system/`.
 
 ## Notes
 

--- a/etc/systemd/README.md
+++ b/etc/systemd/README.md
@@ -49,6 +49,24 @@ sudo journalctl -u makamujo.service -f
 
 Note: the version of `makamujo.service` included in this repository has `ExecStart`/`ExecStop` pointing at `/opt/makamujo` by default. If you install to a different path, edit the unit file accordingly before copying it to `/etc/systemd/system/`.
 
+## Makefile install
+
+This repository includes a top-level `Makefile` that automates the `/opt` installation and systemd enable steps.
+
+Usage (run as root or via sudo):
+
+```sh
+sudo make install           # installs files to /opt/makamujo and enables the service
+sudo make uninstall         # disables the service and removes installed files
+
+# To install to a custom prefix:
+sudo make install PREFIX=/srv/makamujo
+```
+
+Notes:
+- `make install` will copy `bin/*` to `$(PREFIX)/bin` (default `/opt/makamujo/bin`) and copy the unit file to `/etc/systemd/system/makamujo.service` then reload and enable the service.
+- If you prefer to keep files in the repository path, see the "Alternative (quick)" section above.
+
 ## Notes
 
 - `bin/start` requires an X Window session. The unit is configured to start after `graphical.target` so it will wait for the graphical session.

--- a/etc/systemd/README.md
+++ b/etc/systemd/README.md
@@ -1,57 +1,32 @@
 # systemd unit for makamujo
 
-This directory contains a systemd service file to run the application using `bin/start` and `bin/stop`.
+This directory contains the systemd unit file and documentation for installing `makamujo` using the included `Makefile`.
 
-## Install (system-wide)
+## Install (recommended via Makefile)
 
-Recommended (portable): install to `/opt`
+Use the top-level `Makefile` to install to `/opt` (default) and enable the systemd unit.
 
-1. Copy application files to `/opt` and install the unit:
-
-```sh
-sudo mkdir -p /opt/makamujo/bin
-sudo cp -a ./bin/start-with-xauth.sh ./bin/start ./bin/stop /opt/makamujo/bin/
-sudo chown -R root:root /opt/makamujo
-sudo chmod +x /opt/makamujo/bin/*.sh /opt/makamujo/bin/start /opt/makamujo/bin/stop
-sudo cp ./etc/systemd/makamujo.service /etc/systemd/system/makamujo.service
-```
-
-2. Reload systemd and enable/start the service:
+Run as root (or via `sudo`):
 
 ```sh
-sudo systemctl daemon-reload
-sudo systemctl enable --now makamujo.service
+sudo make install
 ```
 
-3. Stop the service:
+To uninstall:
 
 ```sh
-sudo systemctl stop makamujo.service
+sudo make uninstall
 ```
 
-4. View logs (journalctl):
+To install to a custom prefix (example):
 
 ```sh
-sudo journalctl -u makamujo.service -f
+sudo make install PREFIX=/srv/makamujo
 ```
 
-Alternative (quick): leave files in the repository
-
-If you already copied the unit from the repo and prefer to keep files in-place under the repository path, update the installed unit to point at `./workspaces/makamujo` before reloading:
-
-```sh
-sudo sed -i 's|ExecStart=.*|ExecStart=/workspaces/makamujo/bin/start-with-xauth.sh|' /etc/systemd/system/makamujo.service
-sudo sed -i 's|ExecStop=.*|ExecStop=/workspaces/makamujo/bin/stop|' /etc/systemd/system/makamujo.service
-sudo systemctl daemon-reload
-sudo systemctl restart makamujo.service
-sudo journalctl -u makamujo.service -f
-```
-
-Note: the version of `makamujo.service` included in this repository has `ExecStart`/`ExecStop` pointing at `/opt/makamujo` by default. If you install to a different path, edit the unit file accordingly before copying it to `/etc/systemd/system/`.
-
-## Makefile install
-
-This repository includes a top-level `Makefile` that automates the `/opt` installation and systemd enable steps.
+Notes:
+- The default install path is `/opt/makamujo`. The included unit file expects binaries under `/opt/makamujo/bin`.
+- If you change the install prefix, update the installed systemd unit (`/etc/systemd/system/makamujo.service`) so `ExecStart`/`ExecStop` point to the correct paths, then run `sudo systemctl daemon-reload`.
 
 Usage (run as root or via sudo):
 

--- a/etc/systemd/makamujo.service
+++ b/etc/systemd/makamujo.service
@@ -5,11 +5,11 @@ Wants=graphical.target
 
 [Service]
 Type=simple
-WorkingDirectory=/workspaces/makamujo
+WorkingDirectory=/opt/makamujo
 User=root
 Environment=DISPLAY=:0
-ExecStart=/workspaces/makamujo/bin/start-with-xauth.sh
-ExecStop=/workspaces/makamujo/bin/stop
+ExecStart=/opt/makamujo/bin/start-with-xauth.sh
+ExecStop=/opt/makamujo/bin/stop
 Restart=on-failure
 RestartSec=5
 StandardOutput=journal


### PR DESCRIPTION
Installs application files to /opt/makamujo and updates the systemd unit to reference /opt. Makes the start wrapper resolve paths relative to its install location.