### PR TITLE
fix(systemd): reapply missing wrapper & unit fixes

### DIFF
--- a/bin/start-with-xauth.sh
+++ b/bin/start-with-xauth.sh
@@ -56,7 +56,7 @@ fi
 readarray -t pids < <(pgrep -f 'Xorg|Xwayland|gnome-session|startkde|Xsession' 2>/dev/null || true)
 for pid in "${pids[@]}"; do
   if [ -r "/proc/$pid/environ" ]; then
-    xauth=$(tr '\0' '\n' < "/proc/$pid/environ" | awk -F= '$1=="XAUTHORITY"{print $2; exit}')
+    xauth=$(tr '\0' '\n' < "/proc/$pid/environ" 2>/dev/null | awk -F= '$1=="XAUTHORITY"{print $2; exit}')
     if [ -n "$xauth" ] && [ -e "$xauth" ]; then
       export XAUTHORITY="$xauth"
       log "Found XAUTHORITY in /proc/$pid/environ: $XAUTHORITY"

--- a/etc/systemd/README.md
+++ b/etc/systemd/README.md
@@ -1,46 +1,33 @@
 # systemd unit for makamujo
 
-This directory contains the systemd unit file and documentation for installing `makamujo` using the included `Makefile`.
+This directory contains a systemd service file to run the application using `bin/start` and `bin/stop`.
 
-## Install (recommended via Makefile)
+## Install (system-wide)
 
-Use the top-level `Makefile` to install to `/opt` (default) and enable the systemd unit.
-
-Run as root (or via `sudo`):
+1. Copy the service file to the systemd system directory:
 
 ```sh
-sudo make install
+sudo cp /workspaces/makamujo/etc/systemd/makamujo.service /etc/systemd/system/makamujo.service
 ```
 
-To uninstall:
+2. Reload systemd and enable/start the service:
 
 ```sh
-sudo make uninstall
+sudo systemctl daemon-reload
+sudo systemctl enable --now makamujo.service
 ```
 
-To install to a custom prefix (example):
+3. Stop the service:
 
 ```sh
-sudo make install PREFIX=/srv/makamujo
+sudo systemctl stop makamujo.service
 ```
 
-Notes:
-- The default install path is `/opt/makamujo`. The included unit file expects binaries under `/opt/makamujo/bin`.
-- If you change the install prefix, update the installed systemd unit (`/etc/systemd/system/makamujo.service`) so `ExecStart`/`ExecStop` point to the correct paths, then run `sudo systemctl daemon-reload`.
-
-Usage (run as root or via sudo):
+4. View logs (journalctl):
 
 ```sh
-sudo make install           # installs files to /opt/makamujo and enables the service
-sudo make uninstall         # disables the service and removes installed files
-
-# To install to a custom prefix:
-sudo make install PREFIX=/srv/makamujo
+sudo journalctl -u makamujo.service -f
 ```
-
-Notes:
-- `make install` will copy `bin/*` to `$(PREFIX)/bin` (default `/opt/makamujo/bin`) and copy the unit file to `/etc/systemd/system/makamujo.service` then reload and enable the service.
-- If you prefer to keep files in the repository path, see the "Alternative (quick)" section above.
 
 ## Notes
 

--- a/etc/systemd/makamujo.service
+++ b/etc/systemd/makamujo.service
@@ -3,15 +3,17 @@ Description=makamujo service
 After=graphical.target
 Wants=graphical.target
 
+# Service runs multiple backgrounded processes and the start script exits.
+# Use oneshot + RemainAfterExit so systemd considers the service active
+# while background processes run and ExecStop can stop them.
 [Service]
-Type=simple
+Type=oneshot
+RemainAfterExit=yes
 WorkingDirectory=/opt/makamujo
 User=root
 Environment=DISPLAY=:0
 ExecStart=/opt/makamujo/bin/start-with-xauth.sh
 ExecStop=/opt/makamujo/bin/stop
-Restart=on-failure
-RestartSec=5
 StandardOutput=journal
 StandardError=journal
 # If you want to run it as a different user, change `User=` and set `XAUTHORITY` accordingly:


### PR DESCRIPTION
Reapply missing start-with-xauth.sh and systemd unit fixes (silence tr broken-pipe; Type=oneshot + RemainAfterExit; ShellCheck fixes).\n\nCherry-picked commits: 7ebe8e4, a3c0074, eb6e466, 384fe84.