### PR TITLE
feat(systemd): capture child logs in systemd journal

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,13 @@ MAKA Mujo: an AI‑VTuber
 ## Dependencies
 
 - **[automated-gameplay-transmitter](https://github.com/nahcnuj/automated-gameplay-transmitter)**: browser automation helpers, IPC utilities, and shared React components/contexts used by the UI.
+
+## Running as a systemd service
+
+This repository includes a systemd unit and helper scripts under `etc/systemd/` and `bin/`. Use the top-level `Makefile` to install to `/opt/makamujo` and enable the service. After installation, you can follow logs for all makamujo processes with:
+
+```sh
+sudo /opt/makamujo/bin/journal-makamujo -f
+```
+
+More details are in [etc/systemd/README.md](etc/systemd/README.md).

--- a/bin/journal-makamujo
+++ b/bin/journal-makamujo
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+set -eu
+
+# Helper to follow logs for all makamujo transient units
+UNITS="makamujo-screen.service makamujo-browser.service makamujo-obs.service"
+
+JARGS=""
+for u in $UNITS; do
+  JARGS="$JARGS -u $u"
+done
+
+exec journalctl $JARGS "$@"

--- a/bin/start
+++ b/bin/start
@@ -35,12 +35,14 @@ start_cmd() {
     # so the command runs from the project root. Use env when needed.
     if systemd-run --unit="$unit" --description="makamujo ${name}" --property=WorkingDirectory="$PROJECT_ROOT" -- "$@" >/dev/null 2>&1; then
       # try to record MainPID for compatibility with existing stop logic
-      for i in 1 2 3 4 5 6 7 8 9 10; do
+      retries=0
+      while [ "$retries" -lt 10 ]; do
         pid=$(systemctl show -p MainPID --value "${unit}.service" 2>/dev/null || true)
         if [ -n "$pid" ] && [ "$pid" -ne 0 ] 2>/dev/null; then
           echo "$pid" > "${PID_DIR}/${name}"
           break
         fi
+        retries=$((retries + 1))
         sleep 0.2
       done
     else

--- a/bin/start
+++ b/bin/start
@@ -19,11 +19,44 @@ export CONSOLE_BASIC_AUTH_PASSWORD="${PASSWORD}"
 echo "Console Basic auth username: admin"
 echo "Console Basic auth password: ${PASSWORD}"
 
-NODE_ENV=production nohup bun start >"${PROJECT_ROOT}/var/screen.log" 2>&1 &
-echo $! > "${PID_DIR}/screen"
+# Prefer starting subprocesses as transient systemd units so their logs
+# are captured by the journal and manageable via systemctl. If systemd is
+# not available, fall back to the original nohup-based behavior.
+USE_SYSTEMD=0
+if command -v systemd-run >/dev/null 2>&1 && command -v systemctl >/dev/null 2>&1; then
+  USE_SYSTEMD=1
+fi
 
-NODE_ENV=production nohup bun ./bin/x/browser.ts >"${PROJECT_ROOT}/var/browser.log" 2>&1 &
-echo $! > "${PID_DIR}/browser"
+start_cmd() {
+  name="$1"; logfile="$2"; shift 2
+  if [ "$USE_SYSTEMD" -eq 1 ]; then
+    unit="makamujo-${name}"
+    # Run the command under systemd as a transient service; set WorkingDirectory
+    # so the command runs from the project root. Use env when needed.
+    if systemd-run --unit="$unit" --description="makamujo ${name}" --property=WorkingDirectory="$PROJECT_ROOT" -- "$@" >/dev/null 2>&1; then
+      # try to record MainPID for compatibility with existing stop logic
+      for i in 1 2 3 4 5 6 7 8 9 10; do
+        pid=$(systemctl show -p MainPID --value "${unit}.service" 2>/dev/null || true)
+        if [ -n "$pid" ] && [ "$pid" -ne 0 ] 2>/dev/null; then
+          echo "$pid" > "${PID_DIR}/${name}"
+          break
+        fi
+        sleep 0.2
+      done
+    else
+      # fallback to nohup if systemd-run failed
+      nohup "$@" >"${logfile}" 2>&1 &
+      echo $! > "${PID_DIR}/${name}"
+    fi
+  else
+    nohup "$@" >"${logfile}" 2>&1 &
+    echo $! > "${PID_DIR}/${name}"
+  fi
+}
 
-nohup ./bin/x/obs >"${PROJECT_ROOT}/var/obs.log" 2>&1 &
-echo $! > "${PID_DIR}/obs"
+# Start processes (keeps compatibility with previous behavior)
+start_cmd screen "${PROJECT_ROOT}/var/screen.log" /usr/bin/env NODE_ENV=production bun start
+start_cmd browser "${PROJECT_ROOT}/var/browser.log" /usr/bin/env NODE_ENV=production bun ./bin/x/browser.ts
+start_cmd obs "${PROJECT_ROOT}/var/obs.log" ./bin/x/obs
+
+exit 0

--- a/bin/stop
+++ b/bin/stop
@@ -29,7 +29,30 @@ kill_tree() {
   wait_until_process_exits "$1"
 }
 
+# If systemd managed the processes as transient units, prefer stopping them
+SYSTEMCTL_AVAILABLE=0
+if command -v systemctl >/dev/null 2>&1; then
+  SYSTEMCTL_AVAILABLE=1
+fi
+
 for pid_file in "${PID_DIR}/obs" "${PID_DIR}/browser" "${PID_DIR}/screen"; do
+  name=$(basename "$pid_file")
+  unit="makamujo-${name}.service"
+  if [ "$SYSTEMCTL_AVAILABLE" -eq 1 ]; then
+    # try stopping the transient unit; ignore errors and fall back to PID kill
+    if systemctl stop "$unit" 2>/dev/null; then
+      # wait for systemd to stop it
+      for i in 1 2 3 4 5 6 7 8 9 10; do
+        if ! systemctl is-active --quiet "$unit" 2>/dev/null; then
+          break
+        fi
+        sleep 0.1
+      done
+      rm -f "$pid_file"
+      continue
+    fi
+  fi
+
   if [ -f "$pid_file" ]; then
     pid=$(cat "$pid_file")
     if [ -n "$pid" ]; then

--- a/bin/stop
+++ b/bin/stop
@@ -42,10 +42,12 @@ for pid_file in "${PID_DIR}/obs" "${PID_DIR}/browser" "${PID_DIR}/screen"; do
     # try stopping the transient unit; ignore errors and fall back to PID kill
     if systemctl stop "$unit" 2>/dev/null; then
       # wait for systemd to stop it
-      for i in 1 2 3 4 5 6 7 8 9 10; do
+      retries=0
+      while [ "$retries" -lt 10 ]; do
         if ! systemctl is-active --quiet "$unit" 2>/dev/null; then
           break
         fi
+        retries=$((retries + 1))
         sleep 0.1
       done
       rm -f "$pid_file"


### PR DESCRIPTION
Start child processes as transient systemd units (makamujo-screen/browser/obs) so their stdout/stderr are collected by journald. Adds bin/journal-makamujo helper and docs in etc/systemd/README.md. Falls back to nohup when systemd is not available.