### PR TITLE
fix(systemd): add PATH so Bun is available to makamujo service

### DIFF
--- a/etc/systemd/makamujo.service
+++ b/etc/systemd/makamujo.service
@@ -11,7 +11,7 @@ Type=oneshot
 RemainAfterExit=yes
 WorkingDirectory=/opt/makamujo
 User=root
-Environment=PATH=/usr/local/bin:/usr/bin:/bin
+Environment=PATH=/root/.bun/bin:/usr/local/bin:/usr/bin:/bin
 Environment=DISPLAY=:0
 ExecStart=/opt/makamujo/bin/start-with-xauth.sh
 ExecStop=/opt/makamujo/bin/stop

--- a/etc/systemd/makamujo.service
+++ b/etc/systemd/makamujo.service
@@ -11,6 +11,7 @@ Type=oneshot
 RemainAfterExit=yes
 WorkingDirectory=/opt/makamujo
 User=root
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
 Environment=DISPLAY=:0
 ExecStart=/opt/makamujo/bin/start-with-xauth.sh
 ExecStop=/opt/makamujo/bin/stop


### PR DESCRIPTION
This updates etc/systemd/makamujo.service to set PATH=/usr/local/bin:/usr/bin:/bin so Bun can be located when the service starts. It fixes transient unit failures caused by systemd not inheriting the user shell PATH.