### PR TITLE
fix(obs): include obs-studio config in install and pass XDG paths to Flatpak OBS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 PREFIX ?= /opt/makamujo
 UNIT_DIR ?= /etc/systemd/system
 INSTALL_BIN = bin/start-with-xauth.sh bin/start bin/stop
+INSTALL_DATA = obs-studio
 SERVICE = makamujo.service
 UNIT_SRC = etc/systemd/$(SERVICE)
 
@@ -18,6 +19,7 @@ install-app:
 	@if [ "$$(id -u)" -ne 0 ]; then echo "This target requires root: run 'sudo make install'"; exit 1; fi
 	@mkdir -p "$(PREFIX)/bin"
 	@cp -a $(INSTALL_BIN) "$(PREFIX)/bin/"
+	@cp -a $(INSTALL_DATA) "$(PREFIX)/"
 	@chown -R root:root "$(PREFIX)"
 	@chmod +x "$(PREFIX)/bin/"*
 

--- a/bin/obs-studio
+++ b/bin/obs-studio
@@ -2,7 +2,14 @@
 
 set -eu
 
+SCRIPT_PATH=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_PATH/.." && pwd)
+OBS_CONFIG_DIR="$REPO_ROOT/obs-studio"
+
 flatpak run -vv \
     --share=network \
+    --filesystem="$OBS_CONFIG_DIR" \
+    --env=XDG_CONFIG_HOME="$REPO_ROOT" \
+    --env=XDG_DATA_HOME="$REPO_ROOT" \
     com.obsproject.Studio \
     "$@"


### PR DESCRIPTION
This PR installs the repo's obs-studio config directory into /opt/makamujo and updates the Flatpak OBS wrapper to expose that directory plus proper XDG config/data paths. This should allow OBS to load the bundled profiles and scenes when installed under /opt.