### PR TITLE
feat(systemd): add persistent Xorg :10 and x11vnc units for RDP auto-connect

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@
 
 PREFIX ?= /opt/makamujo
 UNIT_DIR ?= /etc/systemd/system
-INSTALL_BIN = bin/start-with-xauth.sh bin/start bin/stop bin/x
+INSTALL_BIN = bin/start-with-xauth.sh bin/start bin/stop bin/x bin/xorg10 bin/x11vnc-10
 INSTALL_DATA = package.json bunfig.toml tsconfig.json bootstrap.ts index.ts lib routes src console obs-studio
 SERVICE = makamujo.service
-UNIT_SRC = etc/systemd/$(SERVICE)
+UNIT_FILES = $(shell ls etc/systemd/*.service 2>/dev/null)
 
 .PHONY: all install install-app install-systemd uninstall uninstall-app uninstall-systemd help
 
@@ -29,9 +29,9 @@ install-app:
 	@chmod +x "$(PREFIX)/bin/"*
 
 install-systemd:
-	@echo "Installing systemd unit to $(UNIT_DIR)"
+	@echo "Installing systemd units to $(UNIT_DIR)"
 	@if [ "$$(id -u)" -ne 0 ]; then echo "This target requires root: run 'sudo make install'"; exit 1; fi
-	@cp "$(UNIT_SRC)" "$(UNIT_DIR)/$(SERVICE)"
+	@cp -a etc/systemd/*.service "$(UNIT_DIR)/"
 	@systemctl daemon-reload
 	@systemctl enable --now "$(SERVICE)"
 
@@ -39,9 +39,9 @@ uninstall: uninstall-systemd uninstall-app
 	@echo "Uninstalled"
 
 uninstall-systemd:
-	@echo "Removing systemd unit"
+	@echo "Removing systemd units"
 	-@systemctl disable --now "$(SERVICE)" 2>/dev/null || true
-	-@rm -f "$(UNIT_DIR)/$(SERVICE)" || true
+	-@for unit in etc/systemd/*.service; do rm -f "$(UNIT_DIR)/$$(basename "$$unit")"; done
 	@systemctl daemon-reload
 
 uninstall-app:

--- a/bin/start
+++ b/bin/start
@@ -86,8 +86,8 @@ start_cmd() {
 }
 
 # Start processes (keeps compatibility with previous behavior)
-start_cmd screen "${PROJECT_ROOT}/var/screen.log" /bin/sh -lc "cd '${PROJECT_ROOT}' && NODE_ENV=production '${BUN_PATH}' start"
-start_cmd browser "${PROJECT_ROOT}/var/browser.log" /bin/sh -lc "cd '${PROJECT_ROOT}' && NODE_ENV=production '${BUN_PATH}' '${PROJECT_ROOT}/bin/x/browser.ts'"
-start_cmd obs "${PROJECT_ROOT}/var/obs.log" /bin/sh -lc "cd '${PROJECT_ROOT}' && '${PROJECT_ROOT}/bin/x/obs'"
+start_cmd screen "${PROJECT_ROOT}/var/screen.log" /usr/bin/env NODE_ENV=production "${BUN_PATH}" --cwd "${PROJECT_ROOT}" start
+start_cmd browser "${PROJECT_ROOT}/var/browser.log" /usr/bin/env NODE_ENV=production "${BUN_PATH}" --cwd "${PROJECT_ROOT}" "${PROJECT_ROOT}/bin/x/browser.ts"
+start_cmd obs "${PROJECT_ROOT}/var/obs.log" "${PROJECT_ROOT}/bin/x/obs"
 
 exit 0

--- a/bin/start
+++ b/bin/start
@@ -86,8 +86,8 @@ start_cmd() {
 }
 
 # Start processes (keeps compatibility with previous behavior)
-start_cmd screen "${PROJECT_ROOT}/var/screen.log" /usr/bin/env NODE_ENV=production "${BUN_PATH}" --cwd "${PROJECT_ROOT}" start
-start_cmd browser "${PROJECT_ROOT}/var/browser.log" /usr/bin/env NODE_ENV=production "${BUN_PATH}" --cwd "${PROJECT_ROOT}" "${PROJECT_ROOT}/bin/x/browser.ts"
-start_cmd obs "${PROJECT_ROOT}/var/obs.log" "${PROJECT_ROOT}/bin/x/obs"
+start_cmd screen "${PROJECT_ROOT}/var/screen.log" /bin/sh -lc "cd '${PROJECT_ROOT}' && NODE_ENV=production '${BUN_PATH}' start"
+start_cmd browser "${PROJECT_ROOT}/var/browser.log" /bin/sh -lc "cd '${PROJECT_ROOT}' && NODE_ENV=production '${BUN_PATH}' '${PROJECT_ROOT}/bin/x/browser.ts'"
+start_cmd obs "${PROJECT_ROOT}/var/obs.log" /bin/sh -lc "cd '${PROJECT_ROOT}' && '${PROJECT_ROOT}/bin/x/obs'"
 
 exit 0

--- a/bin/x11vnc-10
+++ b/bin/x11vnc-10
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+X11VNC_BIN="$(command -v x11vnc 2>/dev/null || true)"
+if [ -z "$X11VNC_BIN" ]; then
+  echo "x11vnc binary not found" >&2
+  exit 1
+fi
+
+AUTH_FILE="${AUTH_FILE:-/root/.Xauthority}"
+if [ ! -e "$AUTH_FILE" ]; then
+  echo "Warning: XAUTHORITY file not found: $AUTH_FILE" >&2
+fi
+
+exec "$X11VNC_BIN" -display :10 -forever -shared -rfbport 5910 -auth "$AUTH_FILE"

--- a/bin/xorg10
+++ b/bin/xorg10
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+XORG_BIN="$(command -v Xorg 2>/dev/null || true)"
+if [ -z "$XORG_BIN" ] && [ -x "/usr/lib/xorg/Xorg" ]; then
+  XORG_BIN="/usr/lib/xorg/Xorg"
+fi
+if [ -z "$XORG_BIN" ]; then
+  echo "Xorg binary not found" >&2
+  exit 1
+fi
+
+AUTH_FILE="${AUTH_FILE:-/root/.Xauthority}"
+if [ ! -e "$AUTH_FILE" ]; then
+  echo "Warning: XAUTHORITY file not found: $AUTH_FILE" >&2
+fi
+
+exec "$XORG_BIN" :10 -auth "$AUTH_FILE" -noreset -nolisten tcp -logfile /var/log/Xorg.10.log

--- a/etc/systemd/README.md
+++ b/etc/systemd/README.md
@@ -8,6 +8,8 @@ This directory contains a systemd service file to run the application using `bin
 
 ```sh
 sudo cp /workspaces/makamujo/etc/systemd/makamujo.service /etc/systemd/system/makamujo.service
+sudo cp /workspaces/makamujo/etc/systemd/xorg10.service /etc/systemd/system/xorg10.service
+sudo cp /workspaces/makamujo/etc/systemd/x11vnc-10.service /etc/systemd/system/x11vnc-10.service
 ```
 
 2. Reload systemd and enable/start the service:
@@ -15,6 +17,26 @@ sudo cp /workspaces/makamujo/etc/systemd/makamujo.service /etc/systemd/system/ma
 ```sh
 sudo systemctl daemon-reload
 sudo systemctl enable --now makamujo.service
+```
+
+If you want the persistent Xorg/VNC services installed by `make install`, use the top-level make target instead:
+
+```sh
+sudo make install
+```
+
+The `make install` target copies all `etc/systemd/*.service` units to `/etc/systemd/system/` and enables `makamujo.service`.
+
+If you want to enable the persistent display services as well:
+
+```sh
+sudo systemctl enable --now xorg10.service x11vnc-10.service
+```
+
+3. Stop the service:
+
+```sh
+sudo systemctl stop makamujo.service
 ```
 
 3. Stop the service:

--- a/etc/systemd/x11vnc-10.service
+++ b/etc/systemd/x11vnc-10.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=x11vnc for Xorg :10
+After=xorg10.service
+Requires=xorg10.service
+
+[Service]
+Type=simple
+User=root
+Environment=DISPLAY=:10
+ExecStart=/opt/makamujo/bin/x11vnc-10
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/etc/systemd/xorg10.service
+++ b/etc/systemd/xorg10.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Persistent Xorg server on :10
+After=network.target
+Wants=network.target
+
+[Service]
+Type=simple
+User=root
+Environment=DISPLAY=:10
+ExecStart=/opt/makamujo/bin/xorg10
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Add persistent Xorg :10 and x11vnc systemd units under etc/systemd, and update Makefile so `make install` deploys all systemd units automatically. This enables RDP clients to connect to a pre-existing X session via localhost:5910.