### PR TITLE
Enable production mode for makamujo service

### DIFF
--- a/etc/systemd/makamujo.service
+++ b/etc/systemd/makamujo.service
@@ -12,6 +12,7 @@ RemainAfterExit=yes
 WorkingDirectory=/opt/makamujo
 User=root
 Environment=PATH=/root/.bun/bin:/usr/local/bin:/usr/bin:/bin
+Environment=NODE_ENV=production
 Environment=DISPLAY=:0
 ExecStart=/opt/makamujo/bin/start-with-xauth.sh
 ExecStop=/opt/makamujo/bin/stop


### PR DESCRIPTION
Add NODE_ENV=production to etc/systemd/makamujo.service so the console service enables Basic authentication in production mode.