### PR TITLE
systemd: make makamujo.service manage display services

### DIFF
--- a/etc/systemd/README.md
+++ b/etc/systemd/README.md
@@ -27,7 +27,9 @@ sudo make install
 
 The `make install` target copies all `etc/systemd/*.service` units to `/etc/systemd/system/` and enables `makamujo.service`.
 
-If you want to enable the persistent display services as well:
+`makamujo.service` now also controls `xorg10.service` and `x11vnc-10.service` when those units are installed. Restarting or stopping `makamujo.service` will propagate to the persistent display services.
+
+If you want to enable the persistent display services as standalone units in addition to `makamujo.service`:
 
 ```sh
 sudo systemctl enable --now xorg10.service x11vnc-10.service

--- a/etc/systemd/makamujo.service
+++ b/etc/systemd/makamujo.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=makamujo service
-After=graphical.target
-Wants=graphical.target
+After=graphical.target xorg10.service x11vnc-10.service
+Wants=graphical.target xorg10.service x11vnc-10.service
 
 # Service runs multiple backgrounded processes and the start script exits.
 # Use oneshot + RemainAfterExit so systemd considers the service active

--- a/etc/systemd/x11vnc-10.service
+++ b/etc/systemd/x11vnc-10.service
@@ -2,6 +2,7 @@
 Description=x11vnc for Xorg :10
 After=xorg10.service
 Requires=xorg10.service
+PartOf=makamujo.service
 
 [Service]
 Type=simple

--- a/etc/systemd/xorg10.service
+++ b/etc/systemd/xorg10.service
@@ -2,6 +2,7 @@
 Description=Persistent Xorg server on :10
 After=network.target
 Wants=network.target
+PartOf=makamujo.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
This PR updates etc/systemd/makamujo.service so it depends on xorg10.service and x11vnc-10.service, and adds PartOf=makamujo.service to the display units. The change also documents that restarting or stopping makamujo.service now propagates to the persistent display services.