### PR TITLE
docs(systemd): clean up systemd README stop section

### DIFF
--- a/etc/systemd/README.md
+++ b/etc/systemd/README.md
@@ -41,12 +41,6 @@ sudo systemctl enable --now xorg10.service x11vnc-10.service
 sudo systemctl stop makamujo.service
 ```
 
-3. Stop the service:
-
-```sh
-sudo systemctl stop makamujo.service
-```
-
 4. View logs (journalctl):
 
 ```sh


### PR DESCRIPTION
This PR cleans up the etc/systemd/README.md file by removing the duplicated stop section and clarifying the service shutdown instructions. It is based on the latest main branch.