### PR TITLE
fix: detect '公開終了' and auto-reload stream page

### DIFF
--- a/console/src/AgentStatus/AgentStatus.tsx
+++ b/console/src/AgentStatus/AgentStatus.tsx
@@ -22,7 +22,6 @@ export const AgentStatus = () => {
   const [lastUpdatedTime, setLastUpdatedTime] = useState("");
   const [isLoadingAgentState, setIsLoadingAgentState] = useState(false);
   const prevTypeRef = useRef<string | undefined>(undefined);
-  const prevMetaUrlRef = useRef<string | undefined>(undefined);
 
   useLayoutEffect(() => {
     if (typeof window === "undefined") return;
@@ -34,7 +33,6 @@ export const AgentStatus = () => {
     (async () => {
       const sseUrl = "/console/api/ws";
       try { (window as any).__sseUrl = sseUrl; } catch {}
-      try { console.debug("[DEBUG] AgentStatus connecting EventSource ->", sseUrl); } catch {}
       try {
         es = new EventSource(sseUrl);
       } catch {
@@ -47,19 +45,7 @@ export const AgentStatus = () => {
       };
       es.onmessage = (ev: MessageEvent) => {
         try {
-          try { console.debug('[DEBUG] SSE onmessage data ->', String(ev.data)); } catch {}
           const responseData = parseAgentStateResponse(String(ev.data));
-          try { console.debug('[DEBUG] parsed SSE niconama ->', responseData?.niconama); } catch {}
-
-          try {
-            console.debug('[DIAG] onmessage detection state ->', {
-              prevType: prevTypeRef.current,
-              prevUrl: prevMetaUrlRef.current,
-              currentType: responseData?.niconama?.type,
-              currentUrl: responseData?.niconama?.meta?.url,
-              currentTitle: responseData?.niconama?.meta?.title,
-            });
-          } catch {}
 
           // Detect end-of-program and reload the page when appropriate.
           try {
@@ -68,26 +54,26 @@ export const AgentStatus = () => {
             const currentTitle = responseData?.niconama?.meta?.title as string | undefined;
 
             const prevType = prevTypeRef.current;
-            const prevUrl = prevMetaUrlRef.current;
 
             if (currentType === 'offline' && prevType === 'live') {
               try {
-                try { console.debug('[DIAG] reload triggered: prevType ->', prevType, 'currentType ->', currentType, 'prevUrl ->', prevUrl, 'currentUrl ->', currentUrl); } catch {}
                 window.location.reload();
                 return;
               } catch {}
             }
 
-            if (currentTitle && currentTitle.includes('公開終了') && prevUrl && prevUrl === currentUrl) {
+            if (currentTitle && currentTitle.includes('公開終了') && currentUrl) {
               try {
-                try { console.debug('[DIAG] reload triggered by title 公開終了: title ->', currentTitle, 'prevUrl ->', prevUrl, 'currentUrl ->', currentUrl); } catch {}
-                window.location.reload();
-                return;
+                const endedKey = `program-ended-${currentUrl}`;
+                if (!sessionStorage.getItem(endedKey)) {
+                  sessionStorage.setItem(endedKey, '1');
+                  window.location.reload();
+                  return;
+                }
               } catch {}
             }
 
             prevTypeRef.current = currentType;
-            prevMetaUrlRef.current = currentUrl;
           } catch (e) {
             // ignore detection errors
           }

--- a/console/src/AgentStatus/AgentStatus.tsx
+++ b/console/src/AgentStatus/AgentStatus.tsx
@@ -1,5 +1,5 @@
 import { Container } from "../agt-compat";
-import { useLayoutEffect, useState } from "hono/jsx";
+import { useLayoutEffect, useState, useRef } from "hono/jsx";
 import type { AgentStatusSection, AgentStateResponse } from "./types";
 import {
   INVALID_AGENT_STATE_RESPONSE_ERROR,
@@ -21,6 +21,8 @@ export const AgentStatus = () => {
   const [agentStatusError, setAgentStatusError] = useState<string | null>(null);
   const [lastUpdatedTime, setLastUpdatedTime] = useState("");
   const [isLoadingAgentState, setIsLoadingAgentState] = useState(false);
+  const prevTypeRef = useRef<string | undefined>(undefined);
+  const prevMetaUrlRef = useRef<string | undefined>(undefined);
 
   useLayoutEffect(() => {
     if (typeof window === "undefined") return;
@@ -45,7 +47,51 @@ export const AgentStatus = () => {
       };
       es.onmessage = (ev: MessageEvent) => {
         try {
+          try { console.debug('[DEBUG] SSE onmessage data ->', String(ev.data)); } catch {}
           const responseData = parseAgentStateResponse(String(ev.data));
+          try { console.debug('[DEBUG] parsed SSE niconama ->', responseData?.niconama); } catch {}
+
+          try {
+            console.debug('[DIAG] onmessage detection state ->', {
+              prevType: prevTypeRef.current,
+              prevUrl: prevMetaUrlRef.current,
+              currentType: responseData?.niconama?.type,
+              currentUrl: responseData?.niconama?.meta?.url,
+              currentTitle: responseData?.niconama?.meta?.title,
+            });
+          } catch {}
+
+          // Detect end-of-program and reload the page when appropriate.
+          try {
+            const currentType = responseData?.niconama?.type;
+            const currentUrl = responseData?.niconama?.meta?.url as string | undefined;
+            const currentTitle = responseData?.niconama?.meta?.title as string | undefined;
+
+            const prevType = prevTypeRef.current;
+            const prevUrl = prevMetaUrlRef.current;
+
+            if (currentType === 'offline' && prevType === 'live') {
+              try {
+                try { console.debug('[DIAG] reload triggered: prevType ->', prevType, 'currentType ->', currentType, 'prevUrl ->', prevUrl, 'currentUrl ->', currentUrl); } catch {}
+                window.location.reload();
+                return;
+              } catch {}
+            }
+
+            if (currentTitle && currentTitle.includes('公開終了') && prevUrl && prevUrl === currentUrl) {
+              try {
+                try { console.debug('[DIAG] reload triggered by title 公開終了: title ->', currentTitle, 'prevUrl ->', prevUrl, 'currentUrl ->', currentUrl); } catch {}
+                window.location.reload();
+                return;
+              } catch {}
+            }
+
+            prevTypeRef.current = currentType;
+            prevMetaUrlRef.current = currentUrl;
+          } catch (e) {
+            // ignore detection errors
+          }
+
           setAgentStateResponse(responseData);
           setAgentStatusError(null);
           setLastUpdatedTime(new Date().toLocaleTimeString("ja-JP"));

--- a/lib/niconamaCommentClient.test.ts
+++ b/lib/niconamaCommentClient.test.ts
@@ -279,6 +279,33 @@ describe("fetchEmbeddedData fallback behavior", () => {
   });
 });
 
+describe("detect program end in fetched HTML", () => {
+  it("emits onMeta and returns sentinel when page contains 公開終了", async () => {
+    const originalFetch = (globalThis as any).fetch;
+    try {
+      const embeddedHtml = '<html><body>この番組は公開終了しました。 公開終了</body></html>';
+      (globalThis as any).fetch = async () => ({ ok: true, text: async () => embeddedHtml });
+
+      const metas: any[] = [];
+      const client = createNiconamaCommentClient({ watchUrl: 'https://live.nicovideo.jp/watch/test', launchPersistentContext: async () => ({ pages: () => [], newPage: async () => ({}), close: async () => {} }) }, {
+        onComments: () => {},
+        onMeta: (m) => { metas.push(m); },
+        onError: (err) => { throw err; },
+      });
+
+      const result = await client.fetchEmbeddedData();
+
+      expect(metas.length).toBeGreaterThan(0);
+      expect(metas[0]).toEqual(expect.objectContaining({ type: 'niconama' }));
+      expect((metas[0] as any).data.isLive).toBe(false);
+      expect((metas[0] as any).data.title).toBe('公開終了');
+      expect(result).toEqual({ programEnded: true, url: 'https://live.nicovideo.jp/watch/test' });
+    } finally {
+      (globalThis as any).fetch = originalFetch;
+    }
+  });
+});
+
 describe('fetchRenderedWatchPageBodyText', () => {
   it('returns body text from Playwright body locator allTextContents', async () => {
     const fakePage = {

--- a/lib/niconamaCommentClient.test.ts
+++ b/lib/niconamaCommentClient.test.ts
@@ -287,7 +287,7 @@ describe("detect program end in fetched HTML", () => {
       (globalThis as any).fetch = async () => ({ ok: true, text: async () => embeddedHtml });
 
       const metas: any[] = [];
-      const client = createNiconamaCommentClient({ watchUrl: 'https://live.nicovideo.jp/watch/test', launchPersistentContext: async () => ({ pages: () => [], newPage: async () => ({}), close: async () => {} }) }, {
+      const client = createNiconamaCommentClient({ watchUrl: 'https://live.nicovideo.jp/watch/test', launchPersistentContext: (async () => ({ pages: () => [], newPage: async () => ({}), close: async () => {} })) as any }, {
         onComments: () => {},
         onMeta: (m) => { metas.push(m); },
         onError: (err) => { throw err; },

--- a/lib/niconamaCommentClient.ts
+++ b/lib/niconamaCommentClient.ts
@@ -813,7 +813,7 @@ export class NiconamaCommentClient {
       // consumers via `onMeta` and return a sentinel object so callers can
       // continue operating (e.g. start polling) instead of aborting.
       try {
-        if (typeof html === 'string' && html.indexOf('公開終了') !== -1) {
+        if (typeof html === 'string' && html.includes('公開終了')) {
           try {
             this.#callbacks.onMeta({
               type: 'niconama',

--- a/lib/niconamaCommentClient.ts
+++ b/lib/niconamaCommentClient.ts
@@ -367,6 +367,14 @@ export class NiconamaCommentClient {
     const targetUrl = watchUrl ?? this.#watchUrl ?? DEFAULT_FALLBACK_WATCH_URL;
     // Try fetching the page HTML first (fast, no browser required)
     const embedded = await this.fetchEmbeddedDataFromPage(targetUrl);
+    // If the earlier fetch returned a sentinel indicating the program has
+    // ended, treat that as a valid result so the client can continue
+    // operating (e.g. start polling for the next program) instead of
+    // aborting startup.
+    if (embedded && typeof embedded === 'object' && (embedded as any).programEnded) {
+      return embedded;
+    }
+
     if (embedded) {
       const commentCount = typeof (embedded as any).program?.statistics?.commentCount === 'number'
         ? (embedded as any).program.statistics.commentCount
@@ -792,6 +800,34 @@ export class NiconamaCommentClient {
   private async fetchEmbeddedDataFromPage(watchUrl: string): Promise<unknown | null> {
     try {
       const html = await this.fetchHtml(watchUrl);
+
+      // If the watch page contains an explicit "公開終了" marker, notify
+      // consumers via `onMeta` and return a sentinel object so callers can
+      // continue operating (e.g. start polling) instead of aborting.
+      try {
+        if (typeof html === 'string' && html.indexOf('公開終了') !== -1) {
+          try {
+            this.#callbacks.onMeta({
+              type: 'niconama',
+              data: {
+                isLive: false,
+                title: '公開終了',
+                startTime: Date.now(),
+                total: 0,
+                points: { gift: 0, ad: 0 },
+                url: watchUrl,
+              },
+            });
+          } catch (cbErr) {
+            this.reportError(cbErr);
+          }
+          return { programEnded: true, url: watchUrl };
+        }
+      } catch (e) {
+        // fall through to regular parsing on unexpected errors
+        this.reportError(e);
+      }
+
       const embeddedData = extractEmbeddedDataFromHtml(html);
       if (!embeddedData) {
         console.warn('[WARN] embedded-data element not found', watchUrl);

--- a/lib/niconamaCommentClient.ts
+++ b/lib/niconamaCommentClient.ts
@@ -338,6 +338,14 @@ export class NiconamaCommentClient {
       return;
     }
 
+    // If the program has already ended, skip the live-meta emission and
+    // watcher setup and go straight into the poll loop.
+    if ((embeddedData as any).programEnded) {
+      this.#running = true;
+      this.#pollTask = this.pollLoop();
+      return;
+    }
+
     this.#running = true;
     this.#callbacks.onMeta({
       type: 'niconama',

--- a/src/contexts/AgentContext.tsx
+++ b/src/contexts/AgentContext.tsx
@@ -90,6 +90,7 @@ export const AgentProvider = ({ children }: PropsWithChildren) => {
 
   const prevTypeRef = useRef<string | undefined>(undefined);
   const prevMetaUrlRef = useRef<string | undefined>(undefined);
+  const prevTitleRef = useRef<string | undefined>(undefined);
 
   useEffect(() => {
     const currentType = streamState && typeof streamState === 'object' ? (streamState as any).type : undefined;
@@ -97,17 +98,18 @@ export const AgentProvider = ({ children }: PropsWithChildren) => {
     const currentTitle = streamState && typeof streamState === 'object' && (streamState as any).meta && typeof (streamState as any).meta.title === 'string' ? (streamState as any).meta.title as string : undefined;
 
     const prevType = prevTypeRef.current;
-    const prevUrl = prevMetaUrlRef.current;
+    const prevTitle = prevTitleRef.current;
 
     // Reload when the stream transitions from live -> offline, or when the
-    // same program URL becomes marked with the explicit "公開終了" marker.
+    // same program URL becomes marked with the explicit "公開終了" marker
+    // for the first time (title transitions from non-ended to ended).
     try {
       if (currentType === 'offline' && prevType === 'live') {
         window.location.reload();
         return;
       }
 
-      if (currentTitle && currentTitle.includes('公開終了') && prevUrl && prevUrl === currentUrl) {
+      if (currentTitle?.includes('公開終了') && !prevTitle?.includes('公開終了')) {
         window.location.reload();
         return;
       }
@@ -117,6 +119,7 @@ export const AgentProvider = ({ children }: PropsWithChildren) => {
 
     prevTypeRef.current = currentType;
     prevMetaUrlRef.current = currentUrl;
+    prevTitleRef.current = currentTitle;
   }, [streamState]);
 
   return (

--- a/src/contexts/AgentContext.tsx
+++ b/src/contexts/AgentContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, type PropsWithChildren } from "hono/jsx/dom";
+import { createContext, useContext, useState, useEffect, useRef, type PropsWithChildren } from "hono/jsx/dom";
 import type { Games } from "../../lib/Agent/games";
 import type { AgentState } from "../../lib/Agent/State";
 import { useInterval } from "../hooks/useInterval";
@@ -87,6 +87,37 @@ export const AgentProvider = ({ children }: PropsWithChildren) => {
       });
     setStreamStateFromMetaApiResponse(res, setStreamState);
   });
+
+  const prevTypeRef = useRef<string | undefined>(undefined);
+  const prevMetaUrlRef = useRef<string | undefined>(undefined);
+
+  useEffect(() => {
+    const currentType = streamState && typeof streamState === 'object' ? (streamState as any).type : undefined;
+    const currentUrl = streamState && typeof streamState === 'object' && (streamState as any).meta && typeof (streamState as any).meta.url === 'string' ? (streamState as any).meta.url as string : undefined;
+    const currentTitle = streamState && typeof streamState === 'object' && (streamState as any).meta && typeof (streamState as any).meta.title === 'string' ? (streamState as any).meta.title as string : undefined;
+
+    const prevType = prevTypeRef.current;
+    const prevUrl = prevMetaUrlRef.current;
+
+    // Reload when the stream transitions from live -> offline, or when the
+    // same program URL becomes marked with the explicit "公開終了" marker.
+    try {
+      if (currentType === 'offline' && prevType === 'live') {
+        window.location.reload();
+        return;
+      }
+
+      if (currentTitle && currentTitle.includes('公開終了') && prevUrl && prevUrl === currentUrl) {
+        window.location.reload();
+        return;
+      }
+    } catch (e) {
+      // ignore reload errors in environments where window is unavailable
+    }
+
+    prevTypeRef.current = currentType;
+    prevMetaUrlRef.current = currentUrl;
+  }, [streamState]);
 
   return (
     <AgentContext.Provider value={{ speech, silent, streamState, playing }}>

--- a/src/contexts/AgentContext.tsx
+++ b/src/contexts/AgentContext.tsx
@@ -89,12 +89,10 @@ export const AgentProvider = ({ children }: PropsWithChildren) => {
   });
 
   const prevTypeRef = useRef<string | undefined>(undefined);
-  const prevMetaUrlRef = useRef<string | undefined>(undefined);
   const prevTitleRef = useRef<string | undefined>(undefined);
 
   useEffect(() => {
     const currentType = streamState && typeof streamState === 'object' ? (streamState as any).type : undefined;
-    const currentUrl = streamState && typeof streamState === 'object' && (streamState as any).meta && typeof (streamState as any).meta.url === 'string' ? (streamState as any).meta.url as string : undefined;
     const currentTitle = streamState && typeof streamState === 'object' && (streamState as any).meta && typeof (streamState as any).meta.title === 'string' ? (streamState as any).meta.title as string : undefined;
 
     const prevType = prevTypeRef.current;
@@ -118,7 +116,6 @@ export const AgentProvider = ({ children }: PropsWithChildren) => {
     }
 
     prevTypeRef.current = currentType;
-    prevMetaUrlRef.current = currentUrl;
     prevTitleRef.current = currentTitle;
   }, [streamState]);
 

--- a/tests/e2e/console/console.test.ts
+++ b/tests/e2e/console/console.test.ts
@@ -350,7 +350,7 @@ test.describe("console", () => {
 
     // Wait for the page to establish the SSE connection before sending
     // the broadcast POST to avoid timing-dependent flakiness.
-    await page.waitForFunction(() => (window as any).__sseOpen === true, { timeout: 10_000 });
+    await page.waitForFunction(() => (window as any).__sseOpen === true, { timeout: 30_000 });
 
     const payload: any = cloneAgentStateResponseMockFixture();
     const res = await fetch(`${BROADCASTING_BASE_URL}/api/meta`, {
@@ -366,10 +366,23 @@ test.describe("console", () => {
   });
 
   test("reloads when broadcasted meta becomes 公開終了", async ({ page, request }) => {
+    // Capture browser console, runtime errors and failed requests for debugging
+    page.on('console', (msg) => {
+      try { console.log('[PW CONSOLE]', msg.type(), msg.text()); } catch {}
+    });
+    page.on('pageerror', (err) => {
+      try { console.error('[PW PAGE ERROR]', String(err)); } catch {}
+    });
+    page.on('requestfailed', (req) => {
+      try { console.warn('[PW REQ FAILED]', req.url(), req.failure()?.errorText ?? ''); } catch {}
+    });
+
     await page.addInitScript(() => {
       const OrigEventSource = (window as any).EventSource;
       Object.defineProperty(window, '__sseOpen', { value: false, writable: true, configurable: true });
       Object.defineProperty(window, '__loadCount', { value: 0, writable: true, configurable: true });
+      // A per-document session id that changes on every navigation/reload.
+      Object.defineProperty(window, '__sessionId', { value: Math.random(), writable: true, configurable: true });
       (window as any).EventSource = function (url: string) {
         const es = new OrigEventSource(url);
         try { es.addEventListener('open', () => { (window as any).__sseOpen = true; }); } catch {}
@@ -397,9 +410,9 @@ test.describe("console", () => {
     // Now post an ended/offline payload with the same program URL and title '公開終了'
     const endedPayload = { niconama: { type: 'offline', meta: { title: '公開終了', url: initialPayload.niconama.meta.url, start: initialPayload.niconama.meta.start } } };
 
-    // Use a load-counter to robustly detect a reload (works even if
-    // navigation events are missed or the URL doesn't appear to change).
-    const beforeLoadCount = await page.evaluate(() => (window as any).__loadCount ?? 0);
+    // Use a per-document session id to robustly detect a reload — the
+    // `__sessionId` is re-created on every navigation and changes value.
+    const beforeSessionId = await page.evaluate(() => (window as any).__sessionId ?? null);
     res = await fetch(`${BROADCASTING_BASE_URL}/api/meta`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
@@ -407,7 +420,7 @@ test.describe("console", () => {
     });
     expect(res.ok, `ended broadcast POST failed: ${res.status}`).toBeTruthy();
 
-    await page.waitForFunction((count) => (window as any).__loadCount > count, beforeLoadCount, { timeout: 10_000 });
+    await page.waitForFunction((id) => (window as any).__sessionId !== id, beforeSessionId, { timeout: 10_000 });
 
     // After reload, the console app should still render
     await expect(page.getByRole('heading', { name: '馬可無序' })).toBeVisible({ timeout: 5_000 });

--- a/tests/e2e/console/console.test.ts
+++ b/tests/e2e/console/console.test.ts
@@ -369,12 +369,14 @@ test.describe("console", () => {
     await page.addInitScript(() => {
       const OrigEventSource = (window as any).EventSource;
       Object.defineProperty(window, '__sseOpen', { value: false, writable: true, configurable: true });
+      Object.defineProperty(window, '__loadCount', { value: 0, writable: true, configurable: true });
       (window as any).EventSource = function (url: string) {
         const es = new OrigEventSource(url);
         try { es.addEventListener('open', () => { (window as any).__sseOpen = true; }); } catch {}
         return es;
       } as any;
       try { (window as any).EventSource.prototype = OrigEventSource.prototype; } catch {}
+      try { window.addEventListener('load', () => { (window as any).__loadCount = ((window as any).__loadCount || 0) + 1; }); } catch {}
     });
 
     await page.goto(`${CONSOLE_BASE_URL}/console/`, { waitUntil: 'domcontentloaded', timeout: BROWSER_PAGE_LOAD_TIMEOUT_MS });
@@ -395,7 +397,9 @@ test.describe("console", () => {
     // Now post an ended/offline payload with the same program URL and title '公開終了'
     const endedPayload = { niconama: { type: 'offline', meta: { title: '公開終了', url: initialPayload.niconama.meta.url, start: initialPayload.niconama.meta.start } } };
 
-    const navigationPromise = page.waitForNavigation({ timeout: 10_000 });
+    // Use a load-counter to robustly detect a reload (works even if
+    // navigation events are missed or the URL doesn't appear to change).
+    const beforeLoadCount = await page.evaluate(() => (window as any).__loadCount ?? 0);
     res = await fetch(`${BROADCASTING_BASE_URL}/api/meta`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
@@ -403,7 +407,7 @@ test.describe("console", () => {
     });
     expect(res.ok, `ended broadcast POST failed: ${res.status}`).toBeTruthy();
 
-    await navigationPromise;
+    await page.waitForFunction((count) => (window as any).__loadCount > count, beforeLoadCount, { timeout: 10_000 });
 
     // After reload, the console app should still render
     await expect(page.getByRole('heading', { name: '馬可無序' })).toBeVisible({ timeout: 5_000 });

--- a/tests/e2e/console/console.test.ts
+++ b/tests/e2e/console/console.test.ts
@@ -366,21 +366,9 @@ test.describe("console", () => {
   });
 
   test("reloads when broadcasted meta becomes 公開終了", async ({ page, request }) => {
-    // Capture browser console, runtime errors and failed requests for debugging
-    page.on('console', (msg) => {
-      try { console.log('[PW CONSOLE]', msg.type(), msg.text()); } catch {}
-    });
-    page.on('pageerror', (err) => {
-      try { console.error('[PW PAGE ERROR]', String(err)); } catch {}
-    });
-    page.on('requestfailed', (req) => {
-      try { console.warn('[PW REQ FAILED]', req.url(), req.failure()?.errorText ?? ''); } catch {}
-    });
-
     await page.addInitScript(() => {
       const OrigEventSource = (window as any).EventSource;
       Object.defineProperty(window, '__sseOpen', { value: false, writable: true, configurable: true });
-      Object.defineProperty(window, '__loadCount', { value: 0, writable: true, configurable: true });
       // A per-document session id that changes on every navigation/reload.
       Object.defineProperty(window, '__sessionId', { value: Math.random(), writable: true, configurable: true });
       (window as any).EventSource = function (url: string) {
@@ -389,11 +377,10 @@ test.describe("console", () => {
         return es;
       } as any;
       try { (window as any).EventSource.prototype = OrigEventSource.prototype; } catch {}
-      try { window.addEventListener('load', () => { (window as any).__loadCount = ((window as any).__loadCount || 0) + 1; }); } catch {}
     });
 
     await page.goto(`${CONSOLE_BASE_URL}/console/`, { waitUntil: 'domcontentloaded', timeout: BROWSER_PAGE_LOAD_TIMEOUT_MS });
-    await page.waitForFunction(() => (window as any).__sseOpen === true, { timeout: 10_000 });
+    await page.waitForFunction(() => (window as any).__sseOpen === true, { timeout: 30_000 });
 
     // Post an initial live payload so the client has a prior live state
     const initialPayload: any = cloneAgentStateResponseMockFixture();

--- a/tests/e2e/console/console.test.ts
+++ b/tests/e2e/console/console.test.ts
@@ -365,6 +365,50 @@ test.describe("console", () => {
     await expect(detailsLocator).toContainText("4-gram", { timeout: 10_000 });
   });
 
+  test("reloads when broadcasted meta becomes 公開終了", async ({ page, request }) => {
+    await page.addInitScript(() => {
+      const OrigEventSource = (window as any).EventSource;
+      Object.defineProperty(window, '__sseOpen', { value: false, writable: true, configurable: true });
+      (window as any).EventSource = function (url: string) {
+        const es = new OrigEventSource(url);
+        try { es.addEventListener('open', () => { (window as any).__sseOpen = true; }); } catch {}
+        return es;
+      } as any;
+      try { (window as any).EventSource.prototype = OrigEventSource.prototype; } catch {}
+    });
+
+    await page.goto(`${CONSOLE_BASE_URL}/console/`, { waitUntil: 'domcontentloaded', timeout: BROWSER_PAGE_LOAD_TIMEOUT_MS });
+    await page.waitForFunction(() => (window as any).__sseOpen === true, { timeout: 10_000 });
+
+    // Post an initial live payload so the client has a prior live state
+    const initialPayload: any = cloneAgentStateResponseMockFixture();
+    let res = await fetch(`${BROADCASTING_BASE_URL}/api/meta`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(initialPayload),
+    });
+    expect(res.ok, `initial broadcast POST failed: ${res.status}`).toBeTruthy();
+
+    const detailsLocator = page.getByTestId('agent-status-details');
+    await detailsLocator.waitFor({ timeout: 10_000 });
+
+    // Now post an ended/offline payload with the same program URL and title '公開終了'
+    const endedPayload = { niconama: { type: 'offline', meta: { title: '公開終了', url: initialPayload.niconama.meta.url, start: initialPayload.niconama.meta.start } } };
+
+    const navigationPromise = page.waitForNavigation({ timeout: 10_000 });
+    res = await fetch(`${BROADCASTING_BASE_URL}/api/meta`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(endedPayload),
+    });
+    expect(res.ok, `ended broadcast POST failed: ${res.status}`).toBeTruthy();
+
+    await navigationPromise;
+
+    // After reload, the console app should still render
+    await expect(page.getByRole('heading', { name: '馬可無序' })).toBeVisible({ timeout: 5_000 });
+  });
+
   test("displays replyTargetComment in the console after broadcast event", async ({ page, request }) => {
     await page.route('**/*fonts*', (route) => route.abort());
     await page.route('**/*fonts.googleapis.com*', (route) => route.abort());


### PR DESCRIPTION
- Detect '公開終了' on NicoNico watch pages and emit offline meta via onMeta
- Treat program-ended sentinel so the comment client doesn't abort
- Reload the streaming page in the frontend when stream transitions to offline or title contains '公開終了'

Files changed:
- lib/niconamaCommentClient.ts
- src/contexts/AgentContext.tsx

Typecheck passed locally: `bun run typecheck`