### PR TITLE
fix(systemd): align makamujo.service DISPLAY with xorg10.service

### DIFF
--- a/etc/systemd/README.md
+++ b/etc/systemd/README.md
@@ -50,6 +50,7 @@ sudo journalctl -u makamujo.service -f
 ## Notes
 
 - `bin/start` requires an X Window session. The unit is configured to start after `graphical.target` so it will wait for the graphical session.
+- This service assumes the persistent Xorg display is on `:10` to match `xorg10.service` and `x11vnc-10.service`.
 - If `bin/start` must run as a non-root user and access the X display, edit the service and add `User=yourusername` and suitable `Environment=` settings (for example `DISPLAY` and `XAUTHORITY`).
 - Adjust `WorkingDirectory` and `ExecStart` paths if you install the application to a different location.
 

--- a/etc/systemd/makamujo.service
+++ b/etc/systemd/makamujo.service
@@ -13,7 +13,7 @@ WorkingDirectory=/opt/makamujo
 User=root
 Environment=PATH=/root/.bun/bin:/usr/local/bin:/usr/bin:/bin
 Environment=NODE_ENV=production
-Environment=DISPLAY=:0
+Environment=DISPLAY=:10
 ExecStart=/opt/makamujo/bin/start-with-xauth.sh
 ExecStop=/opt/makamujo/bin/stop
 StandardOutput=journal


### PR DESCRIPTION
Fix makamujo.service to use DISPLAY=:10 so it matches the persistent display configured by xorg10.service. Also document the expected display in etc/systemd/README.md.