### PR TITLE
fix: allow OBS Flatpak access to obs-studio config and cache

### DIFF
--- a/bin/obs-studio
+++ b/bin/obs-studio
@@ -6,10 +6,13 @@ SCRIPT_PATH=$(cd "$(dirname "$0")" && pwd)
 REPO_ROOT=$(cd "$SCRIPT_PATH/.." && pwd)
 OBS_CONFIG_DIR="$REPO_ROOT/obs-studio"
 
+mkdir -p "$REPO_ROOT/.cache"
+
 flatpak run -vv \
     --share=network \
-    --filesystem="$OBS_CONFIG_DIR" \
+    --filesystem="$REPO_ROOT" \
     --env=XDG_CONFIG_HOME="$REPO_ROOT" \
     --env=XDG_DATA_HOME="$REPO_ROOT" \
+    --env=XDG_CACHE_HOME="$REPO_ROOT/.cache" \
     com.obsproject.Studio \
     "$@"

--- a/bin/obs-studio
+++ b/bin/obs-studio
@@ -4,7 +4,6 @@ set -eu
 
 SCRIPT_PATH=$(cd "$(dirname "$0")" && pwd)
 REPO_ROOT=$(cd "$SCRIPT_PATH/.." && pwd)
-OBS_CONFIG_DIR="$REPO_ROOT/obs-studio"
 
 mkdir -p "$REPO_ROOT/.cache"
 


### PR DESCRIPTION
This PR updates the OBS wrapper so Flatpak shares the full application prefix and sets XDG_CACHE_HOME. That ensures the bundled obs-studio config directory and basic.ini remain accessible when installed to /opt/makamujo.