### PR TITLE
Fix: WebSocket reconnect loop on keepalive message

### DIFF
--- a/lib/niconamaCommentClient.ts
+++ b/lib/niconamaCommentClient.ts
@@ -1007,6 +1007,9 @@ export class NiconamaCommentClient {
       return;
     }
     this.#directWebSocketAudienceToken = this.extractAudienceTokenFromWebSocketUrl(webSocketUrl);
+    if (!this.#directWebSocketAudienceToken) {
+      console.warn('[WARN] direct websocket failed to extract audience token from url', { webSocketUrl, watchUrl });
+    }
 
     try {
       let WebSocketClass: any = (globalThis as any).WebSocket;
@@ -1065,7 +1068,13 @@ export class NiconamaCommentClient {
         } catch (e) {
           // ignore draining errors
         }
-        this.sendDirectWebSocketMessage({ type: 'keepSeat', audienceToken: this.#directWebSocketAudienceToken });
+        const keepSeatMessage = { type: 'keepSeat' } as any;
+        if (this.#directWebSocketAudienceToken) {
+          keepSeatMessage.audienceToken = this.#directWebSocketAudienceToken;
+        } else {
+          console.warn('[WARN] direct websocket sending keepSeat without audience token - server may force reconnect', { webSocketUrl });
+        }
+        this.sendDirectWebSocketMessage(keepSeatMessage);
       };
 
       ws.onmessage = (event: any) => {


### PR DESCRIPTION
## Problem
WebSocket connection established immediately reconnects without any apparent disconnection. The logs show:
```
[INFO] direct websocket established
[INFO] direct websocket requested reconnect
```
This loop occurs immediately after connection, indicating the server is forcing reconnection.

## Root Cause
The `keepSeat` message may be sent with a null/missing `audienceToken` if token extraction from the WebSocket URL fails. The server responds by forcing a reconnect, creating a reconnect loop.

## Solution
- Added validation and diagnostic logging for audience token extraction
- Made `audienceToken` conditionally included in keepSeat messages
- Added warnings when keepSeat is sent without a token to aid debugging

## Changes
- `lib/niconamaCommentClient.ts`: Added token extraction validation and enhanced diagnostics