### PR TITLE
fix: OBS起動時の環境変数を明示的に設定

### DIFF
--- a/etc/systemd/makamujo-obs.service
+++ b/etc/systemd/makamujo-obs.service
@@ -9,6 +9,10 @@ WorkingDirectory=/opt/makamujo
 User=root
 Environment=PATH=/root/.bun/bin:/usr/local/bin:/usr/bin:/bin
 Environment=DISPLAY=:10
+# Ensure OBS config and cache directories are accessible
+Environment=XDG_CONFIG_HOME=/opt/makamujo
+Environment=XDG_DATA_HOME=/opt/makamujo
+Environment=XDG_CACHE_HOME=/opt/makamujo/.cache
 ExecStart=/bin/sh -lc "cd '/opt/makamujo' && '/opt/makamujo/bin/x/obs'"
 StandardOutput=journal
 StandardError=journal


### PR DESCRIPTION
XDG_CONFIG_HOME, XDG_DATA_HOME, XDG_CACHE_HOME を指定して flatpak環境でOBSが設定ファイルを正しく見つけられるようにします。

## 修正内容
- makamujo-obs.serviceに環境変数を追加
- OBSが basic.ini を正しく見つけられるように XDG ディレクトリを指定

## 背景
OBSが起動時に `failed to open basic.ini` エラーを出していたのは、systemd環境下で XDG 環境変数が正しく設定されていなかったため。