### PR TITLE
docs: update profile nav to 1-column vertical with new links and X tracking

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -129,11 +129,11 @@
         display: inline-block;
       }
 
-      /* ── Social links ── */
+      /* ── Profile nav ── */
       .links {
         display: flex;
-        flex-wrap: wrap;
-        gap: 0.75rem;
+        flex-direction: column;
+        gap: 0.5rem;
         margin-top: 0.5rem;
       }
 
@@ -252,14 +252,17 @@
           <span class="tagline-line">AIが自らゲームをプレイし、</span><span class="tagline-line">マルコフ連鎖によるトークとともにライブ配信するバーチャルYouTuberです。</span>
         </p>
         <div class="links">
-          <a class="link-btn link-btn--primary" href="https://live.nicovideo.jp/watch/user/14171889" target="_blank" rel="noopener noreferrer">
-            📺 ニコニコ生放送
+          <a class="link-btn link-btn--primary" href="https://live.nicovideo.jp/watch/user/14171889" target="_blank" rel="noopener noreferrer" id="live-link">
+            ニコニコ生放送で常時配信中！
           </a>
           <a class="link-btn" href="https://x.com/makamujo" target="_blank" rel="noopener noreferrer">
-            𝕏 @makamujo
+            X 公式アカウント @makamujo
           </a>
-          <a class="link-btn" href="https://github.com/nahcnuj/makamujo" target="_blank" rel="noopener noreferrer">
-            ⌨ GitHub
+          <a class="link-btn" href="https://github.com/nahcnuj/automated-gameplay-transmitter" target="_blank" rel="noopener noreferrer">
+            AIVTuberの配信フレームワーク
+          </a>
+          <a class="link-btn" href="https://github.com/sponsors/nahcnuj" target="_blank" rel="noopener noreferrer">
+            開発者を支援する
           </a>
         </div>
       </div>
@@ -298,5 +301,17 @@ a=t.getElementsByTagName(n)[0],a.parentNode.insertBefore(u,a))}(window,document,
 twq('config','ov0j6');
 </script>
 <!-- End X conversion tracking base code -->
+<script>
+(function () {
+  var liveLink = document.getElementById("live-link");
+  if (liveLink) {
+    liveLink.addEventListener("click", function () {
+      // X conversion tracking event code
+      twq("event", "tw-ov0j6-rdexl", {});
+      // End X conversion tracking event code
+    });
+  }
+})();
+</script>
   </body>
 </html>

--- a/docs/index.test.ts
+++ b/docs/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeEach, afterEach } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
 import { JSDOM } from "jsdom";
 
@@ -16,7 +16,7 @@ describe("docs/index.html", () => {
     const scriptRegex = /<script[^>]*>([\s\S]*?)<\/script>/g;
     let m: RegExpExecArray | null;
     while ((m = scriptRegex.exec(fullHtml)) !== null) {
-      const code = m[1];
+      const code = m[1] ?? "";
       if (code.includes("twq") || code.includes("live-link")) {
         scriptContents.push(code.trim());
       }
@@ -81,7 +81,9 @@ describe("docs/index.html", () => {
     expect(specificEvents.length).toBe(0);
 
     // Simulate click on the link
-    liveLink!.dispatchEvent(new (dom.window as any).MouseEvent("click", { bubbles: true }));
+    liveLink!.dispatchEvent(
+      new (dom.window as any).MouseEvent("click", { bubbles: true }),
+    );
 
     specificEvents = twqCalls.filter(
       (c) => c[0] === "event" && c[1] === "tw-ov0j6-rdexl",

--- a/docs/index.test.ts
+++ b/docs/index.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, beforeEach, afterEach } from "bun:test";
+import { readFileSync } from "node:fs";
+import { JSDOM } from "jsdom";
+
+describe("docs/index.html", () => {
+  let dom: JSDOM;
+  let twqCalls: any[][];
+
+  beforeEach(() => {
+    const fullHtml = readFileSync("docs/index.html", "utf-8");
+    twqCalls = [];
+
+    // Extract just the bodies of the two X-related scripts (base + handler) reliably.
+    // We do not rely on <script> execution or runScripts to avoid Proxy/fetch issues in JSDOM.
+    const scriptContents: string[] = [];
+    const scriptRegex = /<script[^>]*>([\s\S]*?)<\/script>/g;
+    let m: RegExpExecArray | null;
+    while ((m = scriptRegex.exec(fullHtml)) !== null) {
+      const code = m[1];
+      if (code.includes("twq") || code.includes("live-link")) {
+        scriptContents.push(code.trim());
+      }
+    }
+    const baseCode = scriptContents[0] || "";
+    const handlerCode = scriptContents[1] || "";
+
+    // Parse the HTML normally (scripts stripped implicitly by not running; DOM structure is what we need)
+    const cleanHtml = fullHtml.replace(/<script[^>]*>[\s\S]*?<\/script>/gi, "");
+    dom = new JSDOM(cleanHtml, { url: "https://example.com/" });
+
+    const window: any = dom.window;
+
+    // Spy function
+    function recordTwq(...args: any[]) {
+      twqCalls.push(args);
+    }
+    window.twq = recordTwq;
+    window.__twqCalls = twqCalls;
+
+    // Patch and eval the codes using fully qualified globals to avoid "not defined" in eval scope.
+    // This simulates the top level execution of the tracking scripts on "page load".
+    // Use new Function to execute handler code (IIFE) providing document and twq as params.
+    // This avoids bare "window"/"document" resolution problems inside eval().
+    if (handlerCode) {
+      try {
+        const injector = new window.Function("document", "twq", handlerCode);
+        injector(window.document, recordTwq);
+      } catch (e) {
+        // non-fatal for test
+      }
+    }
+  });
+
+  afterEach(() => {
+    if (dom) {
+      dom.window.close();
+    }
+  });
+
+  it("does not call twq('event', ...) on page load", () => {
+    // The conversion event tracking must NOT be invoked on page load.
+    // (The base code may call twq('config'), but event tracking is click-only.)
+    const eventCalls = twqCalls.filter(
+      (c) => c[0] === "event" && c[1] === "tw-ov0j6-rdexl",
+    );
+    expect(eventCalls.length).toBe(0);
+
+    // No event calls at all on load.
+    const anyEventCalls = twqCalls.filter((c) => c[0] === "event");
+    expect(anyEventCalls.length).toBe(0);
+  });
+
+  it("calls the X event tracking code when the niconico live link is clicked", () => {
+    const liveLink = dom.window.document.getElementById("live-link");
+    expect(liveLink).not.toBeNull();
+
+    // Ensure no event before click
+    let specificEvents = twqCalls.filter(
+      (c) => c[0] === "event" && c[1] === "tw-ov0j6-rdexl",
+    );
+    expect(specificEvents.length).toBe(0);
+
+    // Simulate click on the link
+    liveLink!.dispatchEvent(new (dom.window as any).MouseEvent("click", { bubbles: true }));
+
+    specificEvents = twqCalls.filter(
+      (c) => c[0] === "event" && c[1] === "tw-ov0j6-rdexl",
+    );
+    expect(specificEvents.length).toBe(1);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "setup": "bun --version && bun ci && bun run typecheck",
     "start": "NODE_ENV=production bun index.ts --port=7777",
     "typecheck": "tsc --noEmit",
-    "test": "bun test lib/ src/ routes/ console/src/",
+    "test": "bun test lib/ src/ routes/ console/src/ docs/",
     "test:integration": "MAKAMUJO_ALLOW_FALLBACK_TTS=1 bun test tests/integration/",
     "test:bin": "true",
     "test:e2e": "bun run test:e2e:specify -- tests/e2e",


### PR DESCRIPTION
﻿## Summary
- Changed the navigation directly under the profile (hero) section to a single-column vertical layout.
- Updated the 4 links to:
  - 「ニコニコ生放送で常時配信中！」 → https://live.nicovideo.jp/watch/user/14171889
  - 「X 公式アカウント @makamujo」 → https://x.com/makamujo
  - 「AIVTuberの配信フレームワーク」 → https://github.com/nahcnuj/automated-gameplay-transmitter
  - 「開発者を支援する」 → https://github.com/sponsors/nahcnuj
- The X conversion tracking event (twq('event', 'tw-ov0j6-rdexl', {})) is now executed **only** when the Niconico live link is clicked.
- Page load does **not** call the event tracking (base config still runs as before).

## Changes
- docs/index.html: layout + links + click handler script
- package.json: include docs/ in bun test
- docs/index.test.ts (new): JSDOM-based tests confirming no event tracking on load + fires on click

## Verification
- bun run test passes (including new test)
- Follows Conventional Commits + project test guidelines
