### PR TITLE
fix(reserve): use Playwright-bundled Chromium and sandbox flags for launchPersistentContext

### DIFF
--- a/bin/x/reserve.ts
+++ b/bin/x/reserve.ts
@@ -1,12 +1,13 @@
 #!/usr/bin/env bun
 
-import { statSync } from "node:fs";
+import { statSync, existsSync } from "node:fs";
 import { parseArgs } from "node:util";
 import { chromium } from "../../lib/Browser/chromium";
+import { getDefaultBrowserPath } from "../../lib/Browser/getDefaultBrowserPath";
 
 const { values: {
   'user-data-dir': userDataDir,
-  'exec-path': executablePath,
+  'exec-path': execPath,
   headless,
 } } = parseArgs({
   options: {
@@ -16,7 +17,6 @@ const { values: {
     },
     'exec-path': {
       type: 'string',
-      default: '/usr/bin/chromium',
     },
     headless: {
       short: 'y',
@@ -30,9 +30,20 @@ if (!statSync(userDataDir).isDirectory()) {
   throw new Error('--user-data-dir must be a directory path');
 }
 
+// Use explicit --exec-path (or its old default) only if the binary actually exists.
+// Otherwise fall back so that Playwright's bundled Chromium (from `playwright install`)
+// is used. This avoids SIGTRAP / immediate crashes from incompatible system Chromium
+// (common on servers, containers, or when /usr/bin/chromium is a distro build).
+const candidateExecutable = execPath ?? getDefaultBrowserPath();
+const effectiveExecutablePath = candidateExecutable && existsSync(candidateExecutable)
+  ? candidateExecutable
+  : undefined;
+
 const ctx = await chromium.launchPersistentContext(userDataDir, {
-  executablePath,
+  ...(effectiveExecutablePath ? { executablePath: effectiveExecutablePath } : {}),
   headless,
+  // Server/headless/root environments commonly require disabling the sandbox.
+  args: ['--no-sandbox', '--disable-setuid-sandbox'],
 });
 
 const page = ctx.pages()[0] ?? await ctx.newPage();


### PR DESCRIPTION
﻿## Summary
`bun ./bin/x/reserve.ts -y` (and non-y) was failing immediately with:

```
error: persistentContext: Target page, context or browser has been closed
...
[pid=...] <process did exit: exitCode=null, signal=SIGTRAP>
```

## Root cause
- `bin/x/reserve.ts` always passed `executablePath: '/usr/bin/chromium'` (the parse default) to `chromium.launchPersistentContext(...)` (the playwright-extra wrapped instance).
- On many Linux server environments (VPS, containers, running as root), the distro-provided `/usr/bin/chromium` is incompatible with the current Playwright version or has restricted `/sys` etc. It dies with SIGTRAP right after launch.
- No fallback existed (unlike `lib/Browser/chromium.ts:create()`).
- Sandbox flags were not explicitly passed for this code path (the niconama watcher already did this).

## Changes
- Compute `effectiveExecutablePath` using the same pattern as the rest of the Browser module: only use an explicit path if `existsSync(...)`.
- Fall back to Playwright's bundled Chromium (what `playwright install chromium` provides) when the candidate does not exist.
- Always pass `args: ['--no-sandbox', '--disable-setuid-sandbox']` (server-friendly).
- Use `getDefaultBrowserPath()` so `CHROMIUM_EXECUTABLE_PATH` env and platform defaults are respected.
- Updated the `--exec-path` parse default to `undefined` (the candidate logic now drives it).

This keeps the legacy behavior for people who have a working system Chromium while making the common case (Playwright-managed browser) reliable.

## Verification
- Targeted tests (`bun test lib/Browser/...`) pass.
- Manual reproduction of the launch path is now robust.
- No other files touched.

## Related
The same pattern is already used in `create()` and `PlaywrightCommentWatcher`.
