### PR TITLE
fix(browser): default to Playwright bundled Chromium instead of system browser

### DIFF
--- a/lib/Browser/chromium.ts
+++ b/lib/Browser/chromium.ts
@@ -16,13 +16,19 @@ export const create = async (
   },
 ): Promise<Browser> => {
   const launchTimeout = Number.parseInt(process.env.CHROMIUM_LAUNCH_TIMEOUT ?? '60000', 10);
-  // If an explicit executablePath was provided but the file doesn't exist,
-  // ignore it and fall back to the Playwright channel mode so that
-  // installed Playwright browsers can be used in CI environments.
+
+  // If an explicit executablePath was provided *and* the file exists on disk,
+  // use it. Otherwise leave it unset so Playwright uses the exact Chromium
+  // revision that matches this version of the `playwright` package
+  // (installed via `playwright install chromium`).
+  //
+  // We no longer default to `{ channel: 'chromium' }` because that forces
+  // discovery of a *system* browser and frequently leads to launch crashes
+  // (SIGTRAP, early exit) after Playwright updates when the system binary
+  // (e.g. /usr/bin/chromium) is not the matching revision.
   const effectiveExecutablePath = executablePath && existsSync(executablePath) ? executablePath : undefined;
 
-  const launchOpts = {
-    ...(effectiveExecutablePath ? { executablePath: effectiveExecutablePath } : { channel: 'chromium' }),
+  const launchOpts: any = {
     headless: process.env.CHROMIUM_HEADLESS === '1',
     timeout: launchTimeout,
     // https://peter.sh/experiments/chromium-command-line-switches/
@@ -32,6 +38,14 @@ export const create = async (
       '--window-position=1280,600',
     ],
   };
+
+  if (effectiveExecutablePath) {
+    launchOpts.executablePath = effectiveExecutablePath;
+  }
+
+  console.log('[INFO] launching browser', effectiveExecutablePath
+    ? `with executablePath=${effectiveExecutablePath}`
+    : 'using Playwright bundled Chromium (no executablePath)');
 
   const fallbackTimeout = 300000;
 
@@ -45,7 +59,7 @@ export const create = async (
     try {
       return await chromium.launch(firstTryOpts);
     } catch (firstErr) {
-      console.warn('[WARN]', 'chromium-extra launch failed, retrying with playwright.chromium', firstErr);
+      console.warn('[WARN]', 'chromium-extra launch failed, retrying with plain playwright.chromium', firstErr);
       const fallbackOpts = cloneLaunchOpts(baseOpts);
       return await playwright.chromium.launch(fallbackOpts);
     }
@@ -60,6 +74,13 @@ export const create = async (
       const fallbackOpts = { ...launchOpts, timeout: fallbackTimeout };
       browser = await launchWith(fallbackOpts);
     } else {
+      if (err instanceof Error) {
+        err.message = `Failed to launch Chromium. ` +
+          `Make sure you have run "bunx playwright install chromium" (or "playwright install chromium") ` +
+          `after updating Playwright. ` +
+          `If you want to force a system browser set CHROMIUM_EXECUTABLE_PATH.\n` +
+          `Original error: ${err.message}`;
+      }
       throw err;
     }
   }

--- a/lib/Browser/getDefaultBrowserPath.test.ts
+++ b/lib/Browser/getDefaultBrowserPath.test.ts
@@ -2,19 +2,18 @@ import { describe, it, expect } from "bun:test";
 import { getDefaultBrowserPath } from "./getDefaultBrowserPath";
 
 describe("getDefaultBrowserPath", () => {
-  it("returns /usr/bin/chromium for linux by default", () => {
-    expect(getDefaultBrowserPath("linux")).toBe("/usr/bin/chromium");
-  });
-
-  it("returns empty string for windows by default", () => {
-    expect(getDefaultBrowserPath("win32" as NodeJS.Platform)).toBe("");
-  });
-
-  it("returns darwin bundle path for macos", () => {
-    expect(getDefaultBrowserPath("darwin")).toBe("/Applications/Chromium.app/Contents/MacOS/Chromium");
+  it("returns undefined by default (lets Playwright use its bundled browser)", () => {
+    expect(getDefaultBrowserPath("linux")).toBeUndefined();
+    expect(getDefaultBrowserPath("win32" as NodeJS.Platform)).toBeUndefined();
+    expect(getDefaultBrowserPath("darwin")).toBeUndefined();
   });
 
   it("prefers env.CHROMIUM_EXECUTABLE_PATH when set", () => {
     expect(getDefaultBrowserPath("win32" as NodeJS.Platform, { ...process.env, CHROMIUM_EXECUTABLE_PATH: "C:\\local\\chrome.exe" })).toBe("C:\\local\\chrome.exe");
+    expect(getDefaultBrowserPath("linux", { ...process.env, CHROMIUM_EXECUTABLE_PATH: "/usr/bin/chromium" })).toBe("/usr/bin/chromium");
+  });
+
+  it("ignores platform when CHROMIUM_EXECUTABLE_PATH is set", () => {
+    expect(getDefaultBrowserPath("linux", { CHROMIUM_EXECUTABLE_PATH: "/opt/chrome/chrome" })).toBe("/opt/chrome/chrome");
   });
 });

--- a/lib/Browser/getDefaultBrowserPath.ts
+++ b/lib/Browser/getDefaultBrowserPath.ts
@@ -1,19 +1,14 @@
 export const getDefaultBrowserPath = (
-  platform: NodeJS.Platform = process.platform,
+  _platform: NodeJS.Platform = process.platform,
   env: NodeJS.ProcessEnv = process.env,
 ): string | undefined => {
   if (env.CHROMIUM_EXECUTABLE_PATH) {
     return env.CHROMIUM_EXECUTABLE_PATH;
   }
 
-  switch (platform) {
-    case "win32":
-      // Use Playwright channel mode (`chromium`) on Windows for bundled browser.
-      // Avoid hardcoding Linux-path `C:\\Program Files` because user may have different installs.
-      return "";
-    case "darwin":
-      return "/Applications/Chromium.app/Contents/MacOS/Chromium";
-    default:
-      return "/usr/bin/chromium";
-  }
+  // Default to undefined so that Playwright uses the bundled Chromium
+  // installed by `bunx playwright install chromium`.
+  // This avoids using whatever random /usr/bin/chromium the distro has,
+  // which frequently crashes with newer Playwright versions.
+  return undefined;
 };


### PR DESCRIPTION
﻿## Problem

After the Playwright 1.61 update, browser launches on Linux (the production streaming server) started failing with:

```
error: launch: Target page, context or browser has been closed
... SIGTRAP ...
<launching> /usr/bin/chromium ...
```

## Root cause

`getDefaultBrowserPath()` (called from `bin/x/browser.ts`) returned `/usr/bin/chromium` on Linux when the file existed. `chromium.ts` then passed it as `executablePath`.

Distro-packaged Chromium is almost never the exact revision that a given Playwright version was built and tested with. Newer Playwright versions emit launch flags / use launch protocols that make the mismatch fatal (early crash inside the browser process).

The previous version bump PR exposed this latent default.

## Changes

- `getDefaultBrowserPath()` now returns `undefined` by default (unless `CHROMIUM_EXECUTABLE_PATH` is set). This lets Playwright use the bundled browser installed by `bunx playwright install chromium`.
- `chromium.ts` no longer forces `{ channel: 'chromium' }`.
- Added a startup log so it's obvious which binary is being used.
- Improved error message that tells the operator to run the install command.
- Updated the unit tests.

## Migration / usage

- On servers: run `bunx playwright install chromium` (or with `--with-deps`) once after updating Playwright.
- If you *want* to keep using a system/custom browser, set `CHROMIUM_EXECUTABLE_PATH=/path/to/chrome`.
- Windows and macOS defaults were also unified to "use bundled" for consistency.

This should make launches reliable after future Playwright updates.
