### PR TITLE
fix(reserve): use getDefaultBrowserPath() for exec-path default

### DIFF
--- a/bin/x/reserve.ts
+++ b/bin/x/reserve.ts
@@ -1,8 +1,9 @@
 #!/usr/bin/env bun
 
-import { statSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import { parseArgs } from "node:util";
 import { chromium } from "../../lib/Browser/chromium";
+import { getDefaultBrowserPath } from "../../lib/Browser/getDefaultBrowserPath";
 
 const { values: {
   'user-data-dir': userDataDir,
@@ -16,7 +17,7 @@ const { values: {
     },
     'exec-path': {
       type: 'string',
-      default: '/usr/bin/chromium',
+      default: getDefaultBrowserPath(),
     },
     headless: {
       short: 'y',
@@ -30,10 +31,11 @@ if (!statSync(userDataDir).isDirectory()) {
   throw new Error('--user-data-dir must be a directory path');
 }
 
-const ctx = await chromium.launchPersistentContext(userDataDir, {
-  executablePath,
-  headless,
-});
+const launchOptions: any = { headless };
+if (executablePath && existsSync(executablePath)) {
+  launchOptions.executablePath = executablePath;
+}
+const ctx = await chromium.launchPersistentContext(userDataDir, launchOptions);
 
 const page = ctx.pages()[0] ?? await ctx.newPage();
 


### PR DESCRIPTION
bin/x/reserve.ts was still hardcoding \'/usr/bin/chromium'\ as the default for \--exec-path\.

This caused \un bin/x/reserve.ts\ (and similar) to always try to launch the system Chromium, which is incompatible with the current Playwright version and crashes with SIGTRAP (as seen in the user's report).

This was missed in #458 because the reserve script has its own CLI parsing instead of going through the main \create()\ helper.

Now:
- Defaults via \getDefaultBrowserPath()\ (i.e. Playwright bundled Chromium when \CHROMIUM_EXECUTABLE_PATH\ is not set).
- Only passes \executablePath\ when it's a valid existing file (consistent with the main launcher).
- Users can still override with \--exec-path\ or the env var.

After merging, run \unx playwright install chromium\ on servers if not already done, then \un bin/x/reserve.ts -y\ should work.