### PR TITLE
fix(reserve): use getDefaultBrowserPath() instead of hardcoding /usr/bin/chromium

### DIFF
--- a/bin/x/reserve.ts
+++ b/bin/x/reserve.ts
@@ -1,8 +1,9 @@
 #!/usr/bin/env bun
 
-import { statSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import { parseArgs } from "node:util";
 import { chromium } from "../../lib/Browser/chromium";
+import { getDefaultBrowserPath } from "../../lib/Browser/getDefaultBrowserPath";
 
 const { values: {
   'user-data-dir': userDataDir,
@@ -16,7 +17,7 @@ const { values: {
     },
     'exec-path': {
       type: 'string',
-      default: '/usr/bin/chromium',
+      default: getDefaultBrowserPath(),
     },
     headless: {
       short: 'y',
@@ -30,10 +31,11 @@ if (!statSync(userDataDir).isDirectory()) {
   throw new Error('--user-data-dir must be a directory path');
 }
 
-const ctx = await chromium.launchPersistentContext(userDataDir, {
-  executablePath,
-  headless,
-});
+const launchOptions: any = { headless };
+if (executablePath && existsSync(executablePath)) {
+  launchOptions.executablePath = executablePath;
+}
+const ctx = await chromium.launchPersistentContext(userDataDir, launchOptions);
 
 const page = ctx.pages()[0] ?? await ctx.newPage();
 


### PR DESCRIPTION
reserve.ts was the last place still hardcoding the system Chromium default.

Now consistently uses getDefaultBrowserPath() (undefined by default -> Playwright bundled) and only sets executablePath when the file actually exists.

This completes the commonization that had diverged because reserve.ts was copied from the transmitter project and maintained separately.