### PR TITLE
ci: enable CI for legacy branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,13 @@ name: CI
 
 on:
   push:
-    branches: ['main']
+    branches:
+      - main
+      - legacy
   pull_request:
-    branches: ['main']
+    branches:
+      - main
+      - legacy
 
 jobs:
   shellcheck:


### PR DESCRIPTION
## Summary

- Add `legacy` to `push` and `pull_request` branch filters in `.github/workflows/ci.yml` (same as `main`).

## Why this is on legacy (not only main)

`main` already lists `legacy` (since #451). For same-repo PRs **into** `legacy`, GitHub runs the workflow from the PR merge commit, which is based on the **legacy** tree. Legacy still only had `branches: [main]`, so base `legacy` never matched and checks stayed empty (e.g. #463).

Pushes to `legacy` also use the workflow file **on that branch**, so legacy itself must include the trigger.

## Test plan

- [ ] After merge, open or push to a PR targeting `legacy` and confirm the CI workflow starts
- [ ] Push to `legacy` and confirm a CI run appears