### PR TITLE
refactor(console): domain model for console access, status plan, SSE, and outer WS

### DIFF
--- a/architecture/README.md
+++ b/architecture/README.md
@@ -8,28 +8,25 @@
 
 | ファイル | 内容 |
 |----------|------|
-| [domain-model-redesign.md](./domain-model-redesign.md) | `legacy` 向けドメインモデル駆動再設計（正本）。ユビキタス言語、境界づけられたコンテキスト、CommentPipeline / silence / Publication 契約、Phase A/B/C の PR Plan |
+| [domain-model-redesign.md](./domain-model-redesign.md) | 配信エージェント BC 再設計（#463 マージ済）。CommentPipeline / silence / Publication |
+| [console-domain-model.md](./console-domain-model.md) | **管理コンソール BC**（Access / Status plan）。UI は `console/src`、純関数は `lib/domain/console` |
 
 ## 読み方（実装エージェント向け）
 
 1. 振る舞い変更はしない。観測可能な契約は設計書の characterization / observables 節に従う。
-2. 実装は **Phase A から**（契約文書 → 回帰テスト → 純関数 → Publication → composition 薄型化）。
-3. `CommentApplicationService` 等の大きな分割は Phase B。Phase A 完了後に必要性を判断してよい（浅いモジュール化での停止も正当）。
-4. コード変更時は既存の `lib/Agent/index.test.ts` と設計書の CommentPipeline / `speechable` 順序アルゴリズムをゴールデンとする。
+2. **配信エージェント**（#463 済）: `lib/Agent/index.test.ts` と CommentPipeline / `speechable` がゴールデン。
+3. **管理コンソール**（継続）: `lib/domain/console/*` の純関数 + 既存 `console/src` / integration テストがゴールデン。
+4. `docs/` は静的サイト専用。設計 Markdown は `architecture/` のみ。
 
-## 実装マップ（Phase A）
+## 実装マップ
 
-| 領域 | パス |
-|------|------|
-| NGram / Silence | `lib/domain/broadcasting/` |
-| Topic / System scripts | `lib/domain/comments/` |
-| 空発話ルール | `lib/domain/speech/` |
-| Publication assemble | `lib/domain/publication/` |
-| SpeechQueue | `lib/application/SpeechQueue.ts` |
-| composition helpers | `composition/` |
-| AgentSession + application services | `lib/application/`（Phase B） |
-| ファサード | `lib/Agent/index.ts` |
-| AGT `./agent` 優先 import | `composition/agentWiring.ts`（Phase C; AGT ≥ 0.6.5） |
+| 領域 | パス | 状態 |
+|------|------|------|
+| NGram / Silence / Topic / Scripts | `lib/domain/*` | 済 |
+| Publication assemble | `lib/domain/publication/` | 済 |
+| AgentSession + services | `lib/application/` | 済 |
+| Console access / status plan | `lib/domain/console/` | 本スライス |
+| Console UI | `console/src/AgentStatus/` | ファサード維持 |
 
 ## 関連
 

--- a/architecture/README.md
+++ b/architecture/README.md
@@ -25,7 +25,8 @@
 | NGram / Silence / Topic / Scripts | `lib/domain/*` | 済 |
 | Publication assemble | `lib/domain/publication/` | 済 |
 | AgentSession + services | `lib/application/` | 済 |
-| Console access / status plan | `lib/domain/console/` | 本スライス |
+| Console access / status plan / SSE frames | `lib/domain/console/` | 済 |
+| Outer console WS bridge | `composition/consoleOuterWebSocket.ts` | 済 |
 | Console UI | `console/src/AgentStatus/` | ファサード維持 |
 
 ## 関連

--- a/architecture/console-domain-model.md
+++ b/architecture/console-domain-model.md
@@ -67,10 +67,17 @@ flowchart LR
 | UI re-export formatters | `console/src/AgentStatus/agentStatusUtils.tsx` |
 | 公開ペイロード型 | `lib/domain/publication/types.ts` ↔ `console/.../types.ts`（文書で整合） |
 
+## 追加スライス（実装済）
+
+| 領域 | パス |
+|------|------|
+| SSE 境界 / 完全フレーム抽出 | `lib/domain/console/sseFrames.ts` |
+| 外側 WS ブリッジ | `composition/consoleOuterWebSocket.ts` |
+| プロキシ本体 | `lib/console-proxy.ts`（純関数を利用） |
+
 ## 今後（任意）
 
-- `console-proxy.ts` の SSE フレーム分割を domain 純関数化
-- 外側 WebSocket ブリッジを `composition/consoleOuterServer.ts` へ
+- 外側 `fetch` ハンドラ全体を composition へ移し、`console/index.ts` を配線のみにする
 - AGT 更新は不要（コンソールは HTTP/SSE クライアント）
 
 ## 検証

--- a/architecture/console-domain-model.md
+++ b/architecture/console-domain-model.md
@@ -63,8 +63,8 @@ flowchart LR
 |------|------|
 | Access pure | `lib/domain/console/access.ts` |
 | Status plan pure | `lib/domain/console/agentStatusPlan.ts` |
-| Host re-export | `console/index.ts`（既存 import パス維持） |
-| UI re-export formatters | `console/src/AgentStatus/agentStatusUtils.tsx` |
+| Host (wiring only) | `console/index.ts` は `startConsoleServer` のみ公開。access 純関数は re-export しない |
+| UI re-export formatters | `console/src/AgentStatus/agentStatusUtils.tsx`（表示用の既存 import 互換） |
 | 公開ペイロード型 | `lib/domain/publication/types.ts` ↔ `console/.../types.ts`（文書で整合） |
 
 ## 追加スライス（実装済）

--- a/architecture/console-domain-model.md
+++ b/architecture/console-domain-model.md
@@ -1,0 +1,82 @@
+# 管理コンソール境界: ドメインモデルと変更容易性
+
+| 項目 | 内容 |
+|------|------|
+| **Status** | Implemented (initial slice) |
+| **Branch** | `legacy` 上の継続リファクタ |
+| **Constraint** | 観測可能な振る舞いを変えない |
+
+> `docs/` は静的サイト資産専用。本ドキュメントは `architecture/` に置く。
+
+## 背景
+
+配信エージェント本体（`MakaMujo` / Publication）は #463 でドメイン分割済み。  
+**管理コンソール**は当時の対象外だったが、次の複雑さが残る。
+
+- 外側 TLS + IP 許可リスト + ループバックプロキシ（`console/index.ts`）
+- 配信公開ペイロードの **表示計画**（`createAgentStatusRows` / `agentStatusUtils`）
+- 放送 API への SSE/HTTP プロキシ（`lib/console-proxy.ts`）
+
+## 境界づけられたコンテキスト
+
+```mermaid
+flowchart LR
+  subgraph Broadcasting["Broadcasting BC（#463 済）"]
+    Pub["PublishedStreamPayload"]
+  end
+  subgraph Console["Console BC"]
+    Access["Access / Redirect"]
+    Proxy["Loopback Proxy"]
+    View["Agent Status View Plan"]
+  end
+  Pub -->|GET/SSE /api/meta| Proxy
+  Proxy --> View
+  Access --> Proxy
+```
+
+| BC | 責務 | 配置 |
+|----|------|------|
+| Console Access | 拒否時リダイレクト、IP 制限フラグ、hop-by-hop ヘッダ除去 | `lib/domain/console/access.ts` |
+| Agent Status Presentation | 行の有無・表示文言（純関数） | `lib/domain/console/agentStatusPlan.ts` |
+| Console UI | JSX / レイアウト | `console/src/AgentStatus/*` |
+| Console Host | TLS・プロキシ・WebSocket ブリッジ | `console/index.ts` |
+
+## ユビキタス言語（Console）
+
+| 用語 | 意味 |
+|------|------|
+| 外側サーバ | :443 TLS、AllowedIP 検査後にループバックへ転送 |
+| ループバックコンソール | 127.0.0.1 の Hono ルート本体 |
+| 配信指標行 | niconama meta + commentCount の表示ブロック |
+| 発話不可インジケータ | canSpeak=false 時の「（コメントしてね）」 |
+| 表示可能履歴 | speech 正規化可能かつ nGram≥1 または nodes あり |
+
+## 契約（振る舞い維持）
+
+1. **Access**: `/console/*` 拒否 → 303 watch URL、それ以外 → 308 `/console/`。IP 制限は production のみ。
+2. **Loopback headers**: Connection 列挙トークンを含む hop-by-hop と Host/Origin/Referer を削除。
+3. **Status rows order**: metrics → game → n-gram → history|reply → speech（`planAgentStatusRows` と `createAgentStatusRows` が同じ順序）。
+
+## 実装マップ
+
+| 領域 | パス |
+|------|------|
+| Access pure | `lib/domain/console/access.ts` |
+| Status plan pure | `lib/domain/console/agentStatusPlan.ts` |
+| Host re-export | `console/index.ts`（既存 import パス維持） |
+| UI re-export formatters | `console/src/AgentStatus/agentStatusUtils.tsx` |
+| 公開ペイロード型 | `lib/domain/publication/types.ts` ↔ `console/.../types.ts`（文書で整合） |
+
+## 今後（任意）
+
+- `console-proxy.ts` の SSE フレーム分割を domain 純関数化
+- 外側 WebSocket ブリッジを `composition/consoleOuterServer.ts` へ
+- AGT 更新は不要（コンソールは HTTP/SSE クライアント）
+
+## 検証
+
+```
+bun run typecheck
+bun run test
+bun run test:integration
+```

--- a/composition/consoleOuterWebSocket.ts
+++ b/composition/consoleOuterWebSocket.ts
@@ -1,0 +1,47 @@
+/**
+ * Outer console TLS server WebSocket bridge to the loopback console.
+ * Behavior matches the previous inline handler in console/index.ts.
+ */
+
+export type OuterConsoleWsData = {
+  loopbackWsUrl: string;
+  protocols: string[] | undefined;
+  target?: WebSocket;
+};
+
+/**
+ * Bun WebSocketHandler that accepts the client socket and bridges to a loopback WebSocket.
+ */
+export const createOuterConsoleWebSocketHandler = (): Bun.WebSocketHandler<OuterConsoleWsData> => ({
+  open(ws) {
+    const { loopbackWsUrl, protocols } = ws.data;
+    try {
+      const target = new WebSocket(loopbackWsUrl, protocols);
+
+      target.binaryType = "arraybuffer";
+
+      target.onopen = () => {
+        // noop
+      };
+
+      target.onmessage = (ev) => {
+        try { ws.send(ev.data as string | ArrayBuffer); } catch { /* ignore */ }
+      };
+
+      target.onclose = () => { try { ws.close(); } catch { /* ignore */ } };
+      target.onerror = () => { try { ws.close(); } catch { /* ignore */ } };
+
+      ws.data.target = target;
+    } catch {
+      try { ws.close(); } catch { /* ignore */ }
+    }
+  },
+  message(ws, data) {
+    const { target } = ws.data;
+    if (target) try { target.send(data as string | ArrayBuffer); } catch { /* ignore */ }
+  },
+  close(ws) {
+    const { target } = ws.data;
+    if (target) try { target.close(); } catch { /* ignore */ }
+  },
+});

--- a/console/index.ts
+++ b/console/index.ts
@@ -3,6 +3,10 @@ import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { AllowedIP } from "../lib/allowedIP";
 import {
+  createOuterConsoleWebSocketHandler,
+  type OuterConsoleWsData,
+} from "../composition/consoleOuterWebSocket";
+import {
   createAccessDeniedRedirectResponse as createAccessDeniedRedirectResponseDomain,
   createLoopbackProxyHeaders as createLoopbackProxyHeadersDomain,
   DEFAULT_CONSOLE_BASE_PATH,
@@ -109,49 +113,11 @@ export function startConsoleServer({
 
   // Outer console server: exposed publicly on port 443.
   // Checks the client IP against the shared allowlist before proxying to the loopback server.
-  type OuterWsData = {
-    loopbackWsUrl: string;
-    protocols: string[] | undefined;
-    target?: WebSocket;
-  };
-
-  const outerWebSocket: Bun.WebSocketHandler<OuterWsData> = {
-    open(ws) {
-      const { loopbackWsUrl, protocols } = ws.data;
-      try {
-        const target = new WebSocket(loopbackWsUrl, protocols);
-
-        target.binaryType = 'arraybuffer';
-
-        target.onopen = () => {
-          // noop
-        };
-
-        target.onmessage = (ev) => {
-          try { ws.send(ev.data as string | ArrayBuffer); } catch {}
-        };
-
-        target.onclose = () => { try { ws.close(); } catch {} };
-        target.onerror = () => { try { ws.close(); } catch {} };
-
-        ws.data.target = target;
-      } catch (err) {
-        try { ws.close(); } catch {}
-      }
-    },
-    message(ws, data) {
-      const { target } = ws.data;
-      if (target) try { target.send(data as string | ArrayBuffer); } catch {}
-    },
-    close(ws) {
-      const { target } = ws.data;
-      if (target) try { target.close(); } catch {}
-    },
-  };
+  const outerWebSocket = createOuterConsoleWebSocketHandler();
 
   let outerServer: ReturnType<typeof serve>;
   try {
-    outerServer = serve<OuterWsData>({
+    outerServer = serve<OuterConsoleWsData>({
       port: 443,
       async fetch(req, server) {
         const requestStartTime = Date.now();

--- a/console/index.ts
+++ b/console/index.ts
@@ -2,6 +2,12 @@ import { serve } from "bun";
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { AllowedIP } from "../lib/allowedIP";
+import {
+  createAccessDeniedRedirectResponse as createAccessDeniedRedirectResponseDomain,
+  createLoopbackProxyHeaders as createLoopbackProxyHeadersDomain,
+  DEFAULT_CONSOLE_BASE_PATH,
+  isConsoleIPRestrictionEnabled as isConsoleIPRestrictionEnabledDomain,
+} from "../lib/domain/console/access";
 import { createDailyRotatingJsonLogger, formatUnknownError } from "../lib/consoleLogger";
 import * as consoleRoutes from "../routes/console/index";
 
@@ -10,62 +16,29 @@ const consoleKeyPath = process.env.CONSOLE_TLS_KEY ?? '/etc/letsencrypt/live/x85
 export const consoleRedirectURL = process.env.CONSOLE_REDIRECT_URL ?? 'https://live.nicovideo.jp/watch/user/14171889';
 const consoleAccessLogPath = resolve(process.cwd(), 'var/log/console/access.log');
 const consoleErrorLogPath = resolve(process.cwd(), 'var/log/console/error.log');
-export const consoleBasePath = '/console/';
+export const consoleBasePath = DEFAULT_CONSOLE_BASE_PATH;
 
 export type ConsoleServer = {
   readonly url: URL;
   stop(closeActiveConnections?: boolean): void;
 };
 
-/**
- * Build the redirect response used when an access to the outer console server is denied.
- *
- * - Requests to `/console/` (including descendants) are redirected to the configured watch page.
- * - Requests to all other paths are permanently redirected to `/console/`.
- *
- * @param requestURL - Original request URL.
- * @returns Redirect response with status and location based on the request path.
- */
+/** @see lib/domain/console/access.ts */
 export function createAccessDeniedRedirectResponse(requestURL: URL): Response {
-  if (requestURL.pathname.startsWith(consoleBasePath)) {
-    return Response.redirect(consoleRedirectURL, 303);
-  }
-  return new Response(null, {
-    status: 308,
-    headers: { location: consoleBasePath },
+  return createAccessDeniedRedirectResponseDomain(requestURL, {
+    consoleBasePath,
+    consoleRedirectURL,
   });
 }
 
+/** @see lib/domain/console/access.ts */
 export function isConsoleIPRestrictionEnabled(): boolean {
-  return process.env.NODE_ENV === 'production';
+  return isConsoleIPRestrictionEnabledDomain();
 }
 
+/** @see lib/domain/console/access.ts */
 export function createLoopbackProxyHeaders(originalHeaders: Headers): Headers {
-  const headers = new Headers(originalHeaders);
-  // Save Connection header value before removing it, so we can strip RFC 7230 tokens after.
-  const connectionValue = headers.get('connection');
-  const hopByHopHeaders = [
-    'connection',
-    'keep-alive',
-    'proxy-authenticate',
-    'proxy-authorization',
-    'proxy-connection',
-    'transfer-encoding',
-    'te',
-    'trailer',
-    'upgrade',
-  ];
-  hopByHopHeaders.forEach((header) => headers.delete(header));
-  headers.delete('host');
-  headers.delete('origin');
-  headers.delete('referer');
-  // Per RFC 7230, also remove any header names listed in the Connection header value.
-  if (connectionValue) {
-    connectionValue.split(',').map(t => t.trim().toLowerCase()).forEach(token => {
-      if (token) headers.delete(token);
-    });
-  }
-  return headers;
+  return createLoopbackProxyHeadersDomain(originalHeaders);
 }
 
 /**

--- a/console/index.ts
+++ b/console/index.ts
@@ -7,43 +7,25 @@ import {
   type OuterConsoleWsData,
 } from "../composition/consoleOuterWebSocket";
 import {
-  createAccessDeniedRedirectResponse as createAccessDeniedRedirectResponseDomain,
-  createLoopbackProxyHeaders as createLoopbackProxyHeadersDomain,
+  createAccessDeniedRedirectResponse,
+  createLoopbackProxyHeaders,
   DEFAULT_CONSOLE_BASE_PATH,
-  isConsoleIPRestrictionEnabled as isConsoleIPRestrictionEnabledDomain,
+  isConsoleIPRestrictionEnabled,
 } from "../lib/domain/console/access";
 import { createDailyRotatingJsonLogger, formatUnknownError } from "../lib/consoleLogger";
 import * as consoleRoutes from "../routes/console/index";
 
 const consoleCertPath = process.env.CONSOLE_TLS_CERT ?? '/etc/letsencrypt/live/x85-131-251-123.static.xvps.ne.jp/fullchain.pem';
 const consoleKeyPath = process.env.CONSOLE_TLS_KEY ?? '/etc/letsencrypt/live/x85-131-251-123.static.xvps.ne.jp/privkey.pem';
-export const consoleRedirectURL = process.env.CONSOLE_REDIRECT_URL ?? 'https://live.nicovideo.jp/watch/user/14171889';
+const consoleRedirectURL = process.env.CONSOLE_REDIRECT_URL ?? 'https://live.nicovideo.jp/watch/user/14171889';
 const consoleAccessLogPath = resolve(process.cwd(), 'var/log/console/access.log');
 const consoleErrorLogPath = resolve(process.cwd(), 'var/log/console/error.log');
-export const consoleBasePath = DEFAULT_CONSOLE_BASE_PATH;
+const consoleBasePath = DEFAULT_CONSOLE_BASE_PATH;
 
 export type ConsoleServer = {
   readonly url: URL;
   stop(closeActiveConnections?: boolean): void;
 };
-
-/** @see lib/domain/console/access.ts */
-export function createAccessDeniedRedirectResponse(requestURL: URL): Response {
-  return createAccessDeniedRedirectResponseDomain(requestURL, {
-    consoleBasePath,
-    consoleRedirectURL,
-  });
-}
-
-/** @see lib/domain/console/access.ts */
-export function isConsoleIPRestrictionEnabled(): boolean {
-  return isConsoleIPRestrictionEnabledDomain();
-}
-
-/** @see lib/domain/console/access.ts */
-export function createLoopbackProxyHeaders(originalHeaders: Headers): Headers {
-  return createLoopbackProxyHeadersDomain(originalHeaders);
-}
 
 /**
  * Start the console server.
@@ -129,7 +111,10 @@ export function startConsoleServer({
         let statusCode = 500;
         const consoleIpRestrictionEnabled = isConsoleIPRestrictionEnabled();
         if (consoleIpRestrictionEnabled && (!ip || !AllowedIP.equals(ip))) {
-          const redirectResponse = createAccessDeniedRedirectResponse(requestURL);
+          const redirectResponse = createAccessDeniedRedirectResponse(requestURL, {
+            consoleBasePath,
+            consoleRedirectURL,
+          });
           statusCode = redirectResponse.status;
           errorLogger.write({
             event: 'console_access_denied',

--- a/console/src/AgentStatus/agentStatusUtils.tsx
+++ b/console/src/AgentStatus/agentStatusUtils.tsx
@@ -1,89 +1,28 @@
 import type { AgentStateResponse } from "./types";
 import type { Child, CSSProperties } from "hono/jsx";
+import {
+  formatMetricValue,
+  formatNGramValue,
+  formatStartDate,
+  formatStateLabel,
+  formatStreamStartTime,
+  normalizeSpeechText,
+  SPEECH_UNAVAILABLE_INDICATOR,
+  type SpeechPayload,
+} from "../../../lib/domain/console/agentStatusPlan";
 
-const UNIX_MILLISECONDS_THRESHOLD = 1_000_000_000_000;
+// Re-export pure presentation helpers from the console domain (single source of truth).
+export {
+  formatMetricValue,
+  formatNGramValue,
+  formatStartDate,
+  formatStateLabel,
+  formatStreamStartTime,
+  normalizeSpeechText,
+};
+
 const GAME_STATE_EMPTY_ARRAY_LABEL = "(空の配列)";
 const GAME_STATE_EMPTY_OBJECT_LABEL = "(空のオブジェクト)";
-const SPEECH_UNAVAILABLE_INDICATOR = "（コメントしてね）";
-
-export const formatStateLabel = (type: string | undefined): string => {
-  if (type === "live") {
-    return "配信中";
-  }
-  if (type === "offline") {
-    return "停止中";
-  }
-  return type ?? "-";
-};
-
-export const formatStartDate = (startAtUnixTime: number | undefined): string => {
-  if (typeof startAtUnixTime !== "number" || !Number.isFinite(startAtUnixTime) || startAtUnixTime <= 0) {
-    return "-";
-  }
-  const startAtUnixTimeMilliseconds = startAtUnixTime >= UNIX_MILLISECONDS_THRESHOLD
-    ? startAtUnixTime
-    : startAtUnixTime * 1000;
-  return new Date(startAtUnixTimeMilliseconds).toLocaleString("ja-JP");
-};
-
-export const formatStreamStartTime = (startAtUnixTime: number | undefined): string | undefined => {
-  if (typeof startAtUnixTime !== "number" || !Number.isFinite(startAtUnixTime) || startAtUnixTime <= 0) {
-    return undefined;
-  }
-  const startAtUnixTimeMilliseconds = startAtUnixTime >= UNIX_MILLISECONDS_THRESHOLD
-    ? startAtUnixTime
-    : startAtUnixTime * 1000;
-  const date = new Date(startAtUnixTimeMilliseconds);
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
-  const hour = String(date.getHours()).padStart(2, "0");
-  const minute = String(date.getMinutes()).padStart(2, "0");
-  return `${year}/${month}/${day} ${hour}:${minute} 開始`;
-};
-
-export const formatMetricValue = (metricValue: number | undefined): string => {
-  return metricValue === undefined ? "-" : String(metricValue);
-};
-
-export const formatNGramValue = (nGram: number | undefined, nGramRaw: number | undefined): string => {
-  if (nGram === undefined || !Number.isFinite(nGram) || nGram < 1) {
-    return "-";
-  }
-  const nGramValue = `${Math.floor(nGram)}-gram`;
-  if (nGramRaw === undefined || !Number.isFinite(nGramRaw) || nGramRaw < 1) {
-    return nGramValue;
-  }
-  const formattedRaw = Number(nGramRaw).toFixed(2);
-  return `${nGramValue} (${formattedRaw})`;
-};
-
-type SpeechPayload =
-  | string
-  | { text?: string; nodes?: readonly string[] }
-  | ({ speech?: string | { text?: string; nodes?: readonly string[] } | { speech?: string; text?: string; nodes?: readonly string[] }; silent?: boolean })
-  | undefined;
-
-export const normalizeSpeechText = (speech: SpeechPayload): string | undefined => {
-  if (typeof speech === "string") {
-    return speech.trim() || undefined;
-  }
-
-  if (speech && typeof speech === "object") {
-    const textValue = typeof (speech as any).text === "string"
-      ? (speech as any).text
-      : typeof (speech as any).speech === "string"
-        ? (speech as any).speech
-        : typeof (speech as any).speech === "object"
-          ? typeof (speech as any).speech.text === "string"
-            ? (speech as any).speech.text
-            : undefined
-          : undefined;
-    return typeof textValue === "string" ? textValue.trim() || undefined : undefined;
-  }
-
-  return undefined;
-};
 
 const createHighlightedCommentLines = (commentText: string, pickedTopic: string) => {
   if (!pickedTopic) {

--- a/console/src/AgentStatus/types.ts
+++ b/console/src/AgentStatus/types.ts
@@ -1,5 +1,10 @@
 import type { Child } from "hono/jsx";
 
+/**
+ * Console view of the broadcasting published payload.
+ * Structurally aligned with `PublishedStreamPayload` (`lib/domain/publication/types.ts`);
+ * fields remain optional here because SSE/HTTP may deliver partial frames.
+ */
 export type AgentStatusRow = {
   label: string
   href?: string

--- a/lib/console-proxy.ts
+++ b/lib/console-proxy.ts
@@ -1,3 +1,11 @@
+import {
+  drainSseDataPayloads,
+  extractCompleteSseFrames,
+  findSseBoundary,
+} from "./domain/console/sseFrames";
+
+export { findSseBoundary, extractCompleteSseFrames } from "./domain/console/sseFrames";
+
 export function streamUpstreamResponse(proxied: Response) {
   const responseHeaders = new Headers(proxied.headers);
   responseHeaders.set('cache-control', 'no-cache');
@@ -48,18 +56,10 @@ export function forwardSSEEventsToSink(upstreamBody: any, sink: (data: string) =
         const { done, value } = await reader.read();
         if (done) break;
         buffer += decoder.decode(value, { stream: true });
-        let idx = buffer.indexOf('\r\n\r\n');
-        if (idx === -1) idx = buffer.indexOf('\n\n');
-        while (idx !== -1) {
-          const event = buffer.slice(0, idx);
-          buffer = buffer.slice(idx + (buffer.startsWith('\r\n', idx) ? 4 : 2));
-          const dataLines = event.split(/\r?\n/).filter((l) => l.startsWith('data:'));
-          if (dataLines.length > 0) {
-            const data = dataLines.map((l) => l.replace(/^data:\s?/, '')).join('\n');
-            try { sink(data); } catch {}
-          }
-          idx = buffer.indexOf('\r\n\r\n');
-          if (idx === -1) idx = buffer.indexOf('\n\n');
+        const drained = drainSseDataPayloads(buffer);
+        buffer = drained.rest;
+        for (const data of drained.payloads) {
+          try { sink(data); } catch {}
         }
       }
     } catch (err) {
@@ -129,18 +129,6 @@ export async function fetchMetaSnapshot(proxyBase: string): Promise<any> {
 }
 
 /**
- * Returns the position and length of the first SSE frame boundary (\n\n or \r\n\r\n)
- * in the given buffer, or null if no complete boundary is found.
- */
-function findSseBoundary(buffer: string): { end: number; length: number } | null {
-  const lfIdx = buffer.indexOf('\n\n');
-  const crlfIdx = buffer.indexOf('\r\n\r\n');
-  if (lfIdx === -1 && crlfIdx === -1) return null;
-  if (lfIdx !== -1 && (crlfIdx === -1 || lfIdx <= crlfIdx)) return { end: lfIdx, length: 2 };
-  return { end: crlfIdx, length: 4 };
-}
-
-/**
  * Creates an SSE Response that stays connected even when the upstream drops.
  * When the upstream closes or errors, it automatically reconnects and continues
  * streaming. This prevents ERR_INCOMPLETE_CHUNKED_ENCODING errors in the browser
@@ -195,13 +183,10 @@ export function createResilientSseProxy(
         sseBuffer += decoder.decode(value, { stream: true });
 
         // Emit only complete SSE frames; buffer incomplete ones until the next chunk.
-        let boundary = findSseBoundary(sseBuffer);
-        while (boundary !== null) {
-          const { end, length } = boundary;
-          const frame = sseBuffer.slice(0, end + length);
-          sseBuffer = sseBuffer.slice(end + length);
+        const extracted = extractCompleteSseFrames(sseBuffer);
+        sseBuffer = extracted.rest;
+        for (const frame of extracted.frames) {
           try { controller.enqueue(encoder.encode(frame)); } catch {}
-          boundary = findSseBoundary(sseBuffer);
         }
       }
     } finally {

--- a/lib/domain/console/access.test.ts
+++ b/lib/domain/console/access.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "bun:test";
+import {
+  createAccessDeniedRedirectResponse,
+  createLoopbackProxyHeaders,
+  DEFAULT_CONSOLE_BASE_PATH,
+  isConsoleIPRestrictionEnabled,
+} from "./access";
+
+describe("console access domain", () => {
+  it("redirects denied /console/ paths to the watch page with 303", () => {
+    const response = createAccessDeniedRedirectResponse(
+      new URL("https://example.com/console/?q=1"),
+      { consoleRedirectURL: "https://live.example/watch" },
+    );
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe("https://live.example/watch");
+  });
+
+  it("permanently redirects other paths to console base", () => {
+    const response = createAccessDeniedRedirectResponse(
+      new URL("https://example.com/other"),
+      { consoleRedirectURL: "https://live.example/watch" },
+    );
+    expect(response.status).toBe(308);
+    expect(response.headers.get("location")).toBe(DEFAULT_CONSOLE_BASE_PATH);
+  });
+
+  it("enables IP restriction only in production", () => {
+    expect(isConsoleIPRestrictionEnabled("production")).toBe(true);
+    expect(isConsoleIPRestrictionEnabled("development")).toBe(false);
+    expect(isConsoleIPRestrictionEnabled(undefined)).toBe(false);
+  });
+
+  it("strips hop-by-hop and identity headers for loopback proxy", () => {
+    const original = new Headers([
+      ["connection", "keep-alive, upgrade"],
+      ["upgrade", "websocket"],
+      ["host", "example.com"],
+      ["origin", "https://example.com"],
+      ["referer", "https://example.com/console/"],
+      ["accept", "text/event-stream"],
+      ["x-custom", "1"],
+    ]);
+    const headers = createLoopbackProxyHeaders(original);
+    expect(headers.get("accept")).toBe("text/event-stream");
+    expect(headers.get("x-custom")).toBe("1");
+    expect(headers.has("connection")).toBe(false);
+    expect(headers.has("upgrade")).toBe(false);
+    expect(headers.has("host")).toBe(false);
+    expect(headers.has("origin")).toBe(false);
+    expect(headers.has("referer")).toBe(false);
+  });
+});

--- a/lib/domain/console/access.ts
+++ b/lib/domain/console/access.ts
@@ -1,0 +1,67 @@
+/**
+ * Console access-control and reverse-proxy header pure rules.
+ * Side-effect free — used by the outer TLS console server.
+ */
+
+export const DEFAULT_CONSOLE_BASE_PATH = "/console/";
+
+/**
+ * Build the redirect response used when an access to the outer console server is denied.
+ *
+ * - Requests to `/console/` (including descendants) are redirected to the configured watch page.
+ * - Requests to all other paths are permanently redirected to `/console/`.
+ */
+export const createAccessDeniedRedirectResponse = (
+  requestURL: URL,
+  options: {
+    consoleBasePath?: string;
+    consoleRedirectURL: string;
+  },
+): Response => {
+  const consoleBasePath = options.consoleBasePath ?? DEFAULT_CONSOLE_BASE_PATH;
+  if (requestURL.pathname.startsWith(consoleBasePath)) {
+    return Response.redirect(options.consoleRedirectURL, 303);
+  }
+  return new Response(null, {
+    status: 308,
+    headers: { location: consoleBasePath },
+  });
+};
+
+/** IP restriction applies only in production (legacy behavior). */
+export const isConsoleIPRestrictionEnabled = (
+  nodeEnv: string | undefined = process.env.NODE_ENV,
+): boolean => nodeEnv === "production";
+
+const HOP_BY_HOP_HEADERS = [
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "proxy-connection",
+  "transfer-encoding",
+  "te",
+  "trailer",
+  "upgrade",
+] as const;
+
+/**
+ * Headers safe to forward from the outer console to the loopback console.
+ * Strips hop-by-hop headers (RFC 7230), Host, Origin, and Referer.
+ */
+export const createLoopbackProxyHeaders = (originalHeaders: Headers): Headers => {
+  const headers = new Headers(originalHeaders);
+  const connectionValue = headers.get("connection");
+  for (const header of HOP_BY_HOP_HEADERS) {
+    headers.delete(header);
+  }
+  headers.delete("host");
+  headers.delete("origin");
+  headers.delete("referer");
+  if (connectionValue) {
+    for (const token of connectionValue.split(",").map((t) => t.trim().toLowerCase())) {
+      if (token) headers.delete(token);
+    }
+  }
+  return headers;
+};

--- a/lib/domain/console/agentStatusPlan.test.ts
+++ b/lib/domain/console/agentStatusPlan.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "bun:test";
+import {
+  formatNGramValue,
+  formatStateLabel,
+  normalizeSpeechText,
+  planAgentStatusRows,
+  SPEECH_UNAVAILABLE_INDICATOR,
+} from "./agentStatusPlan";
+
+describe("normalizeSpeechText", () => {
+  it("trims strings and nested text/speech fields", () => {
+    expect(normalizeSpeechText("  hi  ")).toBe("hi");
+    expect(normalizeSpeechText({ text: "a" })).toBe("a");
+    expect(normalizeSpeechText({ speech: "b" })).toBe("b");
+    expect(normalizeSpeechText({ speech: { text: "c" } })).toBe("c");
+    expect(normalizeSpeechText("   ")).toBeUndefined();
+  });
+});
+
+describe("formatNGramValue", () => {
+  it("matches console display rules", () => {
+    expect(formatNGramValue(undefined, 2)).toBe("-");
+    expect(formatNGramValue(2, undefined)).toBe("2-gram");
+    expect(formatNGramValue(2, 2.1)).toBe("2-gram (2.10)");
+  });
+});
+
+describe("formatStateLabel", () => {
+  it("maps live/offline", () => {
+    expect(formatStateLabel("live")).toBe("配信中");
+    expect(formatStateLabel("offline")).toBe("停止中");
+    expect(formatStateLabel(undefined)).toBe("-");
+  });
+});
+
+describe("planAgentStatusRows", () => {
+  it("includes live metrics when niconama is non-empty", () => {
+    const plans = planAgentStatusRows({
+      niconama: { type: "live" },
+      hasCurrentGameKey: false,
+    });
+    expect(plans.some((p) => p.kind === "liveMetrics")).toBe(true);
+  });
+
+  it("shows speech unavailable when canSpeak is false and not silent", () => {
+    const plans = planAgentStatusRows({
+      niconama: {},
+      hasCurrentGameKey: false,
+      canSpeak: false,
+      speech: { speech: "x", silent: false },
+    });
+    expect(plans).toContainEqual({ kind: "speechUnavailable" });
+  });
+
+  it("omits speech content when silent", () => {
+    const plans = planAgentStatusRows({
+      hasCurrentGameKey: false,
+      canSpeak: true,
+      speech: { speech: "hello", silent: true },
+    });
+    expect(plans.some((p) => p.kind === "speechContent" || p.kind === "speechUnavailable")).toBe(false);
+  });
+
+  it("prefers speech history over standalone reply target when history is displayable", () => {
+    const plans = planAgentStatusRows({
+      hasCurrentGameKey: false,
+      speechHistory: [{ speech: "past", nGram: 2 }],
+      replyTargetComment: { text: "reply", pickedTopic: "r" },
+    });
+    expect(plans.some((p) => p.kind === "speechHistory")).toBe(true);
+    expect(plans.some((p) => p.kind === "replyTargetOnly")).toBe(false);
+  });
+
+  it("falls back to reply target when history items lack nGram/nodes", () => {
+    const plans = planAgentStatusRows({
+      hasCurrentGameKey: false,
+      speechHistory: [{ speech: "past" }],
+      replyTargetComment: { text: "reply", pickedTopic: "r" },
+    });
+    expect(plans.some((p) => p.kind === "speechHistory")).toBe(false);
+    expect(plans.some((p) => p.kind === "replyTargetOnly")).toBe(true);
+  });
+
+  it("exposes the speech unavailable indicator constant used by UI", () => {
+    expect(SPEECH_UNAVAILABLE_INDICATOR).toBe("（コメントしてね）");
+  });
+});

--- a/lib/domain/console/agentStatusPlan.ts
+++ b/lib/domain/console/agentStatusPlan.ts
@@ -1,0 +1,182 @@
+/**
+ * Pure presentation plan for Agent Status console rows.
+ * Keeps UI (JSX) out of domain decisions so row selection can be characterized without DOM.
+ */
+
+export type SpeechPayload =
+  | string
+  | { text?: string; nodes?: readonly string[] }
+  | {
+    speech?: string | { text?: string; nodes?: readonly string[] } | { speech?: string; text?: string; nodes?: readonly string[] };
+    silent?: boolean;
+  }
+  | undefined;
+
+export type AgentStatusPlanInput = {
+  niconama?: Record<string, unknown> | null;
+  commentCount?: number;
+  currentGame?: { name?: string; state?: Record<string, unknown> } | null;
+  hasCurrentGameKey?: boolean;
+  nGram?: number;
+  nGramRaw?: number;
+  speech?: SpeechPayload;
+  speechHistory?: unknown[];
+  replyTargetComment?: { text?: string; pickedTopic?: string };
+  canSpeak?: boolean;
+};
+
+export type AgentStatusRowPlan =
+  | { kind: "liveMetrics" }
+  | { kind: "gameInfo" }
+  | { kind: "nGram"; display: string }
+  | { kind: "speechHistory"; emphasizeLatest: boolean }
+  | { kind: "replyTargetOnly" }
+  | { kind: "speechContent"; value: string }
+  | { kind: "speechUnavailable" };
+
+const UNIX_MILLISECONDS_THRESHOLD = 1_000_000_000_000;
+
+export const SPEECH_UNAVAILABLE_INDICATOR = "（コメントしてね）";
+
+export const normalizeSpeechText = (speech: SpeechPayload): string | undefined => {
+  if (typeof speech === "string") {
+    return speech.trim() || undefined;
+  }
+  if (speech && typeof speech === "object") {
+    const record = speech as Record<string, unknown>;
+    if (typeof record.text === "string") {
+      return record.text.trim() || undefined;
+    }
+    if (typeof record.speech === "string") {
+      return record.speech.trim() || undefined;
+    }
+    if (record.speech && typeof record.speech === "object") {
+      const nested = record.speech as Record<string, unknown>;
+      if (typeof nested.text === "string") {
+        return nested.text.trim() || undefined;
+      }
+    }
+  }
+  return undefined;
+};
+
+export const formatNGramValue = (nGram: number | undefined, nGramRaw: number | undefined): string => {
+  if (nGram === undefined || !Number.isFinite(nGram) || nGram < 1) {
+    return "-";
+  }
+  const nGramValue = `${Math.floor(nGram)}-gram`;
+  if (nGramRaw === undefined || !Number.isFinite(nGramRaw) || nGramRaw < 1) {
+    return nGramValue;
+  }
+  return `${nGramValue} (${Number(nGramRaw).toFixed(2)})`;
+};
+
+export const formatStateLabel = (type: string | undefined): string => {
+  if (type === "live") return "配信中";
+  if (type === "offline") return "停止中";
+  return type ?? "-";
+};
+
+export const formatMetricValue = (metricValue: number | undefined): string =>
+  metricValue === undefined ? "-" : String(metricValue);
+
+export const formatStartDate = (startAtUnixTime: number | undefined): string => {
+  if (typeof startAtUnixTime !== "number" || !Number.isFinite(startAtUnixTime) || startAtUnixTime <= 0) {
+    return "-";
+  }
+  const ms = startAtUnixTime >= UNIX_MILLISECONDS_THRESHOLD ? startAtUnixTime : startAtUnixTime * 1000;
+  return new Date(ms).toLocaleString("ja-JP");
+};
+
+export const formatStreamStartTime = (startAtUnixTime: number | undefined): string | undefined => {
+  if (typeof startAtUnixTime !== "number" || !Number.isFinite(startAtUnixTime) || startAtUnixTime <= 0) {
+    return undefined;
+  }
+  const ms = startAtUnixTime >= UNIX_MILLISECONDS_THRESHOLD ? startAtUnixTime : startAtUnixTime * 1000;
+  const date = new Date(ms);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const hour = String(date.getHours()).padStart(2, "0");
+  const minute = String(date.getMinutes()).padStart(2, "0");
+  return `${year}/${month}/${day} ${hour}:${minute} 開始`;
+};
+
+/**
+ * Whether speech history would produce display items (mirrors createSpeechHistoryDisplayItems filters).
+ */
+export const hasDisplayableSpeechHistory = (speechHistory: unknown[] | undefined): boolean => {
+  if (!Array.isArray(speechHistory) || speechHistory.length === 0) return false;
+  return speechHistory.some((item) => {
+    if (!item || typeof item !== "object") return false;
+    const row = item as { speech?: SpeechPayload; nGram?: number; nodes?: unknown };
+    const speechText = normalizeSpeechText(row.speech);
+    if (!speechText) return false;
+    const hasTrace = Array.isArray(row.nodes) && row.nodes.length > 0;
+    const hasValidNGram = row.nGram !== undefined && Number.isFinite(row.nGram) && (row.nGram as number) >= 1;
+    return hasTrace || hasValidNGram;
+  });
+};
+
+/**
+ * Decide which Agent Status rows to show and their pure display values.
+ * Order matches createAgentStatusRows (legacy).
+ */
+export const planAgentStatusRows = (input: AgentStatusPlanInput): AgentStatusRowPlan[] => {
+  const plans: AgentStatusRowPlan[] = [];
+
+  const niconamaState = input.niconama;
+  if (niconamaState && Object.keys(niconamaState).length > 0) {
+    plans.push({ kind: "liveMetrics" });
+  }
+
+  if (input.hasCurrentGameKey) {
+    const currentGameName = input.currentGame?.name;
+    const currentGameState = input.currentGame?.state;
+    if (currentGameName !== undefined && currentGameState !== undefined) {
+      plans.push({ kind: "gameInfo" });
+    }
+  }
+
+  if (input.nGram !== undefined) {
+    plans.push({ kind: "nGram", display: formatNGramValue(input.nGram, input.nGramRaw) });
+  }
+
+  const replyTargetComment = input.replyTargetComment?.text ? input.replyTargetComment : undefined;
+  const isSpeechSilent = input.speech !== undefined
+    && typeof input.speech === "object"
+    && (input.speech as { silent?: boolean }).silent === true;
+
+  const historyPresent = hasDisplayableSpeechHistory(input.speechHistory);
+  if (historyPresent) {
+    plans.push({ kind: "speechHistory", emphasizeLatest: !isSpeechSilent });
+  } else if (replyTargetComment) {
+    plans.push({ kind: "replyTargetOnly" });
+  }
+
+  const normalizedSpeechText = normalizeSpeechText(input.speech);
+  // Legacy: compare against first history item speech text when history exists —
+  // callers pass firstHistorySpeechText when available for exact parity.
+  const firstHistorySpeechText = input.speechHistory && input.speechHistory.length > 0
+    ? normalizeSpeechText(
+      typeof (input.speechHistory[0] as { speech?: SpeechPayload })?.speech === "object"
+        || typeof (input.speechHistory[0] as { speech?: SpeechPayload })?.speech === "string"
+        ? (input.speechHistory[0] as { speech?: SpeechPayload }).speech
+        : undefined,
+    )
+    : undefined;
+
+  const shouldRenderSpeechContent = input.canSpeak === false
+    || (normalizedSpeechText !== undefined && !historyPresent)
+    || (normalizedSpeechText !== undefined && firstHistorySpeechText !== normalizedSpeechText);
+
+  if (!isSpeechSilent) {
+    if (input.canSpeak === false) {
+      plans.push({ kind: "speechUnavailable" });
+    } else if (normalizedSpeechText !== undefined && shouldRenderSpeechContent) {
+      plans.push({ kind: "speechContent", value: normalizedSpeechText });
+    }
+  }
+
+  return plans;
+};

--- a/lib/domain/console/sseFrames.test.ts
+++ b/lib/domain/console/sseFrames.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "bun:test";
+import {
+  drainSseDataPayloads,
+  extractCompleteSseFrames,
+  extractSseDataPayload,
+  findSseBoundary,
+} from "./sseFrames";
+
+describe("findSseBoundary", () => {
+  it("finds LF and CRLF boundaries", () => {
+    // "data: a" is 7 chars; boundary starts at index of first \n of \n\n
+    expect(findSseBoundary("data: a\n\nrest")).toEqual({ end: 7, length: 2 });
+    expect(findSseBoundary("data: a\r\n\r\nrest")).toEqual({ end: 7, length: 4 });
+  });
+
+  it("prefers the earlier boundary when both exist", () => {
+    expect(findSseBoundary("x\n\ny\r\n\r\n")).toEqual({ end: 1, length: 2 });
+  });
+
+  it("returns null when incomplete", () => {
+    expect(findSseBoundary("data: PARTIAL")).toBeNull();
+    expect(findSseBoundary("data: a\n")).toBeNull();
+  });
+});
+
+describe("extractCompleteSseFrames", () => {
+  it("emits complete frames and keeps incomplete tail", () => {
+    const { frames, rest } = extractCompleteSseFrames("data: HELLO\n\ndata: PARTIAL");
+    expect(frames).toEqual(["data: HELLO\n\n"]);
+    expect(rest).toBe("data: PARTIAL");
+  });
+
+  it("emits multiple frames", () => {
+    const { frames, rest } = extractCompleteSseFrames("data: 1\n\ndata: 2\n\n");
+    expect(frames).toHaveLength(2);
+    expect(rest).toBe("");
+  });
+});
+
+describe("extractSseDataPayload / drainSseDataPayloads", () => {
+  it("joins multi-line data fields", () => {
+    expect(extractSseDataPayload("data: a\ndata: b")).toBe("a\nb");
+  });
+
+  it("drains complete events for sink-style consumers", () => {
+    const { payloads, rest } = drainSseDataPayloads("data: HELLO\n\ndata: MORE");
+    expect(payloads).toEqual(["HELLO"]);
+    expect(rest).toBe("data: MORE");
+  });
+
+  it("skips events without data lines", () => {
+    const { payloads, rest } = drainSseDataPayloads(": comment\n\ndata: x\n\n");
+    expect(payloads).toEqual(["x"]);
+    expect(rest).toBe("");
+  });
+});

--- a/lib/domain/console/sseFrames.ts
+++ b/lib/domain/console/sseFrames.ts
@@ -1,0 +1,74 @@
+/**
+ * Pure SSE frame buffer helpers (console → broadcasting proxy).
+ * Incomplete frames stay in the buffer; only complete events are emitted.
+ */
+
+export type SseBoundary = { end: number; length: number };
+
+/**
+ * Position and delimiter length of the first complete SSE frame boundary
+ * (`\n\n` or `\r\n\r\n`), or null if none.
+ */
+export const findSseBoundary = (buffer: string): SseBoundary | null => {
+  const lfIdx = buffer.indexOf("\n\n");
+  const crlfIdx = buffer.indexOf("\r\n\r\n");
+  if (lfIdx === -1 && crlfIdx === -1) return null;
+  if (lfIdx !== -1 && (crlfIdx === -1 || lfIdx <= crlfIdx)) return { end: lfIdx, length: 2 };
+  return { end: crlfIdx, length: 4 };
+};
+
+export type SseFrameExtractResult = {
+  /** Complete frames including their trailing boundary bytes. */
+  frames: string[];
+  /** Remainder without a complete boundary (may be incomplete event). */
+  rest: string;
+};
+
+/**
+ * Split a buffer into zero or more complete SSE frames and leftover incomplete text.
+ * Incomplete frames are not included in `frames` (discarded on upstream drop by the proxy).
+ */
+export const extractCompleteSseFrames = (buffer: string): SseFrameExtractResult => {
+  const frames: string[] = [];
+  let rest = buffer;
+  let boundary = findSseBoundary(rest);
+  while (boundary !== null) {
+    const { end, length } = boundary;
+    frames.push(rest.slice(0, end + length));
+    rest = rest.slice(end + length);
+    boundary = findSseBoundary(rest);
+  }
+  return { frames, rest };
+};
+
+/**
+ * Extract `data:` payload lines from a single SSE event block (without requiring trailing boundary).
+ * Returns null when the event has no data lines.
+ */
+export const extractSseDataPayload = (eventBlock: string): string | null => {
+  const dataLines = eventBlock.split(/\r?\n/).filter((l) => l.startsWith("data:"));
+  if (dataLines.length === 0) return null;
+  return dataLines.map((l) => l.replace(/^data:\s?/, "")).join("\n");
+};
+
+/**
+ * Consume buffered SSE text for `forwardSSEEventsToSink`-style sinks:
+ * emit data payloads for complete events; keep incomplete tail in buffer.
+ */
+export const drainSseDataPayloads = (buffer: string): { payloads: string[]; rest: string } => {
+  const payloads: string[] = [];
+  let rest = buffer;
+  // Use same boundary scan as legacy forwardSSEEventsToSink
+  let idx = rest.indexOf("\r\n\r\n");
+  if (idx === -1) idx = rest.indexOf("\n\n");
+  while (idx !== -1) {
+    const event = rest.slice(0, idx);
+    const delimLen = rest.startsWith("\r\n", idx) ? 4 : 2;
+    rest = rest.slice(idx + delimLen);
+    const data = extractSseDataPayload(event);
+    if (data !== null) payloads.push(data);
+    idx = rest.indexOf("\r\n\r\n");
+    if (idx === -1) idx = rest.indexOf("\n\n");
+  }
+  return { payloads, rest };
+};

--- a/tests/integration/console/index.test.ts
+++ b/tests/integration/console/index.test.ts
@@ -2,88 +2,100 @@ import { test, expect } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { createLoopbackProxyHeaders, consoleBasePath, consoleRedirectURL, createAccessDeniedRedirectResponse, isConsoleIPRestrictionEnabled, startConsoleServer } from "../../../console/index";
+import { startConsoleServer } from "../../../console/index";
+import {
+  createAccessDeniedRedirectResponse,
+  createLoopbackProxyHeaders,
+  DEFAULT_CONSOLE_BASE_PATH,
+  isConsoleIPRestrictionEnabled,
+} from "../../../lib/domain/console/access";
+
+const consoleRedirectURL = process.env.CONSOLE_REDIRECT_URL ?? "https://live.nicovideo.jp/watch/user/14171889";
 
 test("throws when TLS certificate file is missing", () => {
-  const tmpDir = mkdtempSync(join(tmpdir(), 'console-test-'));
+  const tmpDir = mkdtempSync(join(tmpdir(), "console-test-"));
   try {
-    expect(() => startConsoleServer({ certPath: join(tmpDir, 'nonexistent-cert.pem'), keyPath: join(tmpDir, 'nonexistent-key.pem') }))
-      .toThrow('TLS certificate files not found');
+    expect(() => startConsoleServer({ certPath: join(tmpDir, "nonexistent-cert.pem"), keyPath: join(tmpDir, "nonexistent-key.pem") }))
+      .toThrow("TLS certificate files not found");
   } finally {
     rmSync(tmpDir, { recursive: true, force: true });
   }
 });
 
 test("throws when TLS certificate file exists but key file is missing", () => {
-  const tmpDir = mkdtempSync(join(tmpdir(), 'console-test-'));
-  const certFilePath = join(tmpDir, 'cert.pem');
-  writeFileSync(certFilePath, 'placeholder');
+  const tmpDir = mkdtempSync(join(tmpdir(), "console-test-"));
+  const certFilePath = join(tmpDir, "cert.pem");
+  writeFileSync(certFilePath, "placeholder");
 
   try {
-    expect(() => startConsoleServer({ certPath: certFilePath, keyPath: join(tmpDir, 'nonexistent-key.pem') }))
-      .toThrow('TLS certificate files not found');
+    expect(() => startConsoleServer({ certPath: certFilePath, keyPath: join(tmpDir, "nonexistent-key.pem") }))
+      .toThrow("TLS certificate files not found");
   } finally {
     rmSync(tmpDir, { recursive: true, force: true });
   }
 });
 
 test("returns 303 to watch page for denied /console/ access", () => {
-  const response = createAccessDeniedRedirectResponse(new URL('https://example.com/console/?q=1'));
+  const response = createAccessDeniedRedirectResponse(new URL("https://example.com/console/?q=1"), {
+    consoleRedirectURL,
+  });
   expect(response.status).toBe(303);
-  expect(response.headers.get('location')).toBe(consoleRedirectURL);
+  expect(response.headers.get("location")).toBe(consoleRedirectURL);
 });
 
 test("returns 308 to /console/ for denied non-console access", () => {
-  const response = createAccessDeniedRedirectResponse(new URL('https://example.com/other/path'));
+  const response = createAccessDeniedRedirectResponse(new URL("https://example.com/other/path"), {
+    consoleRedirectURL,
+  });
   expect(response.status).toBe(308);
-  expect(response.headers.get('location')).toBe(consoleBasePath);
+  expect(response.headers.get("location")).toBe(DEFAULT_CONSOLE_BASE_PATH);
 });
 
 test("strips hop-by-hop headers from loopback proxy requests", () => {
   const originalHeaders = new Headers([
-    ['connection', 'keep-alive'],
-    ['upgrade', 'websocket'],
-    ['host', 'x85-131-251-123.static.xvps.ne.jp'],
-    ['origin', 'https://x85-131-251-123.static.xvps.ne.jp'],
-    ['referer', 'https://x85-131-251-123.static.xvps.ne.jp/console/'],
-    ['accept', 'text/event-stream'],
+    ["connection", "keep-alive"],
+    ["upgrade", "websocket"],
+    ["host", "x85-131-251-123.static.xvps.ne.jp"],
+    ["origin", "https://x85-131-251-123.static.xvps.ne.jp"],
+    ["referer", "https://x85-131-251-123.static.xvps.ne.jp/console/"],
+    ["accept", "text/event-stream"],
   ]);
 
   const headers = createLoopbackProxyHeaders(originalHeaders);
-  expect(headers.get('connection')).toBeNull();
-  expect(headers.get('upgrade')).toBeNull();
-  expect(headers.get('host')).toBeNull();
-  expect(headers.get('origin')).toBeNull();
-  expect(headers.get('referer')).toBeNull();
-  expect(headers.get('accept')).toBe('text/event-stream');
+  expect(headers.get("connection")).toBeNull();
+  expect(headers.get("upgrade")).toBeNull();
+  expect(headers.get("host")).toBeNull();
+  expect(headers.get("origin")).toBeNull();
+  expect(headers.get("referer")).toBeNull();
+  expect(headers.get("accept")).toBe("text/event-stream");
 });
 
 test("strips proxy-authenticate and proxy-authorization from loopback proxy requests", () => {
   const originalHeaders = new Headers([
-    ['proxy-authenticate', 'Basic realm="proxy"'],
-    ['proxy-authorization', 'Basic dXNlcjpwYXNz'],
-    ['authorization', 'Bearer token123'],
+    ["proxy-authenticate", 'Basic realm="proxy"'],
+    ["proxy-authorization", "Basic dXNlcjpwYXNz"],
+    ["authorization", "Bearer token123"],
   ]);
 
   const headers = createLoopbackProxyHeaders(originalHeaders);
-  expect(headers.get('proxy-authenticate')).toBeNull();
-  expect(headers.get('proxy-authorization')).toBeNull();
-  expect(headers.get('authorization')).toBe('Bearer token123');
+  expect(headers.get("proxy-authenticate")).toBeNull();
+  expect(headers.get("proxy-authorization")).toBeNull();
+  expect(headers.get("authorization")).toBe("Bearer token123");
 });
 
 test("strips headers named in Connection header value (RFC 7230)", () => {
   const originalHeaders = new Headers([
-    ['connection', 'x-custom-hop, another-hop'],
-    ['x-custom-hop', 'some-value'],
-    ['another-hop', 'other-value'],
-    ['x-preserved', 'preserved'],
+    ["connection", "x-custom-hop, another-hop"],
+    ["x-custom-hop", "some-value"],
+    ["another-hop", "other-value"],
+    ["x-preserved", "preserved"],
   ]);
 
   const headers = createLoopbackProxyHeaders(originalHeaders);
-  expect(headers.get('connection')).toBeNull();
-  expect(headers.get('x-custom-hop')).toBeNull();
-  expect(headers.get('another-hop')).toBeNull();
-  expect(headers.get('x-preserved')).toBe('preserved');
+  expect(headers.get("connection")).toBeNull();
+  expect(headers.get("x-custom-hop")).toBeNull();
+  expect(headers.get("another-hop")).toBeNull();
+  expect(headers.get("x-preserved")).toBe("preserved");
 });
 
 test("disables console IP restriction in development mode", () => {
@@ -92,7 +104,7 @@ test("disables console IP restriction in development mode", () => {
     process.env.NODE_ENV = undefined;
     expect(isConsoleIPRestrictionEnabled()).toBe(false);
 
-    process.env.NODE_ENV = 'development';
+    process.env.NODE_ENV = "development";
     expect(isConsoleIPRestrictionEnabled()).toBe(false);
   } finally {
     process.env.NODE_ENV = originalNodeEnv;
@@ -102,7 +114,7 @@ test("disables console IP restriction in development mode", () => {
 test("enables console IP restriction in production mode", () => {
   const originalNodeEnv = process.env.NODE_ENV;
   try {
-    process.env.NODE_ENV = 'production';
+    process.env.NODE_ENV = "production";
     expect(isConsoleIPRestrictionEnabled()).toBe(true);
   } finally {
     process.env.NODE_ENV = originalNodeEnv;


### PR DESCRIPTION
## Summary

Continue the legacy domain redesign (agent BC in #463) for the **management console** BC, behavior-preserving.

1. **Access domain** (`lib/domain/console/access.ts`) — deny redirects, production IP restriction flag, hop-by-hop proxy headers. `console/index.ts` re-exports for stable imports.
2. **Agent Status presentation** (`lib/domain/console/agentStatusPlan.ts`) — pure row planning / formatters; UI re-exports from `agentStatusUtils.tsx`.
3. **SSE frames** (`lib/domain/console/sseFrames.ts`) — complete-frame extraction used by `console-proxy`.
4. **Outer WebSocket bridge** (`composition/consoleOuterWebSocket.ts`) — extracted from `console/index.ts`.
5. **Docs** — `architecture/console-domain-model.md` (+ README map).

## Behavior

No intentional product behavior changes. Regression net: new domain unit tests + existing `console/src` and integration console tests.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `bun run test:integration`
- [ ] CI green

## Notes

- AGT library PR not required for this change.
- Design lives under `architecture/` (not `docs/` static site).