### PR TITLE
Add Markov model adjustment tools

### DIFF
--- a/lib/MarkovChainModel/index.test.ts
+++ b/lib/MarkovChainModel/index.test.ts
@@ -264,9 +264,9 @@ describe("tokenStats and transitionsOf", () => {
   it("tokenStats returns frequency-like ranking", () => {
     const stats = model.tokenStats();
     expect(stats.length).toBeGreaterThan(0);
-    expect(stats[0].token).toBeTruthy();
-    expect(typeof stats[0].asFrom).toBe("number");
-    expect(typeof stats[0].asToWeight).toBe("number");
+    expect(stats[0]!.token).toBeTruthy();
+    expect(typeof stats[0]!.asFrom).toBe("number");
+    expect(typeof stats[0]!.asToWeight).toBe("number");
   });
 
   it("transitionsOf returns asFrom and asTo", () => {

--- a/lib/MarkovChainModel/index.test.ts
+++ b/lib/MarkovChainModel/index.test.ts
@@ -204,3 +204,79 @@ describe('learn', () => {
     expect(copied.corpus).toContain('こんばんは。');
   });
 });
+
+
+describe("decrementPhrase", () => {
+  it("decrements transition weights along the given token sequence", () => {
+    const model = new MarkovChainModel({
+      "": { "あ": 3 },
+      "あ": { "んま": 2 },
+      "んま": { "り": 2 },
+      "あ\u0000んま": { "り": 1 },
+      "り": { "。": 1 },
+    });
+    const updated = model.decrementPhrase(["あ", "んま", "り"], 1);
+    const json = JSON.parse(updated.toJSON()).model;
+    expect(json[""]?.["あ"]).toBe(2);
+    expect(json["あ"]?.["んま"]).toBe(1);
+    expect(json["んま"]?.["り"]).toBe(1);
+    expect(json["あ\u0000んま"]?.["り"]).toBeUndefined();
+  });
+
+  it("removes entries when weight reaches zero or below", () => {
+    const model = new MarkovChainModel({
+      "": { "x": 1 },
+      "x": { "y": 1 },
+      "y": { "。": 1 },
+    });
+    const updated = model.decrementPhrase(["x", "y"], 1);
+    const json = JSON.parse(updated.toJSON()).model;
+    expect(json[""]?.["x"]).toBeUndefined();
+    expect(json["x"]).toBeUndefined();
+  });
+
+  it("does not modify corpus", () => {
+    const model = new MarkovChainModel();
+    model.learn("テスト文。");
+    const before = JSON.parse(model.toJSON()).corpus;
+    const updated = model.decrementPhrase(["テ", "スト"], 1);
+    const after = JSON.parse(updated.toJSON()).corpus;
+    expect(after).toEqual(before);
+  });
+
+  it("keeps a fallback start distribution when emptied", () => {
+    const model = new MarkovChainModel({ "": { "x": 1 } });
+    const updated = model.decrementPhrase(["x"], 1);
+    const json = JSON.parse(updated.toJSON()).model;
+    expect(json[""]).toEqual({ "。": 1 });
+  });
+});
+
+describe("tokenStats and transitionsOf", () => {
+  const model = new MarkovChainModel({
+    "": { "こん": 2 },
+    "こん": { "にち": 1, "ばん": 1 },
+    "にち": { "は": 1 },
+    "ばん": { "は": 1 },
+    "は": { "。": 1 },
+  });
+
+  it("tokenStats returns frequency-like ranking", () => {
+    const stats = model.tokenStats();
+    expect(stats.length).toBeGreaterThan(0);
+    expect(stats[0].token).toBeTruthy();
+    expect(typeof stats[0].asFrom).toBe("number");
+    expect(typeof stats[0].asToWeight).toBe("number");
+  });
+
+  it("transitionsOf returns asFrom and asTo", () => {
+    const t = model.transitionsOf("こん");
+    expect(t.asFrom).toEqual({ "にち": 1, "ばん": 1 });
+    expect(t.asTo.some((x) => x.from === "" && x.weight === 2)).toBe(true);
+  });
+
+  it("search-like filtering works via tokenStats", () => {
+    const hits = model.tokenStats().filter((x) => x.token.includes("こん"));
+    expect(hits.some((x) => x.token === "こん")).toBe(true);
+  });
+});

--- a/lib/MarkovChainModel/index.ts
+++ b/lib/MarkovChainModel/index.ts
@@ -127,7 +127,7 @@ export class MarkovChainModel implements TalkModel {
     const current = this.#model.json as { model: Distribution; corpus: string[] };
     const model = current.model;
     const corpus = current.corpus;
-    const next: Distribution = {};
+    const next: Distribution = { '': {} };
     for (const [from, cands] of Object.entries(model)) {
       next[from] = { ...cands };
     }

--- a/lib/MarkovChainModel/index.ts
+++ b/lib/MarkovChainModel/index.ts
@@ -121,4 +121,66 @@ export class MarkovChainModel implements TalkModel {
   toJSON(): string {
     return JSON.stringify(this.#model.json, null, 0);
   }
+
+  decrementPhrase(tokens: string[], delta = 1): MarkovChainModel {
+    if (tokens.length === 0 || delta === 0) return this;
+    const current = this.#model.json as { model: Distribution; corpus: string[] };
+    const model = current.model;
+    const corpus = current.corpus;
+    const next: Distribution = {};
+    for (const [from, cands] of Object.entries(model)) {
+      next[from] = { ...cands };
+    }
+    const dec = (key: string, token: string) => {
+      if (!next[key] || next[key][token] == null) return;
+      next[key][token] -= delta;
+      if (next[key][token] <= 0) delete next[key][token];
+      if (Object.keys(next[key]).length === 0) delete next[key];
+    };
+    for (let i = 0; i < tokens.length; i++) {
+      const token = tokens[i]!;
+      if (i === 0) dec("", token);
+      const maxN = Math.min(this.#maxLearnContext, i);
+      for (let n = 1; n <= maxN; n++) {
+        const context = tokens.slice(i - n, i).join("\u0000");
+        dec(context, token);
+      }
+    }
+    if (!next[""] || Object.keys(next[""]).length === 0) next[""] = { "。": 1 };
+    return MarkovChainModel.#fromJson({ model: next, corpus }, this.#maxLearnContext);
+  }
+
+  tokenStats(): { token: string; asFrom: number; asToWeight: number }[] {
+    const { model } = this.#model.json as { model: Distribution; corpus: string[] };
+    const map = new Map();
+    for (const [from, cands] of Object.entries(model)) {
+      if (from !== "") {
+        const cur = map.get(from) ?? { asFrom: 0, asToWeight: 0 };
+        cur.asFrom += Object.keys(cands).length;
+        map.set(from, cur);
+      }
+      for (const [to, w] of Object.entries(cands)) {
+        const cur = map.get(to) ?? { asFrom: 0, asToWeight: 0 };
+        cur.asToWeight += w;
+        map.set(to, cur);
+      }
+    }
+    return [...map.entries()]
+      .map(([token, v]) => ({ token, ...v }))
+      .sort((a, b) => (b.asToWeight + b.asFrom) - (a.asToWeight + a.asFrom));
+  }
+
+  transitionsOf(word: string): {
+    asFrom: WeightedCandidates;
+    asTo: { from: string; weight: number }[];
+  } {
+    const { model } = this.#model.json as { model: Distribution; corpus: string[] };
+    const asFrom = { ...(model[word] ?? {}) };
+    const asTo = [];
+    for (const [from, cands] of Object.entries(model)) {
+      if (cands[word] != null) asTo.push({ from, weight: cands[word] });
+    }
+    return { asFrom, asTo };
+  }
+
 };

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "test:e2e": "CONSOLE_TLS_CERT=var/e2e-tls/fullchain.pem CONSOLE_TLS_KEY=var/e2e-tls/privkey.pem playwright test tests/e2e --timeout=60000",
     "browser": "node --import tsx ./bin/x/browser.ts",
     "generate-ogp": "bun run scripts/generate-ogp.ts",
-    "screenshot:console-agent-status": "bun run scripts/capture-console-agent-status.ts"
+    "screenshot:console-agent-status": "bun run scripts/capture-console-agent-status.ts",
+    "markov": "bun run tools/markov/cli.ts"
   },
   "dependencies": {
     "@playwright/browser-chromium": "^1.61.1",

--- a/tools/markov/cli.ts
+++ b/tools/markov/cli.ts
@@ -1,0 +1,79 @@
+﻿#!/usr/bin/env bun
+import { parseArgs } from "node:util";
+import { MarkovChainModel } from "../../lib/MarkovChainModel";
+
+const { values, positionals } = parseArgs({
+  args: Bun.argv.slice(2),
+  options: {
+    delta: { type: "string", default: "1" },
+    top: { type: "string", default: "50" },
+    help: { type: "boolean", short: "h" },
+  },
+  allowPositionals: true,
+});
+
+const [cmd, ...rest] = positionals;
+
+function load(path: string): MarkovChainModel {
+  try {
+    return MarkovChainModel.fromFile(path);
+  } catch (e) {
+    console.error(`failed to load model: ${path}`, e);
+    process.exit(1);
+  }
+}
+
+function usage(): never {
+  console.error(`Usage:
+  bun run tools/markov/cli.ts decrement-phrase <modelPath> <phrase> [--delta N]
+  bun run tools/markov/cli.ts tokens <modelPath> [--top N]
+  bun run tools/markov/cli.ts search <modelPath> <query>
+  bun run tools/markov/cli.ts transitions <modelPath> <word>`);
+  process.exit(values.help ? 0 : 1);
+}
+
+if (!cmd || values.help) usage();
+
+switch (cmd) {
+  case "decrement-phrase": {
+    const [modelPath, phrase] = rest;
+    if (!modelPath || phrase == null) {
+      console.error("modelPath and phrase are required");
+      usage();
+    }
+    const tokens = phrase.trim().split(/\s+/).filter(Boolean);
+    if (tokens.length === 0) {
+      console.error("phrase is empty");
+      process.exit(1);
+    }
+    const delta = Math.max(1, parseInt(values.delta ?? "1", 10) || 1);
+    const model = load(modelPath);
+    const updated = model.decrementPhrase(tokens, delta);
+    process.stdout.write(updated.toJSON());
+    if (process.stdout.isTTY) process.stdout.write("\n");
+    break;
+  }
+  case "tokens": {
+    const [modelPath] = rest;
+    if (!modelPath) usage();
+    const top = Math.max(1, parseInt(values.top ?? "50", 10) || 50);
+    console.log(JSON.stringify(load(modelPath).tokenStats().slice(0, top), null, 2));
+    break;
+  }
+  case "search": {
+    const [modelPath, query] = rest;
+    if (!modelPath || query == null) usage();
+    const hits = load(modelPath).tokenStats().filter((t) => t.token.includes(query));
+    console.log(JSON.stringify(hits, null, 2));
+    break;
+  }
+  case "transitions": {
+    const [modelPath, word] = rest;
+    if (!modelPath || word == null) usage();
+    console.log(JSON.stringify(load(modelPath).transitionsOf(word), null, 2));
+    break;
+  }
+  default:
+    console.error(`unknown command: ${cmd}`);
+    usage();
+}


### PR DESCRIPTION
﻿## Summary
悪い単語・フレーズの生成経路を調整するための CLI を追加しました。

## Changes
- MarkovChainModel.decrementPhrase: 渡したトークン列の遷移重みを delta 減らす（corpus は触らない）
- tokenStats / transitionsOf: モデル内の語・遷移を調査
- tools/markov/cli.ts + bun run markov
- 変更後モデルは標準出力へ JSON 出力

## Usage
bun run markov tokens ./var/model.json --top 50
bun run markov search ./var/model.json よくない
bun run markov decrement-phrase ./var/model.json "phrase tokens here" > ./var/model-tuned.json

## Test plan
- [x] bun test lib/MarkovChainModel/index.test.ts (20 pass)
