### PR TITLE
Markov decrement-phrase -i and n-gram state key weakening

### DIFF
--- a/tools/markov/cli.test.ts
+++ b/tools/markov/cli.test.ts
@@ -130,3 +130,47 @@ describe("markov cli decrement-phrase --in-place", () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 });
+
+describe("markov cli decrement-phrase -iSUFFIX", () => {
+  it("writes backup with suffix then overwrites model", async () => {
+    mkdirSync(tmpDir, { recursive: true });
+    writeFileSync(
+      modelPath,
+      JSON.stringify({
+        model: { "": { beige: 2 }, beige: { panty: 3 } },
+        corpus: [],
+      }),
+    );
+
+    const proc = Bun.spawn(
+      [
+        "bun",
+        "run",
+        "tools/markov/cli.ts",
+        "decrement-phrase",
+        modelPath,
+        "beige panty",
+        "--delta",
+        "1",
+        "-i.bak",
+      ],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+    const stdout = await new Response(proc.stdout).text();
+    const stderr = await new Response(proc.stderr).text();
+    const code = await proc.exited;
+
+    expect(code).toBe(0);
+    expect(stdout.trim()).toBe("");
+    expect(stderr).toContain("backup:");
+    expect(stderr).toContain("wrote:");
+
+    const backup = JSON.parse(require("fs").readFileSync(modelPath + ".bak", "utf8"));
+    expect(backup.model[""].beige).toBe(2);
+
+    const saved = JSON.parse(require("fs").readFileSync(modelPath, "utf8"));
+    expect(saved.model[""].beige).toBe(1);
+
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+});

--- a/tools/markov/cli.test.ts
+++ b/tools/markov/cli.test.ts
@@ -85,3 +85,48 @@ describe("markov cli decrement-phrase", () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 });
+
+describe("markov cli decrement-phrase --in-place", () => {
+  it("in-place writes model back without stdout JSON", async () => {
+    mkdirSync(tmpDir, { recursive: true });
+    writeFileSync(
+      modelPath,
+      JSON.stringify({
+        model: {
+          "": { beige: 2 },
+          beige: { panty: 3 },
+        },
+        corpus: [],
+      }),
+    );
+
+    const proc = Bun.spawn(
+      [
+        "bun",
+        "run",
+        "tools/markov/cli.ts",
+        "decrement-phrase",
+        "-i",
+        modelPath,
+        "beige panty",
+        "--delta",
+        "1",
+      ],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+    const stdout = await new Response(proc.stdout).text();
+    const stderr = await new Response(proc.stderr).text();
+    const code = await proc.exited;
+
+    expect(code).toBe(0);
+    expect(stdout.trim()).toBe("");
+    expect(stderr).toContain("changed:");
+    expect(stderr).toContain("wrote:");
+
+    const saved = JSON.parse(require("fs").readFileSync(modelPath, "utf8"));
+    expect(saved.model[""].beige).toBe(1);
+    expect(saved.model.beige.panty).toBe(2);
+
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+});

--- a/tools/markov/cli.ts
+++ b/tools/markov/cli.ts
@@ -1,5 +1,6 @@
 ﻿#!/usr/bin/env bun
 import { parseArgs } from "node:util";
+import { writeFileSync } from "node:fs";
 import { MarkovChainModel } from "../../lib/MarkovChainModel";
 
 const vis = (s: string) => s.replaceAll("\u0000", "/");
@@ -24,6 +25,7 @@ const { values, positionals } = parseArgs({
   options: {
     delta: { type: "string", default: "1" },
     top: { type: "string", default: "50" },
+    "in-place": { type: "boolean", short: "i", default: false },
     help: { type: "boolean", short: "h" },
   },
   allowPositionals: true,
@@ -42,7 +44,7 @@ function load(path: string): MarkovChainModel {
 
 function usage(): never {
   console.error(`Usage:
-  bun run tools/markov/cli.ts decrement-phrase <modelPath> <phrase> [--delta N]
+  bun run tools/markov/cli.ts decrement-phrase <modelPath> <phrase> [--delta N] [--in-place|-i]
   bun run tools/markov/cli.ts tokens <modelPath> [--top N]
   bun run tools/markov/cli.ts search <modelPath> <query>
   bun run tools/markov/cli.ts transitions <modelPath> <word>`);
@@ -86,8 +88,13 @@ switch (cmd) {
     }
     console.error(`changed: ${changed} transitions`);
 
-    process.stdout.write(updated.toJSON());
-    if (process.stdout.isTTY) process.stdout.write("\n");
+    if (values["in-place"]) {
+      writeFileSync(modelPath, updated.toJSON(), "utf8");
+      console.error(`wrote: ${modelPath}`);
+    } else {
+      process.stdout.write(updated.toJSON());
+      if (process.stdout.isTTY) process.stdout.write("\n");
+    }
     break;
   }
   case "tokens": {

--- a/tools/markov/cli.ts
+++ b/tools/markov/cli.ts
@@ -1,6 +1,19 @@
 ﻿#!/usr/bin/env bun
 import { parseArgs } from "node:util";
-import { writeFileSync } from "node:fs";
+import { writeFileSync, copyFileSync } from "node:fs";
+
+function expandInPlaceArgs(argv: string[]): string[] {
+  const out: string[] = [];
+  for (const a of argv) {
+    if (a.startsWith("-i") && a.length > 2 && !a.startsWith("--")) {
+      out.push("-i", "--suffix", a.slice(2));
+    } else {
+      out.push(a);
+    }
+  }
+  return out;
+}
+
 import { MarkovChainModel } from "../../lib/MarkovChainModel";
 
 const vis = (s: string) => s.replaceAll("\u0000", "/");
@@ -21,11 +34,12 @@ const printCsv = (header: string[], rows: (string | number)[][]) => {
 };
 
 const { values, positionals } = parseArgs({
-  args: Bun.argv.slice(2),
+  args: expandInPlaceArgs(Bun.argv.slice(2)),
   options: {
     delta: { type: "string", default: "1" },
     top: { type: "string", default: "50" },
     "in-place": { type: "boolean", short: "i", default: false },
+    suffix: { type: "string", default: "" },
     help: { type: "boolean", short: "h" },
   },
   allowPositionals: true,
@@ -44,7 +58,7 @@ function load(path: string): MarkovChainModel {
 
 function usage(): never {
   console.error(`Usage:
-  bun run tools/markov/cli.ts decrement-phrase <modelPath> <phrase> [--delta N] [--in-place|-i]
+  bun run tools/markov/cli.ts decrement-phrase <modelPath> <phrase> [--delta N] [-i|-iSUFFIX] [--suffix SUFFIX]
   bun run tools/markov/cli.ts tokens <modelPath> [--top N]
   bun run tools/markov/cli.ts search <modelPath> <query>
   bun run tools/markov/cli.ts transitions <modelPath> <word>`);
@@ -89,6 +103,12 @@ switch (cmd) {
     console.error(`changed: ${changed} transitions`);
 
     if (values["in-place"]) {
+      const suffix = values.suffix ?? "";
+      if (suffix) {
+        const backupPath = modelPath + suffix;
+        copyFileSync(modelPath, backupPath);
+        console.error(`backup: ${backupPath}`);
+      }
       writeFileSync(modelPath, updated.toJSON(), "utf8");
       console.error(`wrote: ${modelPath}`);
     } else {


### PR DESCRIPTION
Add --in-place/-i for in-file model updates (stderr logs, no stdout JSON). decrementPhrase also weakens outgoing edges from n-gram keys equal to or containing the phrase.