### PR TITLE
Markov moderation: purge, delimiter, vis, in-place

### DIFF
--- a/lib/MarkovChainModel/index.test.ts
+++ b/lib/MarkovChainModel/index.test.ts
@@ -215,7 +215,7 @@ describe("decrementPhrase", () => {
       "あ\u0000んま": { "り": 1 },
       "り": { "。": 1 },
     });
-    const updated = model.decrementPhrase(["あ", "んま", "り"], 1);
+    const updated = model.decrementPhrase(["あ", "んま", "り"], { delta: 1 });
     const json = JSON.parse(updated.toJSON()).model;
     expect(json[""]?.["あ"]).toBe(2);
     expect(json["あ"]?.["んま"]).toBe(1);
@@ -229,7 +229,7 @@ describe("decrementPhrase", () => {
       "x": { "y": 1 },
       "y": { "。": 1 },
     });
-    const updated = model.decrementPhrase(["x", "y"], 1);
+    const updated = model.decrementPhrase(["x", "y"], { delta: 1 });
     const json = JSON.parse(updated.toJSON()).model;
     expect(json[""]?.["x"]).toBeUndefined();
     expect(json["x"]).toBeUndefined();
@@ -239,14 +239,14 @@ describe("decrementPhrase", () => {
     const model = new MarkovChainModel();
     model.learn("テスト文。");
     const before = JSON.parse(model.toJSON()).corpus;
-    const updated = model.decrementPhrase(["テ", "スト"], 1);
+    const updated = model.decrementPhrase(["テ", "スト"], { delta: 1 });
     const after = JSON.parse(updated.toJSON()).corpus;
     expect(after).toEqual(before);
   });
 
   it("keeps a fallback start distribution when emptied", () => {
     const model = new MarkovChainModel({ "": { "x": 1 } });
-    const updated = model.decrementPhrase(["x"], 1);
+    const updated = model.decrementPhrase(["x"], { delta: 1 });
     const json = JSON.parse(updated.toJSON()).model;
     expect(json[""]).toEqual({ "。": 1 });
   });
@@ -260,7 +260,7 @@ describe("decrementPhrase", () => {
       unrelated: { x: 9 },
     });
 
-    const updated = model.decrementPhrase(["beige", "panty"], 1);
+    const updated = model.decrementPhrase(["beige", "panty"], { delta: 1 });
     const m = JSON.parse(updated.toJSON()).model;
     const phraseKey = "beige" + String.fromCharCode(0) + "panty";
     const longKey = "pre" + String.fromCharCode(0) + "beige" + String.fromCharCode(0) + "panty";
@@ -279,7 +279,7 @@ describe("decrementPhrase", () => {
       "": {},
       [phraseKey]: { end: 1 },
     });
-    const updated = model.decrementPhrase(["beige", "panty"], 1);
+    const updated = model.decrementPhrase(["beige", "panty"], { delta: 1 });
     const m = JSON.parse(updated.toJSON()).model;
     expect(m[phraseKey]).toBeUndefined();
   });
@@ -294,7 +294,7 @@ describe("decrementPhrase", () => {
       ["pre" + String.fromCharCode(0) + "beige" + String.fromCharCode(0) + "panty"]: { end: 4 },
       unrelated: { x: 9 },
     });
-    const updated = model.decrementPhrase(["beige", "panty"], 1, { purge: true });
+    const updated = model.decrementPhrase(["beige", "panty"], { purge: true });
     const m = JSON.parse(updated.toJSON()).model;
     const phraseKey = "beige" + String.fromCharCode(0) + "panty";
     const longKey = "pre" + String.fromCharCode(0) + "beige" + String.fromCharCode(0) + "panty";
@@ -313,9 +313,9 @@ describe("decrementPhrase", () => {
       "": { beige: 5 },
       beige: { panty: 5 },
     });
-    const a = JSON.parse(model.decrementPhrase(["beige"], 1).toJSON()).model;
+    const a = JSON.parse(model.decrementPhrase(["beige"], { delta: 1 }).toJSON()).model;
     expect(a[""]?.beige).toBe(4);
-    const b = JSON.parse(model.decrementPhrase(["beige"], 1, { purge: true }).toJSON()).model;
+    const b = JSON.parse(model.decrementPhrase(["beige"], { purge: true }).toJSON()).model;
     expect(b[""]?.beige).toBeUndefined();
   });
 

--- a/lib/MarkovChainModel/index.test.ts
+++ b/lib/MarkovChainModel/index.test.ts
@@ -284,6 +284,41 @@ describe("decrementPhrase", () => {
     expect(m[phraseKey]).toBeUndefined();
   });
 
+
+  it("purge removes all edges to tokens and matching n-gram keys", () => {
+    const model = new MarkovChainModel({
+      "": { beige: 2, other: 1 },
+      beige: { panty: 3 },
+      no: { panty: 4 },
+      ["beige" + String.fromCharCode(0) + "panty"]: { end: 5 },
+      ["pre" + String.fromCharCode(0) + "beige" + String.fromCharCode(0) + "panty"]: { end: 4 },
+      unrelated: { x: 9 },
+    });
+    const updated = model.decrementPhrase(["beige", "panty"], 1, { purge: true });
+    const m = JSON.parse(updated.toJSON()).model;
+    const phraseKey = "beige" + String.fromCharCode(0) + "panty";
+    const longKey = "pre" + String.fromCharCode(0) + "beige" + String.fromCharCode(0) + "panty";
+
+    expect(m[""]?.beige).toBeUndefined();
+    expect(m[""]?.other).toBe(1);
+    expect(m.beige).toBeUndefined();
+    expect(m.no?.panty).toBeUndefined();
+    expect(m[phraseKey]).toBeUndefined();
+    expect(m[longKey]).toBeUndefined();
+    expect(m.unrelated?.x).toBe(9);
+  });
+
+  it("purge and normal delta remain distinct", () => {
+    const model = new MarkovChainModel({
+      "": { beige: 5 },
+      beige: { panty: 5 },
+    });
+    const a = JSON.parse(model.decrementPhrase(["beige"], 1).toJSON()).model;
+    expect(a[""]?.beige).toBe(4);
+    const b = JSON.parse(model.decrementPhrase(["beige"], 1, { purge: true }).toJSON()).model;
+    expect(b[""]?.beige).toBeUndefined();
+  });
+
 });
 
 describe("tokenStats and transitionsOf", () => {

--- a/lib/MarkovChainModel/index.ts
+++ b/lib/MarkovChainModel/index.ts
@@ -6,6 +6,11 @@ const jaJP = new Intl.Locale('ja-JP');
 
 type WeightedCandidates = Record<string, number>;
 
+export type DecrementPhraseOptions =
+  | { readonly purge: true; readonly delta?: never }
+  | { readonly purge?: false; readonly delta?: number };
+
+
 type Distribution = {
   /** initial word candidates */
   '': WeightedCandidates
@@ -122,9 +127,8 @@ export class MarkovChainModel implements TalkModel {
     return JSON.stringify(this.#model.json, null, 0);
   }
 
-  decrementPhrase(tokens: string[], delta = 1, opts?: { purge?: boolean }): MarkovChainModel {
+  decrementPhrase(tokens: string[], opts: DecrementPhraseOptions = { delta: 1 }): MarkovChainModel {
     if (tokens.length === 0) return this;
-    if (!opts?.purge && delta === 0) return this;
     const current = this.#model.json as { model: Distribution; corpus: string[] };
     const model = current.model;
     const corpus = current.corpus;
@@ -139,7 +143,7 @@ export class MarkovChainModel implements TalkModel {
       if (Object.keys(next[key]).length === 0) delete next[key];
     };
 
-    if (opts?.purge) {
+    if (opts.purge === true) {
       const phraseParts = tokens;
       const keyHasPhrase = (from: string): boolean => {
         if (from === tokens.join("\u0000")) return true;
@@ -164,6 +168,9 @@ export class MarkovChainModel implements TalkModel {
       if (!next[""] || Object.keys(next[""]).length === 0) next[""] = { "。": 1 };
       return MarkovChainModel.#fromJson({ model: next, corpus }, this.#maxLearnContext);
     }
+
+    const delta = opts.delta ?? 1;
+    if (delta === 0) return this;
 
     for (let i = 0; i < tokens.length; i++) {
       const token = tokens[i]!;

--- a/lib/MarkovChainModel/index.ts
+++ b/lib/MarkovChainModel/index.ts
@@ -122,8 +122,9 @@ export class MarkovChainModel implements TalkModel {
     return JSON.stringify(this.#model.json, null, 0);
   }
 
-  decrementPhrase(tokens: string[], delta = 1): MarkovChainModel {
-    if (tokens.length === 0 || delta === 0) return this;
+  decrementPhrase(tokens: string[], delta = 1, opts?: { purge?: boolean }): MarkovChainModel {
+    if (tokens.length === 0) return this;
+    if (!opts?.purge && delta === 0) return this;
     const current = this.#model.json as { model: Distribution; corpus: string[] };
     const model = current.model;
     const corpus = current.corpus;
@@ -137,6 +138,33 @@ export class MarkovChainModel implements TalkModel {
       if (next[key][token] <= 0) delete next[key][token];
       if (Object.keys(next[key]).length === 0) delete next[key];
     };
+
+    if (opts?.purge) {
+      const phraseParts = tokens;
+      const keyHasPhrase = (from: string): boolean => {
+        if (from === tokens.join("\u0000")) return true;
+        const segs = from.split("\u0000");
+        for (let i = 0; i <= segs.length - phraseParts.length; i++) {
+          if (phraseParts.every((tok, j) => segs[i + j] === tok)) return true;
+        }
+        return false;
+      };
+      for (const from of Object.keys(next)) {
+        if (keyHasPhrase(from)) {
+          delete next[from];
+          continue;
+        }
+        const cands = next[from];
+        if (!cands) continue;
+        for (const tok of tokens) {
+          if (cands[tok] != null) delete cands[tok];
+        }
+        if (Object.keys(cands).length === 0) delete next[from];
+      }
+      if (!next[""] || Object.keys(next[""]).length === 0) next[""] = { "。": 1 };
+      return MarkovChainModel.#fromJson({ model: next, corpus }, this.#maxLearnContext);
+    }
+
     for (let i = 0; i < tokens.length; i++) {
       const token = tokens[i]!;
       if (i === 0) dec("", token);

--- a/tools/markov/cli.test.ts
+++ b/tools/markov/cli.test.ts
@@ -240,3 +240,65 @@ describe("markov cli delimiter", () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 });
+
+describe("markov cli decrement-phrase --purge", () => {
+  it("rejects --purge with --delta", async () => {
+    mkdirSync(tmpDir, { recursive: true });
+    writeFileSync(
+      modelPath,
+      JSON.stringify({ model: { "": { a: 1 } }, corpus: [] }),
+    );
+    const proc = Bun.spawn(
+      [
+        "bun",
+        "run",
+        "tools/markov/cli.ts",
+        "decrement-phrase",
+        modelPath,
+        "a",
+        "--purge",
+        "--delta",
+        "1",
+      ],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+    const stderr = await new Response(proc.stderr).text();
+    const code = await proc.exited;
+    expect(code).toBe(1);
+    expect(stderr).toContain("--purge and --delta cannot be used together");
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("purge removes token edges", async () => {
+    mkdirSync(tmpDir, { recursive: true });
+    writeFileSync(
+      modelPath,
+      JSON.stringify({
+        model: { "": { beige: 2, x: 1 }, no: { beige: 3 } },
+        corpus: [],
+      }),
+    );
+    const proc = Bun.spawn(
+      [
+        "bun",
+        "run",
+        "tools/markov/cli.ts",
+        "decrement-phrase",
+        modelPath,
+        "beige",
+        "--purge",
+      ],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+    const stdout = await new Response(proc.stdout).text();
+    const stderr = await new Response(proc.stderr).text();
+    const code = await proc.exited;
+    expect(code).toBe(0);
+    expect(stderr).toContain("purge");
+    const out = JSON.parse(stdout);
+    expect(out.model[""]?.beige).toBeUndefined();
+    expect(out.model[""]?.x).toBe(1);
+    expect(out.model.no?.beige).toBeUndefined();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+});

--- a/tools/markov/cli.ts
+++ b/tools/markov/cli.ts
@@ -50,6 +50,7 @@ const { values, positionals } = parseArgs({
     "in-place": { type: "boolean", short: "i", default: false },
     suffix: { type: "string", default: "" },
     delimiter: { type: "string", short: "d", default: " " },
+    purge: { type: "boolean", default: false },
     help: { type: "boolean", short: "h" },
   },
   allowPositionals: true,
@@ -68,7 +69,7 @@ function load(path: string): MarkovChainModel {
 
 function usage(): never {
   console.error(`Usage:
-  bun run tools/markov/cli.ts decrement-phrase <modelPath> <phrase> [--delta N] [-i|-iSUFFIX] [-d DELIM]
+  bun run tools/markov/cli.ts decrement-phrase <modelPath> <phrase> [--delta N | --purge] [-i|-iSUFFIX] [-d DELIM]
   bun run tools/markov/cli.ts tokens <modelPath> [--top N]
   bun run tools/markov/cli.ts search <modelPath> <query>
   bun run tools/markov/cli.ts transitions <modelPath> <word> [-d DELIM]`);
@@ -89,15 +90,23 @@ switch (cmd) {
       console.error("phrase is empty");
       process.exit(1);
     }
+    
+    const deltaExplicit = Bun.argv.slice(2).some(
+      (a) => a === "--delta" || a.startsWith("--delta="),
+    );
+    if (values.purge && deltaExplicit) {
+      console.error("--purge and --delta cannot be used together");
+      process.exit(1);
+    }
     const delta = Math.max(1, parseInt(values.delta ?? "1", 10) || 1);
     const model = load(modelPath);
     const before = JSON.parse(model.toJSON()).model as Record<string, Record<string, number>>;
-    const updated = model.decrementPhrase(tokens, delta);
+    const updated = model.decrementPhrase(tokens, delta, values.purge ? { purge: true } : undefined);
     const after = JSON.parse(updated.toJSON()).model as Record<string, Record<string, number>>;
 
     const ctxLabel = (s: string) => vis(s) || "(BOS)";
     let changed = 0;
-    console.error(`decrement-phrase delta=${delta} tokens=${JSON.stringify(tokens)}`);
+    console.error(`decrement-phrase ${values.purge ? "purge" : `delta=${delta}`} tokens=${JSON.stringify(tokens)}`);
     for (const k of new Set([...Object.keys(before), ...Object.keys(after)])) {
       const ka = before[k] ?? {};
       const kb = after[k] ?? {};

--- a/tools/markov/cli.ts
+++ b/tools/markov/cli.ts
@@ -101,7 +101,10 @@ switch (cmd) {
     const delta = Math.max(1, parseInt(values.delta ?? "1", 10) || 1);
     const model = load(modelPath);
     const before = JSON.parse(model.toJSON()).model as Record<string, Record<string, number>>;
-    const updated = model.decrementPhrase(tokens, delta, values.purge ? { purge: true } : undefined);
+    const updated = model.decrementPhrase(
+      tokens,
+      values.purge ? { purge: true } : { delta },
+    );
     const after = JSON.parse(updated.toJSON()).model as Record<string, Record<string, number>>;
 
     const ctxLabel = (s: string) => vis(s) || "(BOS)";


### PR DESCRIPTION
## Summary
モデレーション用 CLI / model API の強化。

## Changes
- --purge: 語・フレーズ関連の遷移と n-gram key を削除 (--delta と併用不可)
- -d/--delimiter: フレーズ区切り (default space, -d/ 可)
- ログ/CSV の \u0000 は常に / 表示
- -i / -iSUFFIX: その場更新とバックアップ

## Usage
bun run markov decrement-phrase -i.bak ./var/model.json パンティー --purge
bun run markov decrement-phrase -i -d/ ./var/model.json ベージュ/パンティー --delta 1