### PR TITLE
refactor(cookieclicker): testable state machine and high solver coverage

### DIFF
--- a/lib/Agent/games/org.dashnet.orteil/cookieclicker/ReactComponent.test.tsx
+++ b/lib/Agent/games/org.dashnet.orteil/cookieclicker/ReactComponent.test.tsx
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "bun:test";
+import Component from "./ReactComponent";
+import type { State } from "./State";
+
+const baseState = {
+  cookies: 0,
+  cps: 0,
+  isWrinkled: false,
+  ascendNumber: 0,
+  store: {
+    products: { bulkMode: "buy" as const, items: [] },
+    upgrades: [],
+    tech: [],
+    switches: [],
+  },
+} satisfies Omit<State, "statistics">;
+
+async function renderHtml(state: State): Promise<string> {
+  const node = Component({ state }) as unknown;
+  if (typeof node === "string") return node;
+  if (node != null && typeof (node as { toString?: unknown }).toString === "function") {
+    const s = (node as { toString: () => string | Promise<string> }).toString();
+    return typeof s === "string" ? s : await s;
+  }
+  return String(node);
+}
+
+describe("CookieClicker ReactComponent", () => {
+  it("shows generation and click count when statistics are enriched", async () => {
+    const html = await renderHtml({
+      ...baseState,
+      statistics: {
+        general: {
+          "遺産の始まり：": {
+            innerText: " 362日前, 昇天 107回",
+            ascensions: 107,
+            daysAgo: 362,
+          },
+          "クリック回数：": {
+            innerText: " 1,009",
+            value: 1009,
+          },
+        } as NonNullable<State["statistics"]>["general"],
+      },
+    });
+    expect(html).toContain("107世代目");
+    expect(html).toContain("クリック 1,009回");
+  });
+
+  it("shows placeholders when statistics are missing", async () => {
+    const html = await renderHtml({ ...baseState });
+    expect(html).toContain("—世代目");
+    expect(html).toContain("クリック —回");
+  });
+
+  it("shows placeholders when values are not yet parsed", async () => {
+    const html = await renderHtml({
+      ...baseState,
+      statistics: {
+        general: {
+          "遺産の始まり：": { innerText: " 362日前" },
+          "クリック回数：": { innerText: " 不明" },
+        },
+      },
+    });
+    expect(html).toContain("—世代目");
+    expect(html).toContain("クリック —回");
+  });
+});

--- a/lib/Agent/games/org.dashnet.orteil/cookieclicker/solver.test.ts
+++ b/lib/Agent/games/org.dashnet.orteil/cookieclicker/solver.test.ts
@@ -1,6 +1,24 @@
 import { Action, ActionResult } from "automated-gameplay-transmitter";
 import { beforeAll, describe, expect, it } from "bun:test";
-import { solver } from "./solver";
+import {
+  solver,
+  IDLE_CLICKS_BEFORE_SAVE,
+  States,
+  hydrate,
+  handleSeeStats,
+  stepSeeStats,
+  handleSave,
+  stepSave,
+  stepIdle,
+  stepInitialize,
+  handleIdle,
+  handleInitialize,
+  handleClosed,
+  type HandlerCtx,
+  type GameState,
+  runActions,
+} from "./solver";
+import type { Action as ActionType } from "automated-gameplay-transmitter";
 
 beforeAll(() => {
   console.debug = () => { };
@@ -19,7 +37,6 @@ describe('solver', () => {
       Action.clickByText('日本語'),
       Action.clickByText('Got it'),
       Action.clickByText('次回から表示しない'),
-      Action.noop,
     ];
 
     let prev;
@@ -33,6 +50,7 @@ describe('solver', () => {
     const data = 'Mi4wNTJ8fDE3NjM4ODAzNTI5MTQ7MTc2Mzg4MDM1MjkxNDsxNzYzODgwMzYyNTE1O1RyaXBsZSBHbm9tZTt5dnJjZjswLDEsMCwwLDAsMCwwfDExMTExMTAxMTAwMTAxMTAwMTAxMDExMDAwMXwwOzA7MDswOzA7MDswOzA7MDswOzA7MDswOzA7MDswOzA7MDswOzA7MDswOzswOzA7MDswOzA7MDswOy0xOy0xOy0xOy0xOy0xOzA7MDswOzA7NzU7MDswOy0xOy0xOzE3NjM4ODAzNTI5MTQ7MDswOzs0MTswOzA7MDs1MDswOzA7fDAsMCwwLDAsLDAsMDswLDAsMCwwLCwwLDA7MCwwLDAsMCwsMCwwOzAsMCwwLDAsLDAsMDswLDAsMCwwLCwwLDA7MCwwLDAsMCwsMCwwOzAsMCwwLDAsLDAsMDswLDAsMCwwLCwwLDA7MCwwLDAsMCwsMCwwOzAsMCwwLDAsLDAsMDswLDAsMCwwLCwwLDA7MCwwLDAsMCwsMCwwOzAsMCwwLDAsLDAsMDswLDAsMCwwLCwwLDA7MCwwLDAsMCwsMCwwOzAsMCwwLDAsLDAsMDswLDAsMCwwLCwwLDA7MCwwLDAsMCwsMCwwOzAsMCwwLDAsLDAsMDswLDAsMCwwLCwwLDA7fDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDB8MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMHx8%21END%21';
     const solve = solver({
       type: 'initialize',
+      phase: 'open',
       data,
     });
 
@@ -45,7 +63,6 @@ describe('solver', () => {
       { name: 'press', key: 'Control+O' },
       { name: 'fill', value: data, on: { selector: '#game', role: 'textbox' } },
       { name: 'press', key: 'Enter' },
-      Action.noop,
     ];
 
     let prev;
@@ -66,7 +83,6 @@ describe('solver', () => {
     // optional steps fail (e.g. dialogs not present) — initialization should continue
     expect(solve.next(ActionResult.error(Action.clickByText('日本語')) as any).value).toEqual(Action.clickByText('Got it'));
     expect(solve.next(ActionResult.error(Action.clickByText('Got it')) as any).value).toEqual(Action.clickByText('次回から表示しない'));
-    expect(solve.next(ActionResult.error(Action.clickByText('次回から表示しない')) as any).value).toEqual(Action.noop);
   });
 
   it('should be done when got closed state', () => {
@@ -81,7 +97,7 @@ describe('solver', () => {
       state: { clickableElementIds: ['bigCookie'] },
     };
 
-    const solve = solver({ type: 'idle', count: 0 });
+    const solve = solver({ type: 'idle', phase: 'sight', count: 0 });
 
     expect(solve.next().value).toEqual(Action.noop);
     expect(solve.next(idleState as any).value).toEqual(Action.clickByElementId('bigCookie'));
@@ -94,7 +110,7 @@ describe('solver', () => {
       state: { clickableElementIds: ['bigCookie', 'shimmer1', 'shimmer2'] },
     };
 
-    const solve = solver({ type: 'idle', count: 0 });
+    const solve = solver({ type: 'idle', phase: 'sight', count: 0 });
 
     expect(solve.next().value).toEqual(Action.noop);
     const clickAction = solve.next(idleState as any).value as any;
@@ -109,7 +125,7 @@ describe('solver', () => {
       state: { clickableElementIds: [] },
     };
 
-    const solve = solver({ type: 'idle', count: 0 });
+    const solve = solver({ type: 'idle', phase: 'sight', count: 0 });
 
     expect(solve.next().value).toEqual(Action.noop);
     expect(solve.next(idleState as any).value).toEqual(Action.clickByElementId('bigCookie'));
@@ -122,7 +138,7 @@ describe('solver', () => {
       state: { clickableElementIds: ['bigCookie', 'shimmer1', 'shimmer2'] },
     };
 
-    const solve = solver({ type: 'idle', count: 0 }, { isSilent: () => true });
+    const solve = solver({ type: 'idle', phase: 'sight', count: 0 }, { isSilent: () => true });
 
     expect(solve.next().value).toEqual(Action.noop);
     expect(solve.next(idleState as any).value).toEqual(Action.clickByElementId('bigCookie'));
@@ -135,7 +151,7 @@ describe('solver', () => {
       state: { clickableElementIds: ['bigCookie', 'shimmer1', 'shimmer2'] },
     };
 
-    const solve = solver({ type: 'idle', count: 0 }, { isSilent: () => false });
+    const solve = solver({ type: 'idle', phase: 'sight', count: 0 }, { isSilent: () => false });
 
     expect(solve.next().value).toEqual(Action.noop);
     const clickAction = solve.next(idleState as any).value as any;
@@ -150,7 +166,7 @@ describe('solver', () => {
     };
     const openAction = Action.open('https://orteil.dashnet.org/cookieclicker/');
 
-    const solve = solver({ type: 'idle', count: 0 });
+    const solve = solver({ type: 'idle', phase: 'sight', count: 0 });
 
     expect(solve.next().value).toEqual(Action.noop);
     // When at wrong URL, transition to initialize state and open Cookie Clicker
@@ -167,7 +183,7 @@ describe('solver', () => {
     };
     const clickAction = Action.clickByElementId('bigCookie');
 
-    const solve = solver({ type: 'idle', count: 0 });
+    const solve = solver({ type: 'idle', phase: 'sight', count: 0 });
 
     expect(solve.next().value).toEqual(Action.noop);
     expect(solve.next(idleState as any).value).toEqual(clickAction);
@@ -177,7 +193,7 @@ describe('solver', () => {
   it('should press ESC after the first click in save sequence fails', () => {
     const optionsAction = Action.clickByText('オプション');
 
-    const solve = solver({ type: 'save', failureCount: 0 });
+    const solve = solver({ type: 'save', phase: 'options', failureCount: 0 });
 
     expect(solve.next().value).toEqual(optionsAction);
     expect(solve.next(ActionResult.error(optionsAction) as any).value).toEqual({ name: 'press', key: 'Escape' });
@@ -187,7 +203,7 @@ describe('solver', () => {
     const optionsAction = Action.clickByText('オプション');
     const exportAction = Action.clickByText('セーブをエクスポート');
 
-    const solve = solver({ type: 'save', failureCount: 0 });
+    const solve = solver({ type: 'save', phase: 'options', failureCount: 0 });
 
     expect(solve.next().value).toEqual(optionsAction);
     expect(solve.next(ActionResult.ok(optionsAction) as any).value).toEqual(exportAction);
@@ -202,7 +218,7 @@ describe('solver', () => {
     };
     const clickAction = Action.clickByElementId('bigCookie');
 
-    const solve = solver({ type: 'idle', count: 0 });
+    const solve = solver({ type: 'idle', phase: 'sight', count: 0 });
 
     expect(solve.next().value).toEqual(Action.noop);
     expect(solve.next(idleState as any).value).toEqual(clickAction);
@@ -214,7 +230,7 @@ describe('solver', () => {
     const optionsAction = Action.clickByText('オプション');
     const escapeAction = { name: 'press', key: 'Escape' } as const;
 
-    const solve = solver({ type: 'save', failureCount: 0 });
+    const solve = solver({ type: 'save', phase: 'options', failureCount: 0 });
 
     // First failure: failureCount 0 → 1, stays in save
     expect(solve.next().value).toEqual(optionsAction);
@@ -234,7 +250,7 @@ describe('solver', () => {
     const statsAction = Action.clickByText('記録');
     const escapeAction = { name: 'press', key: 'Escape' } as const;
 
-    const solve = solver({ type: 'seeStats', failureCount: 0 });
+    const solve = solver({ type: 'seeStats', phase: 'open', failureCount: 0 });
 
     // First failure: failureCount 0 → 1, stays in seeStats
     expect(solve.next().value).toEqual(statsAction);
@@ -248,5 +264,808 @@ describe('solver', () => {
     // Third failure: failureCount 2 → 3 >= MAX_CONSECUTIVE_FAILURES → transitions to idle
     expect(solve.next(ActionResult.error(statsAction) as any).value).toEqual(escapeAction);
     expect(solve.next(ActionResult.ok(escapeAction as any) as any).value).toEqual(Action.noop);
+  });
+  it('seeStats opens the stats menu then sights', () => {
+    const solve = solver({ type: 'seeStats', phase: 'open', failureCount: 0 });
+    const stats = Action.clickByText('記録');
+
+    expect(solve.next().value).toEqual(stats);
+    expect(solve.next(ActionResult.ok(stats) as any).value).toEqual(Action.noop);
+  });
+
+  it('save exports save data then dismisses the dialog', () => {
+    const solve = solver({ type: 'save', phase: 'options', failureCount: 0 });
+    const options = Action.clickByText('オプション');
+    const exportSave = Action.clickByText('セーブをエクスポート');
+    const escape = { name: 'press', key: 'Escape' } as const;
+
+    expect(solve.next().value).toEqual(options);
+    expect(solve.next(ActionResult.ok(options) as any).value).toEqual(exportSave);
+    expect(solve.next(ActionResult.ok(exportSave) as any).value).toEqual(Action.noop);
+    expect(
+      solve.next({
+        name: 'idle',
+        url: 'https://orteil.dashnet.org/cookieclicker/',
+        selectedText: 'SAVE_DATA',
+      } as any).value,
+    ).toEqual(escape);
+  });
+
+  it('idle starts save after enough clicks', () => {
+    const idleState = {
+      name: 'idle' as const,
+      url: 'https://orteil.dashnet.org/cookieclicker/',
+      state: { clickableElementIds: ['bigCookie'] },
+    };
+    const click = Action.clickByElementId('bigCookie');
+    const solve = solver({ type: 'idle', phase: 'sight', count: 0 });
+
+    // Black-box safety bound only: if save never starts by then, treat as broken.
+    const maxClicks = 1_000_000;
+    let action: unknown = solve.next().value;
+
+    for (let i = 0; i < maxClicks; i++) {
+      expect(action).toEqual(Action.noop);
+      expect(solve.next(idleState as any).value).toEqual(click);
+      action = solve.next(ActionResult.ok(click) as any).value;
+
+      const a = action as { name?: string; target?: { text?: string } };
+      if (a?.name === 'click' && a.target?.text === 'オプション') {
+        return;
+      }
+    }
+    throw new Error(`did not enter save within ${maxClicks} clicks`);
+  });
+});
+
+
+function* testRunActions(
+  actions: readonly ActionType.Action[],
+): Generator<ActionType.Action, boolean, unknown> {
+  for (const action of actions) {
+    const result = yield action;
+    if ((result as { name?: string } | undefined)?.name === "closed") {
+      return false;
+    }
+    if (
+      action.name !== "noop" &&
+      (result as { name?: string })?.name === "result" &&
+      (result as { succeeded?: boolean })?.succeeded === false
+    ) {
+      yield { name: "press", key: "Escape" } as ActionType.Action;
+      return false;
+    }
+  }
+  return true;
+}
+
+function baseCtx(overrides: Partial<HandlerCtx> = {}): HandlerCtx {
+  return {
+    listeners: { onSave: [], isSilent: () => false },
+    getGameData: () => undefined,
+    setGameData: () => {},
+    getHasReloadedForShoten: () => false,
+    setHasReloadedForShoten: () => {},
+    runActions: testRunActions as HandlerCtx["runActions"],
+    ...overrides,
+  };
+}
+
+function drive(
+  gen: Generator<ActionType.Action, GameState, unknown>,
+  replies: unknown[],
+): { actions: ActionType.Action[]; state: GameState } {
+  const actions: ActionType.Action[] = [];
+  let step = gen.next();
+  let i = 0;
+  while (!step.done) {
+    actions.push(step.value);
+    step = gen.next(replies[i++]);
+  }
+  return { actions, state: step.value };
+}
+
+describe("handleSeeStats", () => {
+  it("opens stats, sights, then returns idle", () => {
+    const gen = handleSeeStats({ type: "seeStats", phase: "open", failureCount: 0 }, baseCtx());
+    const { actions, state } = drive(gen, [
+      ActionResult.ok(Action.clickByText("記録")),
+      ActionResult.ok(Action.noop),
+    ]);
+    expect(actions[0]).toEqual(Action.clickByText("記録"));
+    expect(actions[1]).toEqual(Action.noop);
+    expect(state).toEqual({ type: "idle", phase: "sight", count: 0 });
+  });
+
+  it("bumps failureCount when 記録 fails", () => {
+    const gen = handleSeeStats({ type: "seeStats", phase: "open", failureCount: 0 }, baseCtx());
+    const { actions, state } = drive(gen, [
+      ActionResult.error(Action.clickByText("記録")),
+      ActionResult.ok({ name: "press", key: "Escape" } as any),
+    ]);
+    expect(actions[0]).toEqual(Action.clickByText("記録"));
+    expect(actions[1]).toEqual({ name: "press", key: "Escape" });
+    expect(state).toEqual({ type: "seeStats", phase: "open", failureCount: 1 });
+  });
+});
+
+describe("handleSave", () => {
+  it("exports save, notifies onSave, then enters seeStats", () => {
+    const saved: string[] = [];
+    const ctx = baseCtx({
+      listeners: {
+        onSave: [(t) => saved.push(t)],
+        isSilent: () => false,
+      },
+      setGameData: () => {},
+    });
+    const gen = handleSave({ type: "save", phase: "options", failureCount: 0 }, ctx);
+    const options = Action.clickByText("オプション");
+    const exportSave = Action.clickByText("セーブをエクスポート");
+    const { actions, state } = drive(gen, [
+      ActionResult.ok(options),
+      ActionResult.ok(exportSave),
+      {
+        name: "idle",
+        url: "https://orteil.dashnet.org/cookieclicker/",
+        selectedText: "SAVE_BLOB",
+      },
+      ActionResult.ok({ name: "press", key: "Escape" } as any),
+    ]);
+    expect(actions[0]).toEqual(options);
+    expect(actions[1]).toEqual(exportSave);
+    expect(actions[2]).toEqual(Action.noop);
+    expect(actions[3]).toEqual({ name: "press", key: "Escape" });
+    expect(saved).toEqual(["SAVE_BLOB"]);
+    expect(state).toEqual({ type: "seeStats", phase: "open", failureCount: 0 });
+  });
+});
+
+describe('stepSeeStats', () => {
+  it('open with no event requests 記録', () => {
+    const out = stepSeeStats(States.seeStats(), undefined);
+    expect(out.action).toEqual(Action.clickByText('記録'));
+    expect(out.state).toMatchObject({ type: 'seeStats', phase: 'open' });
+  });
+
+  it('open success moves to sight with noop', () => {
+    const out = stepSeeStats(
+      States.seeStats(),
+      ActionResult.ok(Action.clickByText('記録')) as any,
+    );
+    expect(out.action).toEqual(Action.noop);
+    expect(out.state).toMatchObject({ type: 'seeStats', phase: 'sight' });
+  });
+
+  it('open failure moves to escape', () => {
+    const out = stepSeeStats(
+      States.seeStats(),
+      ActionResult.error(Action.clickByText('記録')) as any,
+    );
+    expect(out.action).toEqual({ name: 'press', key: 'Escape' });
+    expect(out.state).toMatchObject({ type: 'seeStats', phase: 'escape' });
+  });
+
+  it('sight after noop goes idle', () => {
+    const out = stepSeeStats(
+      { type: 'seeStats', phase: 'sight', failureCount: 0 },
+      ActionResult.ok(Action.noop) as any,
+    );
+    expect(out.state).toMatchObject({ type: 'idle' });
+  });
+
+  it('closed event closes', () => {
+    const out = stepSeeStats(States.seeStats(), { name: 'closed' } as any);
+    expect(out.state).toEqual({ type: 'closed' });
+  });
+});
+
+describe('stepSave', () => {
+  const ctx = {
+    listeners: { onSave: [] as Array<(t: string) => void>, isSilent: () => false },
+    setGameData: (_: string | undefined) => {},
+  };
+
+  it('options with no event requests オプション', () => {
+    const out = stepSave(States.save(), undefined, ctx);
+    expect(out.action).toEqual(Action.clickByText('オプション'));
+  });
+
+  it('options success moves to export', () => {
+    const out = stepSave(
+      States.save(),
+      ActionResult.ok(Action.clickByText('オプション')) as any,
+      ctx,
+    );
+    expect(out.action).toEqual(Action.clickByText('セーブをエクスポート'));
+    expect(out.state).toMatchObject({ phase: 'export' });
+  });
+
+  it('read with selectedText notifies onSave and escapes', () => {
+    const saved: string[] = [];
+    const out = stepSave(
+      { type: 'save', phase: 'read', failureCount: 0 },
+      {
+        name: 'idle',
+        url: 'https://orteil.dashnet.org/cookieclicker/',
+        selectedText: 'BLOB',
+      } as any,
+      {
+        listeners: { onSave: [(t) => saved.push(t)], isSilent: () => false },
+        setGameData: () => {},
+      },
+    );
+    expect(saved).toEqual(['BLOB']);
+    expect(out.action).toEqual({ name: 'press', key: 'Escape' });
+    expect(out.state).toMatchObject({ phase: 'escape' });
+  });
+
+  it('escape success goes to seeStats', () => {
+    const out = stepSave(
+      { type: 'save', phase: 'escape', failureCount: 0 },
+      ActionResult.ok({ name: 'press', key: 'Escape' } as any) as any,
+      ctx,
+    );
+    expect(out.state).toMatchObject({ type: 'seeStats' });
+  });
+});
+
+describe('stepIdle', () => {
+  function idleCtx(overrides: Partial<HandlerCtx> = {}): HandlerCtx {
+    return {
+      listeners: { onSave: [], isSilent: () => false },
+      getGameData: () => undefined,
+      setGameData: () => {},
+      getHasReloadedForShoten: () => false,
+      setHasReloadedForShoten: () => {},
+      runActions: function* () { return true; } as any,
+      ...overrides,
+    };
+  }
+
+  it('sight with no event requests noop', () => {
+    const out = stepIdle(States.idle(), undefined, idleCtx());
+    expect(out.action).toEqual(Action.noop);
+  });
+
+  it('sight on foreign origin re-initializes', () => {
+    const out = stepIdle(
+      States.idle(),
+      { name: 'idle', url: 'https://example.com/' } as any,
+      idleCtx({ getGameData: () => 'X' }),
+    );
+    expect(out.state).toMatchObject({ type: 'initialize', data: 'X' });
+  });
+
+  it('click success below threshold stays idle', () => {
+    const out = stepIdle(
+      { type: 'idle', phase: 'click', count: 0 },
+      ActionResult.ok(Action.clickByElementId('bigCookie')) as any,
+      idleCtx(),
+    );
+    expect(out.state).toMatchObject({ type: 'idle', count: 1 });
+  });
+
+  it('click success at threshold enters save', () => {
+    const out = stepIdle(
+      { type: 'idle', phase: 'click', count: IDLE_CLICKS_BEFORE_SAVE },
+      ActionResult.ok(Action.clickByElementId('bigCookie')) as any,
+      idleCtx(),
+    );
+    expect(out.state).toMatchObject({ type: 'save' });
+  });
+});
+
+describe('stepInitialize', () => {
+  it('open with no event opens the game', () => {
+    const out = stepInitialize(States.initialize(), undefined);
+    expect(out.action).toHaveProperty('name', 'open');
+  });
+
+  it('open success moves to lang', () => {
+    const out = stepInitialize(
+      States.initialize(),
+      ActionResult.ok(Action.open('https://orteil.dashnet.org/cookieclicker/')) as any,
+    );
+    expect(out.state).toMatchObject({ type: 'initialize', phase: 'lang' });
+  });
+
+  it('dontShow without data finishes to seeStats', () => {
+    const out = stepInitialize(
+      { type: 'initialize', phase: 'dontShow' },
+      ActionResult.ok(Action.clickByText('次回から表示しない')) as any,
+    );
+    expect(out.state).toMatchObject({ type: 'seeStats' });
+  });
+
+  it('dontShow with data moves to importKey', () => {
+    const out = stepInitialize(
+      { type: 'initialize', phase: 'dontShow', data: 'SAVE' },
+      ActionResult.ok(Action.clickByText('次回から表示しない')) as any,
+    );
+    expect(out.state).toMatchObject({ phase: 'importKey' });
+  });
+});
+
+describe('step* remaining branches', () => {
+  const saveCtx = {
+    listeners: { onSave: [] as Array<(t: string) => void>, isSilent: () => false },
+    setGameData: (_: string | undefined) => {},
+  };
+
+  function idleCtx(overrides: Partial<HandlerCtx> = {}): HandlerCtx {
+    return {
+      listeners: { onSave: [], isSilent: () => false },
+      getGameData: () => undefined,
+      setGameData: () => {},
+      getHasReloadedForShoten: () => false,
+      setHasReloadedForShoten: () => {},
+      runActions: function* () { return true; } as any,
+      ...overrides,
+    };
+  }
+
+  it('stepSeeStats escape after fail bumps failureCount', () => {
+    const out = stepSeeStats(
+      { type: 'seeStats', phase: 'escape', failureCount: 0 },
+      ActionResult.ok({ name: 'press', key: 'Escape' } as any) as any,
+    );
+    expect(out.state).toMatchObject({ type: 'seeStats', phase: 'open', failureCount: 1 });
+  });
+
+  it('stepSave options failure moves to failEscape', () => {
+    const out = stepSave(
+      States.save(),
+      ActionResult.error(Action.clickByText('オプション')) as any,
+      saveCtx,
+    );
+    expect(out.state).toMatchObject({ phase: 'failEscape' });
+    expect(out.action).toEqual({ name: 'press', key: 'Escape' });
+  });
+
+  it('stepSave failEscape bumps failureCount', () => {
+    const out = stepSave(
+      { type: 'save', phase: 'failEscape', failureCount: 0 },
+      ActionResult.ok({ name: 'press', key: 'Escape' } as any) as any,
+      saveCtx,
+    );
+    expect(out.state).toMatchObject({ type: 'save', phase: 'options', failureCount: 1 });
+  });
+
+  it('stepSave export success moves to read', () => {
+    const out = stepSave(
+      { type: 'save', phase: 'export', failureCount: 0 },
+      ActionResult.ok(Action.clickByText('セーブをエクスポート')) as any,
+      saveCtx,
+    );
+    expect(out.state).toMatchObject({ phase: 'read' });
+    expect(out.action).toEqual(Action.noop);
+  });
+
+  it('stepIdle silent ascending re-initializes', () => {
+    let marked = false;
+    const out = stepIdle(
+      States.idle(),
+      {
+        name: 'idle',
+        url: 'https://orteil.dashnet.org/cookieclicker/',
+        state: { title: '昇天中', clickableElementIds: ['bigCookie'] },
+      } as any,
+      idleCtx({
+        listeners: { onSave: [], isSilent: () => true },
+        getHasReloadedForShoten: () => false,
+        setHasReloadedForShoten: () => { marked = true; },
+      }),
+    );
+    expect(marked).toBeTrue();
+    expect(out.state).toMatchObject({ type: 'initialize' });
+  });
+
+  it('stepIdle click failure moves to failEscape', () => {
+    const out = stepIdle(
+      { type: 'idle', phase: 'click', count: 3 },
+      ActionResult.error(Action.clickByElementId('bigCookie')) as any,
+      idleCtx(),
+    );
+    expect(out.state).toMatchObject({ phase: 'failEscape' });
+    expect(out.action).toEqual({ name: 'press', key: 'Escape' });
+  });
+
+  it('stepIdle failEscape returns to sight', () => {
+    const out = stepIdle(
+      { type: 'idle', phase: 'failEscape', count: 3 },
+      ActionResult.ok({ name: 'press', key: 'Escape' } as any) as any,
+      idleCtx(),
+    );
+    expect(out.state).toMatchObject({ type: 'idle', phase: 'sight', count: 3 });
+  });
+
+  it('stepInitialize lang advances to gotIt', () => {
+    const out = stepInitialize(
+      { type: 'initialize', phase: 'lang' },
+      ActionResult.ok(Action.clickByText('日本語')) as any,
+    );
+    expect(out.state).toMatchObject({ phase: 'gotIt' });
+  });
+
+  it('stepInitialize importKey starts fill path', () => {
+    const out = stepInitialize(
+      { type: 'initialize', phase: 'importKey', data: 'SAVE' },
+      undefined,
+    );
+    expect(out.action).toEqual({ name: 'press', key: 'Control+O' });
+  });
+
+  it('stepInitialize importEnter success goes to seeStats', () => {
+    const out = stepInitialize(
+      { type: 'initialize', phase: 'importEnter', data: 'SAVE' },
+      ActionResult.ok({ name: 'press', key: 'Enter' } as any) as any,
+    );
+    expect(out.state).toMatchObject({ type: 'seeStats' });
+  });
+
+  it('hydrate fills default phases', () => {
+    
+    expect(hydrate({ type: 'initialize' } as any)).toMatchObject({ phase: 'open' });
+    expect(hydrate({ type: 'idle', count: 2 })).toMatchObject({ phase: 'sight', count: 2 });
+    expect(hydrate({ type: 'save', failureCount: 1 })).toMatchObject({ phase: 'options' });
+    expect(hydrate({ type: 'seeStats', failureCount: 0 })).toMatchObject({ phase: 'open' });
+    expect(hydrate({ type: 'closed' })).toEqual({ type: 'closed' });
+  });
+});
+
+describe('States factories and thin handles', () => {
+  it('States helpers return hydrated shapes', () => {
+    expect(States.initialize('D')).toMatchObject({ type: 'initialize', phase: 'open', data: 'D' });
+    expect(States.idle(5)).toMatchObject({ type: 'idle', phase: 'sight', count: 5 });
+    expect(States.save(2)).toMatchObject({ type: 'save', phase: 'options', failureCount: 2 });
+    expect(States.seeStats(1)).toMatchObject({ type: 'seeStats', phase: 'open', failureCount: 1 });
+    expect(States.closed()).toEqual({ type: 'closed' });
+  });
+
+  it('handleClosed returns closed', () => {
+    const gen = handleClosed({ type: 'closed' }, {
+      listeners: { onSave: [], isSilent: () => false },
+      getGameData: () => undefined,
+      setGameData: () => {},
+      getHasReloadedForShoten: () => false,
+      setHasReloadedForShoten: () => {},
+      runActions: function* () { return true; } as any,
+    });
+    const step = gen.next();
+    expect(step.done).toBeTrue();
+    expect(step.value).toEqual({ type: 'closed' });
+  });
+
+
+  it('handleIdle one successful click stays idle', () => {
+    const ctx = {
+      listeners: { onSave: [], isSilent: () => false },
+      getGameData: () => undefined,
+      setGameData: () => {},
+      getHasReloadedForShoten: () => false,
+      setHasReloadedForShoten: () => {},
+      runActions: function* () { return true; } as any,
+    };
+    const gen = handleIdle(States.idle(0), ctx as any);
+    let s = gen.next();
+    expect(s.value).toEqual(Action.noop);
+    s = gen.next({
+      name: 'idle',
+      url: 'https://orteil.dashnet.org/cookieclicker/',
+      state: { clickableElementIds: ['bigCookie'] },
+    } as any);
+    // click action
+    expect(s.done).toBeFalse();
+    s = gen.next(ActionResult.ok(s.value as any) as any);
+    expect(s.done).toBeTrue();
+    expect(s.value).toMatchObject({ type: 'idle', count: 1 });
+  });
+  it('handleInitialize reaches seeStats on happy path', () => {
+    const gen = handleInitialize(States.initialize(), {
+      listeners: { onSave: [], isSilent: () => false },
+      getGameData: () => undefined,
+      setGameData: () => {},
+      getHasReloadedForShoten: () => false,
+      setHasReloadedForShoten: () => {},
+      runActions: function* () { return true; } as any,
+    });
+    // open
+    let s = gen.next();
+    expect(s.value).toHaveProperty('name', 'open');
+    s = gen.next(ActionResult.ok(s.value as any) as any);
+    // lang, gotIt, dontShow
+    for (const _ of [0, 1, 2]) {
+      if (s.done) break;
+      s = gen.next(ActionResult.ok(s.value as any) as any);
+    }
+    // may still be yielding dialogs — drain until done
+    let guard = 0;
+    while (!s.done && guard++ < 20) {
+      s = gen.next(ActionResult.ok(s.value as any) as any);
+    }
+    expect(s.done).toBeTrue();
+    expect(s.value).toMatchObject({ type: 'seeStats' });
+  });
+});
+
+describe('failure ceiling and runActions edges', () => {
+  it('bumpFailureCount reaches idle after enough seeStats failures', () => {
+    // failureCount 2 + 1 → idle (MAX_CONSECUTIVE_FAILURES = 3)
+    const out = stepSeeStats(
+      { type: 'seeStats', phase: 'escape', failureCount: 2 },
+      ActionResult.ok({ name: 'press', key: 'Escape' } as any) as any,
+    );
+    expect(out.state).toMatchObject({ type: 'idle' });
+  });
+
+  it('bumpFailureCount reaches idle after enough save failures', () => {
+    const out = stepSave(
+      { type: 'save', phase: 'failEscape', failureCount: 2 },
+      ActionResult.ok({ name: 'press', key: 'Escape' } as any) as any,
+      {
+        listeners: { onSave: [], isSilent: () => false },
+        setGameData: () => {},
+      },
+    );
+    expect(out.state).toMatchObject({ type: 'idle' });
+  });
+
+  it('runActions warns on unexpected result then continues', () => {
+    const solve = solver(States.idle(0));
+    expect(solve.next().value).toEqual(Action.noop);
+    const click = solve.next({
+      name: 'idle',
+      url: 'https://orteil.dashnet.org/cookieclicker/',
+      state: { clickableElementIds: ['bigCookie'] },
+    } as any).value;
+    // non-result, non-closed reply to a click — hits unexpected branch inside runActions
+    const next = solve.next({ name: 'idle', url: 'https://orteil.dashnet.org/cookieclicker/' } as any);
+    expect(next.done === true || next.value != null).toBeTrue();
+  });
+});
+
+describe('obvious step* branches', () => {
+  const saveCtx = {
+    listeners: { onSave: [] as Array<(t: string) => void>, isSilent: () => false },
+    setGameData: (_: string | undefined) => {},
+  };
+
+  function idleCtx(overrides: Partial<HandlerCtx> = {}): HandlerCtx {
+    return {
+      listeners: { onSave: [], isSilent: () => false },
+      getGameData: () => undefined,
+      setGameData: () => {},
+      getHasReloadedForShoten: () => false,
+      setHasReloadedForShoten: () => {},
+      runActions: function* () { return true; } as any,
+      ...overrides,
+    };
+  }
+
+  it('stepInitialize closed event', () => {
+    expect(stepInitialize(States.initialize(), { name: 'closed' } as any).state)
+      .toEqual({ type: 'closed' });
+  });
+
+  it('stepSave closed event', () => {
+    expect(stepSave(States.save(), { name: 'closed' } as any, saveCtx).state)
+      .toEqual({ type: 'closed' });
+  });
+
+  it('stepInitialize open failure stays on open', () => {
+    const open = Action.open('https://orteil.dashnet.org/cookieclicker/');
+    const out = stepInitialize(States.initialize(), ActionResult.error(open) as any);
+    expect(out.state).toMatchObject({ type: 'initialize', phase: 'open' });
+    expect(out.action).toBeUndefined();
+  });
+
+  it('stepInitialize importEnter failure stays', () => {
+    const out = stepInitialize(
+      { type: 'initialize', phase: 'importEnter', data: 'SAVE' },
+      ActionResult.error({ name: 'press', key: 'Enter' } as any) as any,
+    );
+    expect(out.state).toMatchObject({ phase: 'importEnter' });
+  });
+
+  it('stepSave export with no event requests export click', () => {
+    const out = stepSave(
+      { type: 'save', phase: 'export', failureCount: 0 },
+      undefined,
+      saveCtx,
+    );
+    expect(out.action).toEqual(Action.clickByText('セーブをエクスポート'));
+  });
+
+  it('stepSave read with no event requests noop', () => {
+    const out = stepSave(
+      { type: 'save', phase: 'read', failureCount: 0 },
+      undefined,
+      saveCtx,
+    );
+    expect(out.action).toEqual(Action.noop);
+  });
+
+  it('stepSave escape with no event requests Escape', () => {
+    const out = stepSave(
+      { type: 'save', phase: 'escape', failureCount: 0 },
+      undefined,
+      saveCtx,
+    );
+    expect(out.action).toEqual({ name: 'press', key: 'Escape' });
+  });
+
+  it('stepSave escape failure calls afterFail', () => {
+    const out = stepSave(
+      { type: 'save', phase: 'escape', failureCount: 0 },
+      ActionResult.error({ name: 'press', key: 'Escape' } as any) as any,
+      saveCtx,
+    );
+    expect(out.state).toMatchObject({ type: 'save', phase: 'options', failureCount: 1 });
+  });
+
+  it('stepIdle click with no event clicks bigCookie', () => {
+    const out = stepIdle(
+      { type: 'idle', phase: 'click', count: 0 },
+      undefined,
+      idleCtx(),
+    );
+    expect(out.action).toEqual(Action.clickByElementId('bigCookie'));
+  });
+
+  it('stepSeeStats sight with no event requests noop', () => {
+    const out = stepSeeStats(
+      { type: 'seeStats', phase: 'sight', failureCount: 0 },
+      undefined,
+    );
+    expect(out.action).toEqual(Action.noop);
+  });
+
+  it('runActions closed on Escape after click failure', () => {
+    const solve = solver(States.idle(0));
+    expect(solve.next().value).toEqual(Action.noop);
+    const click = solve.next({
+      name: 'idle',
+      url: 'https://orteil.dashnet.org/cookieclicker/',
+      state: { clickableElementIds: ['bigCookie'] },
+    } as any).value;
+    expect(solve.next(ActionResult.error(click as any) as any).value)
+      .toEqual({ name: 'press', key: 'Escape' });
+    const done = solve.next({ name: 'closed' } as any);
+    expect(done.done).toBeTrue();
+  });
+});
+
+describe('runActions', () => {
+  it('returns true when all actions succeed', () => {
+    const action = Action.clickByText('x');
+    const gen = runActions([action]);
+    let s = gen.next();
+    expect(s.value).toEqual(action);
+    s = gen.next(ActionResult.ok(action) as any);
+    expect(s.done).toBeTrue();
+    expect(s.value).toBe(true);
+  });
+
+  it('returns false on closed and invokes onClosed', () => {
+    let closed = false;
+    const action = Action.clickByText('x');
+    const gen = runActions([action], () => { closed = true; });
+    gen.next();
+    const s = gen.next({ name: 'closed' } as any);
+    expect(s.done).toBeTrue();
+    expect(s.value).toBe(false);
+    expect(closed).toBeTrue();
+  });
+
+  it('yields Escape on failure then returns false', () => {
+    const action = Action.clickByText('x');
+    const gen = runActions([action]);
+    let s = gen.next();
+    s = gen.next(ActionResult.error(action) as any);
+    expect(s.value).toEqual({ name: 'press', key: 'Escape' });
+    s = gen.next(ActionResult.ok({ name: 'press', key: 'Escape' } as any) as any);
+    expect(s.done).toBeTrue();
+    expect(s.value).toBe(false);
+  });
+
+  it('onClosed when Escape is closed after failure', () => {
+    let closed = false;
+    const action = Action.clickByText('x');
+    const gen = runActions([action], () => { closed = true; });
+    gen.next();
+    let s = gen.next(ActionResult.error(action) as any);
+    expect(s.value).toEqual({ name: 'press', key: 'Escape' });
+    s = gen.next({ name: 'closed' } as any);
+    expect(s.value).toBe(false);
+    expect(closed).toBeTrue();
+  });
+
+  it('skips success check for noop', () => {
+    const gen = runActions([Action.noop]);
+    let s = gen.next();
+    expect(s.value).toEqual(Action.noop);
+    s = gen.next({ name: 'idle', url: 'https://example.com/' } as any);
+    expect(s.done).toBeTrue();
+    expect(s.value).toBe(true);
+  });
+});
+
+describe('step* invalid phase', () => {
+  const saveCtx = {
+    listeners: { onSave: [] as Array<(t: string) => void>, isSilent: () => false },
+    setGameData: (_: string | undefined) => {},
+  };
+
+  it('stepSeeStats throws on unknown phase', () => {
+    expect(() =>
+      stepSeeStats(
+        { type: 'seeStats', phase: 'nope' as any, failureCount: 0 },
+        undefined,
+      ),
+    ).toThrow();
+  });
+
+  it('stepSave throws on unknown phase', () => {
+    expect(() =>
+      stepSave(
+        { type: 'save', phase: 'nope' as any, failureCount: 0 },
+        undefined,
+        saveCtx,
+      ),
+    ).toThrow();
+  });
+});
+
+describe("remaining stepInitialize branches", () => {
+  it("importKey failure stays", () => {
+    const out = stepInitialize(
+      { type: "initialize", phase: "importKey", data: "SAVE" },
+      ActionResult.error({ name: "press", key: "Control+O" } as any) as any,
+    );
+    expect(out.state).toMatchObject({ phase: "importKey" });
+    expect(out.action).toBeUndefined();
+  });
+
+  it("importFill failure stays", () => {
+    const out = stepInitialize(
+      { type: "initialize", phase: "importFill", data: "SAVE" },
+      ActionResult.error({
+        name: "fill",
+        value: "SAVE",
+        on: { selector: "#game", role: "textbox" },
+      } as any) as any,
+    );
+    expect(out.state).toMatchObject({ phase: "importFill" });
+    expect(out.action).toBeUndefined();
+  });
+});
+describe("handleInitialize terminal open failure", () => {
+  it("stops when open fails", () => {
+    const gen = handleInitialize(States.initialize(), {
+      listeners: { onSave: [], isSilent: () => false },
+      getGameData: () => undefined,
+      setGameData: () => {},
+      getHasReloadedForShoten: () => false,
+      setHasReloadedForShoten: () => {},
+      runActions: function* () { return true; } as any,
+    } as any);
+    let s = gen.next();
+    expect(s.value).toHaveProperty("name", "open");
+    s = gen.next(ActionResult.error(s.value as any) as any);
+    expect(s.done).toBeTrue();
+    expect(s.value).toMatchObject({ type: "initialize", phase: "open" });
+  });
+});
+describe("runActions unexpected result branch", () => {
+  it("warns on unexpected non-result reply", () => {
+    const action = Action.clickByText("x");
+    const gen = runActions([action]);
+    let s = gen.next();
+    expect(s.value).toEqual(action);
+    // not result / not closed — hits console.warn branch then continues
+    s = gen.next({ name: "idle", url: "https://example.com/" } as any);
+    expect(s.done).toBeTrue();
+    expect(s.value).toBe(true);
   });
 });

--- a/lib/Agent/games/org.dashnet.orteil/cookieclicker/solver.ts
+++ b/lib/Agent/games/org.dashnet.orteil/cookieclicker/solver.ts
@@ -4,21 +4,23 @@
 // the strategy logic here is unique to the AI agent's behaviour.
 import { Action, type State } from "automated-gameplay-transmitter";
 
-type GameState =
-  | undefined
+export type GameState =
   | {
     type: 'initialize'
+    phase?: 'open' | 'lang' | 'gotIt' | 'dontShow' | 'importKey' | 'importFill' | 'importEnter'
     data?: string
   }
   | {
     type: 'idle'
+    phase?: 'sight' | 'click' | 'failEscape'
     count: number
   }
   | {
     type: 'seeStats'
+    phase?: 'open' | 'sight' | 'escape'
     failureCount: number
   }
-  | { type: 'save'; failureCount: number }
+  | { type: 'save'; phase?: 'options' | 'export' | 'read' | 'escape' | 'failEscape'; failureCount: number }
   | { type: 'closed' };
 
 type SolverEventListeners = {
@@ -28,197 +30,608 @@ type SolverEventListeners = {
 
 const MAX_CONSECUTIVE_FAILURES = 3;
 
+/** Clicks in idle before entering save. */
+
+/** Public entry: callers (app / tests) need not know phase. */
+export type SolverStart =
+  | { type: 'initialize'; data?: string }
+  | { type: 'closed' };
+
+/** Factories for legal running states (phase filled in). Prefer these over raw literals. */
+export const States = {
+  initialize: (data?: string): Extract<GameState, { type: 'initialize' }> => ({
+    type: 'initialize',
+    phase: 'open',
+    data,
+  }),
+  idle: (count = 0): Extract<GameState, { type: 'idle' }> => ({
+    type: 'idle',
+    phase: 'sight',
+    count,
+  }),
+  save: (failureCount = 0): Extract<GameState, { type: 'save' }> => ({
+    type: 'save',
+    phase: 'options',
+    failureCount,
+  }),
+  seeStats: (failureCount = 0): Extract<GameState, { type: 'seeStats' }> => ({
+    type: 'seeStats',
+    phase: 'open',
+    failureCount,
+  }),
+  closed: (): Extract<GameState, { type: 'closed' }> => ({ type: 'closed' }),
+};
+
+/** Fill default phases so external callers can omit them. */
+export function hydrate(state: GameState | SolverStart): GameState {
+  switch (state.type) {
+    case 'initialize':
+      return {
+        type: 'initialize',
+        phase: 'phase' in state && state.phase ? state.phase : 'open',
+        data: state.data,
+      };
+    case 'idle':
+      return {
+        type: 'idle',
+        phase: 'phase' in state && state.phase ? state.phase : 'sight',
+        count: 'count' in state ? state.count : 0,
+      };
+    case 'save':
+      return {
+        type: 'save',
+        phase: 'phase' in state && state.phase ? state.phase : 'options',
+        failureCount: 'failureCount' in state ? state.failureCount : 0,
+      };
+    case 'seeStats':
+      return {
+        type: 'seeStats',
+        phase: 'phase' in state && state.phase ? state.phase : 'open',
+        failureCount: 'failureCount' in state ? state.failureCount : 0,
+      };
+    case 'closed':
+      return { type: 'closed' };
+  }
+}
+export const IDLE_CLICKS_BEFORE_SAVE = 1_000;
+
+/** After boot, open Stats so stream UI can show generation / clicks. */
+export function stateAfterInitialize(): GameState {
+  return { type: 'seeStats', phase: 'open', failureCount: 0 };
+}
+
+/** After a successful idle click. */
+export function stateAfterIdleClick(count: number): GameState {
+  if (count >= IDLE_CLICKS_BEFORE_SAVE) {
+    return { type: 'save', phase: 'options', failureCount: 0 };
+  }
+  return { type: 'idle', phase: 'sight', count: count + 1 };
+}
+
+/** After save sequence succeeds. */
+export function stateAfterSaveSuccess(): GameState {
+  return { type: 'seeStats', phase: 'open', failureCount: 0 };
+}
+
+/** After seeStats sequence succeeds. */
+export function stateAfterSeeStatsSuccess(): GameState {
+  return { type: 'idle', phase: 'sight', count: 0 };
+}
+
 /**
  * Increments the `failureCount` of the given state by one.
  * If the updated count reaches {@link MAX_CONSECUTIVE_FAILURES}, returns an `idle` state instead.
  */
-function bumpFailureCount<T extends { failureCount: number }>(state: T): T | { type: 'idle'; count: number } {
+function bumpFailureCount<T extends { failureCount: number }>(state: T): T | { type: 'idle'; phase: 'sight'; count: number } {
   const next = { ...state, failureCount: state.failureCount + 1 };
   if (next.failureCount >= MAX_CONSECUTIVE_FAILURES) {
-    return { type: 'idle', count: 0 };
+    return { type: 'idle', phase: 'sight', count: 0 };
   }
   return next;
 }
 
-export function* solver(state: GameState = { type: 'initialize' }, eventListeners: Partial<SolverEventListeners> = {}): Generator<Action.Action, undefined, State> {
+type RunActions = (actions: readonly Action.Action[]) => Generator<Action.Action, boolean, State>;
+
+export type HandlerCtx = {
+  listeners: SolverEventListeners
+  getGameData: () => string | undefined
+  setGameData: (data: string | undefined) => void
+  getHasReloadedForShoten: () => boolean
+  setHasReloadedForShoten: (v: boolean) => void
+  runActions: RunActions
+  /** runActions が closed を検知したときに参照する（既存挙動維持） */
+};
+
+
+export function stepInitialize(
+  state: Extract<GameState, { type: 'initialize' }>,
+  event: State | undefined,
+): { state: GameState; action?: Action.Action } {
+  if (event?.name === 'closed') {
+    return { state: { type: 'closed' } };
+  }
+
+  const phase = state.phase ?? 'open';
+  switch (phase) {
+    case 'open': {
+      if (event === undefined) {
+        return {
+          state,
+          action: Action.open('https://orteil.dashnet.org/cookieclicker/'),
+        };
+      }
+      // open failed or succeeded — continue to optional dialogs (same as before for optional path)
+      if (event.name === 'result' && event.succeeded === false) {
+        // open is required in old runActions — stay or still continue?
+        // Old: runActions false → return state or closed. Treat fail as stop at initialize open.
+        return { state: { ...state, phase: 'open' } };
+      }
+      return { state: { ...state, phase: 'lang' } };
+    }
+    case 'lang': {
+      if (event === undefined) {
+        return { state, action: Action.clickByText('日本語') };
+      }
+      // optional: always advance
+      return { state: { ...state, phase: 'gotIt' } };
+    }
+    case 'gotIt': {
+      if (event === undefined) {
+        return { state, action: Action.clickByText('Got it') };
+      }
+      return { state: { ...state, phase: 'dontShow' } };
+    }
+    case 'dontShow': {
+      if (event === undefined) {
+        return { state, action: Action.clickByText('次回から表示しない') };
+      }
+      if (state.data) {
+        return { state: { ...state, phase: 'importKey' } };
+      }
+      return { state: stateAfterInitialize() };
+    }
+    case 'importKey': {
+      if (event === undefined) {
+        return { state, action: { name: 'press', key: 'Control+O' } };
+      }
+      if (event.name === 'result' && event.succeeded === false) {
+        return { state };
+      }
+      return { state: { ...state, phase: 'importFill' } };
+    }
+    case 'importFill': {
+      if (event === undefined) {
+        return {
+          state,
+          action: {
+            name: 'fill',
+            value: state.data ?? '',
+            on: { selector: '#game', role: 'textbox' },
+          },
+        };
+      }
+      if (event.name === 'result' && event.succeeded === false) {
+        return { state };
+      }
+      return { state: { ...state, phase: 'importEnter' } };
+    }
+    case 'importEnter': {
+      if (event === undefined) {
+        return { state, action: { name: 'press', key: 'Enter' } };
+      }
+      if (event.name === 'result' && event.succeeded === false) {
+        return { state };
+      }
+      return { state: stateAfterInitialize() };
+    }
+  }
+}
+
+export function* handleInitialize(
+  state: Extract<GameState, { type: 'initialize' }>,
+  _ctx: HandlerCtx,
+): Generator<Action.Action, GameState, State> {
+  let s: Extract<GameState, { type: 'initialize' }> = {
+    type: 'initialize',
+    phase: state.phase ?? 'open',
+    data: state.data,
+  };
+  let event: State | undefined;
+
+  for (;;) {
+    const prevPhase = s.phase;
+    const out = stepInitialize(s, event);
+    if (out.state.type !== 'initialize') {
+      return out.state;
+    }
+    s = out.state;
+    if (!out.action) {
+      // Phase-only transition: keep going. Same phase after an event: stop.
+      if (event !== undefined && s.phase === prevPhase) {
+        return s;
+      }
+      event = undefined;
+      continue;
+    }
+    event = yield out.action;
+  }
+}
+
+
+export function stepIdle(
+  state: Extract<GameState, { type: 'idle' }>,
+  event: State | undefined,
+  ctx: HandlerCtx,
+): { state: GameState; action?: Action.Action } {
+  if (event?.name === 'closed') {
+    return { state: { type: 'closed' } };
+  }
+
+  const phase = state.phase ?? 'sight';
+  switch (phase) {
+    case 'sight': {
+      if (event === undefined) {
+        return { state, action: Action.noop };
+      }
+
+      if (event.name === 'idle' && !event.url.startsWith('https://orteil.dashnet.org/cookieclicker/')) {
+        return { state: { type: 'initialize', phase: 'open', data: ctx.getGameData() } };
+      }
+
+      const sightData = event.name === 'idle' ? event.state : undefined;
+
+      if (!ctx.listeners.isSilent()) {
+        ctx.setHasReloadedForShoten(false);
+      } else if (
+        (sightData as { title?: string } | undefined)?.title?.includes('昇天中') &&
+        !ctx.getHasReloadedForShoten()
+      ) {
+        ctx.setHasReloadedForShoten(true);
+        return { state: { type: 'initialize', phase: 'open', data: ctx.getGameData() } };
+      }
+
+      const clickableElementIds = Array.isArray(
+        (sightData as { clickableElementIds?: string[] } | undefined)?.clickableElementIds,
+      )
+        ? (sightData as { clickableElementIds: string[] }).clickableElementIds
+        : ['bigCookie'];
+      const candidateIds = ctx.listeners.isSilent()
+        ? ['bigCookie']
+        : clickableElementIds.length > 0
+          ? clickableElementIds
+          : ['bigCookie'];
+      const targetId = candidateIds[Math.floor(Math.random() * candidateIds.length)]!;
+
+      return {
+        state: { type: 'idle', phase: 'click', count: state.count },
+        action: Action.clickByElementId(targetId),
+      };
+    }
+    case 'click': {
+      if (event === undefined) {
+        return { state, action: Action.clickByElementId('bigCookie') };
+      }
+      if (event.name === 'result' && event.succeeded === false) {
+        return {
+          state: { type: 'idle', phase: 'failEscape', count: state.count },
+          action: { name: 'press', key: 'Escape' },
+        };
+      }
+      return { state: stateAfterIdleClick(state.count) };
+    }
+    case 'failEscape': {
+      return { state: { type: 'idle', phase: 'sight', count: state.count } };
+    }
+  }
+}
+
+export function* handleIdle(
+  state: Extract<GameState, { type: 'idle' }>,
+  ctx: HandlerCtx,
+): Generator<Action.Action, GameState, State> {
+  let s: Extract<GameState, { type: 'idle' }> = {
+    type: 'idle',
+    phase: state.phase ?? 'sight',
+    count: state.count,
+  };
+  let event: State | undefined;
+
+  for (;;) {
+    const out = stepIdle(s, event, ctx);
+    if (out.state.type !== 'idle') {
+      return out.state;
+    }
+    s = out.state;
+    if (!out.action) {
+      return out.state;
+    }
+    event = yield out.action;
+  }
+}
+
+
+export function stepSave(
+  state: Extract<GameState, { type: 'save' }>,
+  event: State | undefined,
+  ctx: Pick<HandlerCtx, 'listeners' | 'setGameData'>,
+): { state: GameState; action?: Action.Action } {
+  if (event?.name === 'closed') {
+    return { state: { type: 'closed' } };
+  }
+
+  const afterFail = (): GameState => {
+    const next = bumpFailureCount({
+      type: 'save' as const,
+      phase: 'options' as const,
+      failureCount: state.failureCount,
+    });
+    if ((next as GameState).type === 'idle') {
+      return { type: 'idle', phase: 'sight', count: 0 };
+    }
+    return {
+      type: 'save',
+      phase: 'options',
+      failureCount: (next as { failureCount: number }).failureCount,
+    };
+  };
+
+  const phase = state.phase ?? 'options';
+  switch (phase) {
+    case 'options': {
+      if (event === undefined) {
+        return { state, action: Action.clickByText('オプション') };
+      }
+      if (event.name === 'result' && event.succeeded === false) {
+        return {
+          state: { ...state, phase: 'failEscape' },
+          action: { name: 'press', key: 'Escape' },
+        };
+      }
+      return {
+        state: { ...state, phase: 'export' },
+        action: Action.clickByText('セーブをエクスポート'),
+      };
+    }
+    case 'export': {
+      if (event === undefined) {
+        return { state, action: Action.clickByText('セーブをエクスポート') };
+      }
+      if (event.name === 'result' && event.succeeded === false) {
+        return {
+          state: { ...state, phase: 'failEscape' },
+          action: { name: 'press', key: 'Escape' },
+        };
+      }
+      return {
+        state: { ...state, phase: 'read' },
+        action: Action.noop,
+      };
+    }
+    case 'read': {
+      if (event === undefined) {
+        return { state, action: Action.noop };
+      }
+      if (event.name === 'idle' && event.selectedText) {
+        const text = event.selectedText ?? '';
+        ctx.setGameData(text);
+        ctx.listeners.onSave.forEach((f) => f(text));
+      }
+      return {
+        state: { ...state, phase: 'escape' },
+        action: { name: 'press', key: 'Escape' },
+      };
+    }
+    case 'escape': {
+      if (event === undefined) {
+        return { state, action: { name: 'press', key: 'Escape' } };
+      }
+      if (event.name === 'result' && event.succeeded === false) {
+        return { state: afterFail() };
+      }
+      return { state: stateAfterSaveSuccess() };
+    }
+    case 'failEscape': {
+      return { state: afterFail() };
+    }
+    default: {
+      
+      throw new Error(`unexpected save phase: ${String(phase)}`);
+    }
+  }
+}
+
+export function* handleSave(
+  state: Extract<GameState, { type: 'save' }>,
+  ctx: HandlerCtx,
+): Generator<Action.Action, GameState, State> {
+  let s: Extract<GameState, { type: 'save' }> = {
+    type: 'save',
+    phase: state.phase ?? 'options',
+    failureCount: state.failureCount,
+  };
+  let event: State | undefined;
+
+  for (;;) {
+    const out = stepSave(s, event, ctx);
+    if (out.state.type !== 'save') {
+      return out.state;
+    }
+    s = out.state;
+    if (!out.action) {
+      return out.state;
+    }
+    event = yield out.action;
+  }
+}
+
+export function stepSeeStats(
+  state: Extract<GameState, { type: 'seeStats' }>,
+  event: State | undefined,
+): { state: GameState; action?: Action.Action } {
+  if (event?.name === 'closed') {
+    return { state: { type: 'closed' } };
+  }
+
+  const phase = state.phase ?? 'options';
+  switch (phase) {
+    case 'open': {
+      if (event === undefined) {
+        return { state, action: Action.clickByText('記録') };
+      }
+      if (event.name === 'result' && event.succeeded === false) {
+        return {
+          state: { ...state, phase: 'escape' },
+          action: { name: 'press', key: 'Escape' },
+        };
+      }
+      return {
+        state: { ...state, phase: 'sight' },
+        action: Action.noop,
+      };
+    }
+    case 'escape': {
+      const next = bumpFailureCount({
+        type: 'seeStats' as const,
+        phase: 'open' as const,
+        failureCount: state.failureCount,
+      });
+      if ((next as GameState).type === 'idle') {
+        return { state: { type: 'idle', phase: 'sight', count: 0 } };
+      }
+      return {
+        state: {
+          type: 'seeStats',
+          phase: 'open',
+          failureCount: (next as { failureCount: number }).failureCount,
+        },
+      };
+    }
+    case 'sight': {
+      if (event === undefined) {
+        return { state, action: Action.noop };
+      }
+      return { state: stateAfterSeeStatsSuccess() };
+    }
+    default: {
+      
+      throw new Error(`unexpected seeStats phase: ${String(phase)}`);
+    }
+  }
+}
+
+export function* handleSeeStats(
+  state: Extract<GameState, { type: 'seeStats' }>,
+  _ctx: HandlerCtx,
+): Generator<Action.Action, GameState, State> {
+  let s: Extract<GameState, { type: 'seeStats' }> = {
+    type: 'seeStats',
+    phase: state.phase ?? 'open',
+    failureCount: state.failureCount,
+  };
+  let event: State | undefined;
+
+  for (;;) {
+    const out = stepSeeStats(s, event);
+    if (out.state.type !== 'seeStats') {
+      return out.state;
+    }
+    s = out.state;
+    // No action means this handle turn is finished (e.g. after failure recovery).
+    if (!out.action) {
+      return out.state;
+    }
+    event = yield out.action;
+  }
+}
+
+export function* handleClosed(
+  state: Extract<GameState, { type: 'closed' }>,
+  _ctx: HandlerCtx,
+): Generator<Action.Action, GameState, State> {
+  return state;
+}
+
+/**
+ * state.type → その state の runner。
+ * GameState に type を足したら、ここにキーを足すまで型エラー。
+ */
+const machine = {
+  initialize: { run: handleInitialize },
+  idle: { run: handleIdle },
+  save: { run: handleSave },
+  seeStats: { run: handleSeeStats },
+  closed: { run: handleClosed },
+} as const satisfies {
+  [K in GameState['type']]: {
+    run: (
+      state: Extract<GameState, { type: K }>,
+      ctx: HandlerCtx,
+    ) => Generator<Action.Action, GameState, State>
+  }
+};
+
+
+/**
+ * Shared action runner (module-level so coverage and tests can target it directly).
+ * @returns true if all actions succeeded, false on failure or closed.
+ */
+export function* runActions(
+  actions: readonly Action.Action[],
+  onClosed: () => void = () => {},
+): Generator<Action.Action, boolean, State> {
+  for (const action of actions) {
+    const result = yield action;
+    if (result.name === 'closed') {
+      onClosed();
+      return false;
+    }
+    if (action.name !== 'noop') {
+      if (result.name === 'result') {
+        if (!result.succeeded) {
+          console.error(`failed to`, result.action);
+          const escapeKeyPressResult = yield { name: 'press', key: 'Escape' } as const;
+          if (escapeKeyPressResult.name === 'closed') {
+            onClosed();
+          }
+          return false;
+        }
+      } else {
+        console.warn('unexpected result', result);
+      }
+    }
+  }
+  return true;
+}
+export function* solver(
+  state: GameState | SolverStart = { type: 'initialize' },
+  eventListeners: Partial<SolverEventListeners> = {},
+): Generator<Action.Action, undefined, State> {
   const listeners: SolverEventListeners = {
     onSave: [],
     isSilent: () => false,
     ...eventListeners,
   };
 
+  state = hydrate(state);
   let hasReloadedForShoten = false;
-  let gameData: string | undefined = state?.type === 'initialize' ? state.data : undefined;
+  let gameData: string | undefined = state.type === 'initialize' ? state.data : undefined;
+  let closed = false;
 
-  function* runActions(actions: readonly Action.Action[]): Generator<Action.Action, boolean, State> {
-    for (const action of actions) {
-      const result = yield action;
-      if (result.name === 'closed') {
-        state = { type: 'closed' };
-        return false;
-      }
-      if (action.name !== 'noop') {
-        if (result.name === 'result') {
-          if (!result.succeeded) {
-            console.error(`failed to`, result.action);
-            const escapeKeyPressResult = yield { name: 'press', key: 'Escape' } as const;
-            if (escapeKeyPressResult.name === 'closed') {
-              state = { type: 'closed' };
-            }
-            return false;
-          }
-        } else {
-          console.warn('unexpected result', result);
-        }
-      }
-    }
-    return true;
+  function* runActionsBound(actions: readonly Action.Action[]): Generator<Action.Action, boolean, State> {
+    return yield* runActions(actions, () => { closed = true; });
   }
 
+  const ctx: HandlerCtx = {
+    listeners,
+    getGameData: () => gameData,
+    setGameData: (data) => { gameData = data; },
+    getHasReloadedForShoten: () => hasReloadedForShoten,
+    setHasReloadedForShoten: (v) => { hasReloadedForShoten = v; },
+    runActions: runActionsBound,
+  };
+
   while (state.type !== 'closed') {
-    switch (state.type) {
-      case 'initialize': {
-        if (!(yield* runActions([Action.open('https://orteil.dashnet.org/cookieclicker/')]))) break;
-
-        // These dialogs may not always appear (e.g. when already set or dismissed).
-        // Treat each as optional: continue initialization even if a step fails.
-        for (const action of [
-          Action.clickByText('日本語'),
-          Action.clickByText('Got it'),
-          Action.clickByText('次回から表示しない'),
-        ]) {
-          const result = yield action;
-          if (result.name === 'closed') {
-            state = { type: 'closed' };
-            break;
-          }
-        }
-
-        if (state.type === 'closed') break;
-
-        if (state.data) {
-          if (!(yield* runActions([
-            { name: 'press', key: 'Control+O' },
-            {
-              name: 'fill',
-              value: state.data,
-              on: { selector: '#game', role: 'textbox' },
-            },
-            { name: 'press', key: 'Enter' },
-          ]))) break;
-        }
-
-        state = {
-          type: 'idle',
-          count: 0,
-        };
-        break;
-      }
-      case 'idle': {
-        const noopResult = yield Action.noop;
-        if (noopResult.name === 'closed') {
-          state = { type: 'closed' };
-          break;
-        }
-
-        if (noopResult.name === 'idle' && !noopResult.url.startsWith('https://orteil.dashnet.org/cookieclicker/')) {
-          state = { type: 'initialize', data: gameData };
-          break;
-        }
-
-        const sightData = noopResult.name === 'idle' ? noopResult.state : undefined;
-
-        if (!listeners.isSilent()) {
-          hasReloadedForShoten = false;
-        } else if ((sightData as any)?.title?.includes('昇天中') && !hasReloadedForShoten) {
-          hasReloadedForShoten = true;
-          state = { type: 'initialize', data: gameData };
-          break;
-        }
-
-        const clickableElementIds = Array.isArray((sightData as any)?.clickableElementIds)
-          ? (sightData as any).clickableElementIds as string[]
-          : ['bigCookie'];
-        const candidateIds = listeners.isSilent()
-          ? ['bigCookie']
-          : clickableElementIds.length > 0 ? clickableElementIds : ['bigCookie'];
-        const targetId = candidateIds[Math.floor(Math.random() * candidateIds.length)]!;
-
-        if (!(yield* runActions([Action.clickByElementId(targetId)]))) break;
-
-        state = state.count >= 1_000 ?
-          {
-            type: 'save',
-            failureCount: 0,
-          } :
-          {
-            ...state,
-            count: state.count + 1,
-          };
-        break;
-      }
-      case 'save': {
-        {
-          const actions = [
-            Action.clickByText('オプション'),
-            Action.clickByText('セーブをエクスポート'),
-          ];
-
-          if (!(yield* runActions(actions))) {
-            if (state.type === 'save') {
-              state = bumpFailureCount(state);
-            }
-            break;
-          }
-        }
-
-        {
-          const result = yield Action.noop;
-          if (result.name === 'idle' && result.selectedText) {
-            const text = result.selectedText ?? '';
-            gameData = text;
-            listeners.onSave.forEach(f => f(text));
-          }
-        }
-
-        {
-          const actions = [
-            { name: 'press', key: 'Escape' },
-          ] as const;
-
-          if (!(yield* runActions(actions))) {
-            if (state.type === 'save') {
-              state = bumpFailureCount(state);
-            }
-            break;
-          }
-        }
-        state = { type: 'seeStats', failureCount: 0 };
-        break;
-      }
-      case 'seeStats': {
-        const actions = [
-          Action.clickByText('記録'),
-          Action.noop,
-        ];
-
-        if (!(yield* runActions(actions))) {
-          if (state.type === 'seeStats') {
-            state = bumpFailureCount(state);
-          }
-          break;
-        }
-
-        state = {
-          type: 'idle',
-          count: 0,
-        };
-        break;
-      }
-      default: {
-        const _: never = state;
-        throw new Error('unreachable');
-      }
-    }
+    closed = false;
+    state = yield* machine[state.type].run(state as never, ctx);
   }
 }


### PR DESCRIPTION
- Extract step*/handle* with phase for initialize, idle, save, seeStats
- Dispatch via machine; pure transitions via stateAfter* and States/hydrate
- Lift runActions to module scope and unit-test it directly
- Stream-oriented stats: initialize to seeStats; sidebar shows generation/clicks
- Expand solver tests; solver.ts coverage at least 90% funcs and lines
