### PR TITLE
feat(cookieclicker): learn news ticker lines from sight and seed idle speech

### DIFF
--- a/lib/Agent/games/org.dashnet.orteil/cookieclicker/State.ts
+++ b/lib/Agent/games/org.dashnet.orteil/cookieclicker/State.ts
@@ -66,6 +66,8 @@ export type State = {
   isWrinkled: boolean
   ascendNumber: number
   commentsText?: string
+  /** News ticker lines (#commentsText1 / #commentsText2). */
+  newsLines?: string[]
   store: {
     products: {
       bulkMode: 'buy' | 'sell'

--- a/lib/Agent/games/org.dashnet.orteil/cookieclicker/server.test.ts
+++ b/lib/Agent/games/org.dashnet.orteil/cookieclicker/server.test.ts
@@ -3,6 +3,7 @@ import {
   buildSightResult,
   collectClickableElementIds,
   enrichStatisticsGeneral,
+  parseNewsLines,
 } from "./server";
 import type { ElementLike, SightRawData } from "./server";
 
@@ -197,6 +198,8 @@ const baseSightRawData: SightRawData = {
   cpsIsWrinkled: false,
   ascendNumberText: undefined,
   commentsText: undefined,
+  commentsText1: undefined,
+  commentsText2: undefined,
   storeBulkModeSelectedId: undefined,
   statisticsGeneralListings: undefined,
   url: 'https://example.com',
@@ -306,6 +309,36 @@ it('enriches Japanese statistics keys with parsed numbers', () => {
     });
   });
 
+
+  it("builds newsLines from child lines", () => {
+    const result = buildSightResult({
+      ...baseSightRawData,
+      commentsText1: "ニュース1",
+      commentsText2: "ニュース2",
+      commentsText: "親の全文",
+    });
+    expect(result.newsLines).toEqual(["ニュース1", "ニュース2"]);
+  });
+
+  it("builds newsLines from commentsText fallback when child lines are empty", () => {
+    const result = buildSightResult({
+      ...baseSightRawData,
+      commentsText1: undefined,
+      commentsText2: "  ",
+      commentsText: "一行目\n二行目\n",
+    });
+    expect(result.newsLines).toEqual(["一行目", "二行目"]);
+  });
+
+  it("builds empty newsLines when no news text is present", () => {
+    const result = buildSightResult({
+      ...baseSightRawData,
+      commentsText1: undefined,
+      commentsText2: undefined,
+      commentsText: undefined,
+    });
+    expect(result.newsLines).toEqual([]);
+  });
   it('sets statistics to undefined when no listings are provided', () => {
     const result = buildSightResult({ ...baseSightRawData, statisticsGeneralListings: undefined });
     expect(result.statistics).toBeUndefined();
@@ -391,5 +424,17 @@ describe('enrichStatisticsGeneral', () => {
       'Cookie clicks': { innerText: ' 42' },
       '所有建物：': { innerText: ' 457' },
     });
+  });
+});
+
+describe("parseNewsLines", () => {
+  it("prefers child lines over fallback", () => {
+    expect(parseNewsLines("行1", "行2", "無視\nされる")).toEqual(["行1", "行2"]);
+  });
+  it("falls back to splitting commentsText", () => {
+    expect(parseNewsLines(undefined, undefined, "a\nb\n")).toEqual(["a", "b"]);
+  });
+  it("drops empty lines", () => {
+    expect(parseNewsLines("  ", "本体", undefined)).toEqual(["本体"]);
   });
 });

--- a/lib/Agent/games/org.dashnet.orteil/cookieclicker/server.ts
+++ b/lib/Agent/games/org.dashnet.orteil/cookieclicker/server.ts
@@ -94,6 +94,8 @@ export type SightRawData = {
   cpsIsWrinkled: boolean;
   ascendNumberText: string | undefined;
   commentsText: string | undefined;
+  commentsText1: string | undefined;
+  commentsText2: string | undefined;
   storeBulkModeSelectedId: string | undefined;
   statisticsGeneralListings: Array<{ key: string; innerText: string }> | undefined;
   url: string;
@@ -174,6 +176,27 @@ export function enrichSightState<T extends { statistics?: { general?: Record<str
     },
   };
 }
+
+/**
+ * Cookie Clicker news ticker lines.
+ * Prefer per-line elements; fall back to splitting parent commentsText.
+ */
+export const parseNewsLines = (
+  line1?: string,
+  line2?: string,
+  fallbackCommentsText?: string,
+): string[] => {
+  const fromChildren = [line1, line2]
+    .map((s) => s?.normalize("NFC").trim() ?? "")
+    .filter((s) => s.length > 0);
+  if (fromChildren.length > 0) return fromChildren;
+  if (!fallbackCommentsText) return [];
+  return fallbackCommentsText
+    .normalize("NFC")
+    .split(/\r?\n/u)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+};
 export const buildSightResult = (data: SightRawData) => {
   const parseNumber = (text?: string): number =>
     text ? Number.parseFloat(text.replaceAll(',', '')) : Number.NaN;
@@ -204,6 +227,11 @@ export const buildSightResult = (data: SightRawData) => {
     isWrinkled: data.cpsIsWrinkled,
     ascendNumber: parseNumber(data.ascendNumberText),
     commentsText: data.commentsText,
+    newsLines: parseNewsLines(
+      data.commentsText1,
+      data.commentsText2,
+      data.commentsText,
+    ),
     store: {
       products: {
         bulkMode: parseBulkMode(data.storeBulkModeSelectedId),
@@ -329,6 +357,17 @@ export const sight = () => {
     isWrinkled: cookiesPerSecond?.classList.contains('wrinkled') ?? false,
     ascendNumber: parseNumber(document.getElementById('ascendNumber')?.innerText.replaceAll(',', '')),
     commentsText: document.getElementById('commentsText')?.innerText,
+    newsLines: (() => {
+      const commentsText1 = document.getElementById('commentsText1')?.innerText;
+      const commentsText2 = document.getElementById('commentsText2')?.innerText;
+      const commentsText = document.getElementById('commentsText')?.innerText;
+      const fromChildren = [commentsText1, commentsText2]
+        .map((s) => (s ?? '').trim())
+        .filter((s) => s.length > 0);
+      if (fromChildren.length > 0) return fromChildren;
+      if (!commentsText) return [];
+      return commentsText.split(/\r?\n/).map((s) => s.trim()).filter((s) => s.length > 0);
+    })(),
     store: {
       products: {
         bulkMode: parseBulkMode(

--- a/lib/Agent/index.ts
+++ b/lib/Agent/index.ts
@@ -6,6 +6,7 @@ import { SpeechQueue, type SpeechEvent } from "../application/SpeechQueue";
 import { StreamApplicationService } from "../application/StreamApplicationService";
 import type { TalkModelGenerateResult as AppTalkModelGenerateResult } from "../application/types";
 import { evaluateSpeechable } from "../domain/broadcasting/SilencePolicy";
+import { pickTopic } from "../domain/comments/TopicPicker";
 export const SILENCE_THRESHOLD_MS = 5 * 60 * 1_000; // 5 minutes
 
 /**
@@ -26,6 +27,10 @@ export class MakaMujo {
    * Empty → generate("") (legacy random seed).
    */
   #nextStart: string[] = [];
+  /** In-process set of news lines already learned (at most once). */
+  #learnedNewsLines = new Set<string>();
+  /** Latest news lines from sight (for spontaneous topic). */
+  #currentNewsLines: string[] = [];
 
   constructor(talkModel: TalkModel, tts: TTS) {
     this.#talkModel = talkModel;
@@ -47,7 +52,24 @@ export class MakaMujo {
       this.#session,
       () => this.speechable,
       () => this.#notifyGameStateChangeAsync(),
+      (sightState) => this.#onGameSight(sightState),
     );
+  }
+
+  #onGameSight(sightState: Record<string, unknown>): void {
+    const raw = sightState.newsLines;
+    const lines = Array.isArray(raw)
+      ? raw
+          .filter((x): x is string => typeof x === "string" && x.trim().length > 0)
+          .map((s) => s.normalize("NFC").trim())
+      : [];
+    this.#currentNewsLines = lines;
+
+    for (const line of lines) {
+      if (this.#learnedNewsLines.has(line)) continue;
+      this.#talkModel.learn(`${line}。`);
+      this.#learnedNewsLines.add(line);
+    }
   }
 
   play(name: Parameters<GameplayApplicationService["play"]>[0], data?: string) {
@@ -71,7 +93,11 @@ export class MakaMujo {
       // Spontaneous / continuation: AGT gen accepts a single bos token.
       const pending = this.#nextStart;
       this.#nextStart = [];
-      const start = pending.length > 0 ? pending[pending.length - 1]! : "";
+      let start = pending.length > 0 ? pending[pending.length - 1]! : "";
+      if (!start && this.#currentNewsLines.length > 0) {
+        const newsText = this.#currentNewsLines.join("");
+        start = pickTopic(newsText) ?? "";
+      }
       const ret = this.#talkModel.generate(start, session.currentNGramSize);
       if (typeof ret === "string") {
         const text =

--- a/lib/application/GameplayApplicationService.ts
+++ b/lib/application/GameplayApplicationService.ts
@@ -11,15 +11,18 @@ export class GameplayApplicationService {
   #session: AgentSession;
   #isSpeechable: () => boolean;
   #notifyGameStateChange: () => void;
+  #onGameSight?: (sightState: Record<string, unknown>) => void;
 
   constructor(
     session: AgentSession,
     isSpeechable: () => boolean,
     notifyGameStateChange: () => void,
+    onGameSight?: (sightState: Record<string, unknown>) => void,
   ) {
     this.#session = session;
     this.#isSpeechable = isSpeechable;
     this.#notifyGameStateChange = notifyGameStateChange;
+    this.#onGameSight = onGameSight;
   }
 
   play(name: GameName, data?: string): void {
@@ -57,6 +60,7 @@ export class GameplayApplicationService {
               },
             };
             this.#notifyGameStateChange();
+            this.#onGameSight?.(nextState);
           }
         }
 


### PR DESCRIPTION
Parse news lines in sight (commentsText1/2 with commentsText fallback),
learn each unique line at most once per process via MakaMujo, and use
pickTopic on current news for spontaneous speech. Comment replies unchanged.
