### PR TITLE
fix: pick news speech topics uniformly from word candidates

### DIFF
--- a/lib/Agent/index.ts
+++ b/lib/Agent/index.ts
@@ -6,7 +6,7 @@ import { SpeechQueue, type SpeechEvent } from "../application/SpeechQueue";
 import { StreamApplicationService } from "../application/StreamApplicationService";
 import type { TalkModelGenerateResult as AppTalkModelGenerateResult } from "../application/types";
 import { evaluateSpeechable } from "../domain/broadcasting/SilencePolicy";
-import { pickTopic } from "../domain/comments/TopicPicker";
+import { pickRandomFrom, segmentWords } from "../domain/comments/TopicPicker";
 export const SILENCE_THRESHOLD_MS = 5 * 60 * 1_000; // 5 minutes
 
 /**
@@ -103,7 +103,7 @@ export class MakaMujo {
 
     // News: same as comment — generate(topic) then speech(generated) (no strip).
     if (pending.length === 0 && this.#currentNewsLines.length > 0) {
-      const topic = pickTopic(this.#currentNewsLines.join(""));
+      const topic = pickRandomFrom(segmentWords(this.#currentNewsLines.join("")));
       if (topic) {
         await this.speech(
           this.#talkModel.generate(topic, session.currentNGramSize),

--- a/lib/domain/comments/TopicPicker.ts
+++ b/lib/domain/comments/TopicPicker.ts
@@ -1,4 +1,10 @@
-const jaJP = new Intl.Locale("ja-JP");
+﻿const jaJP = new Intl.Locale("ja-JP");
+
+/** 単語セグメントに分割（呼び出し側で候補を組み立てる用） */
+export const segmentWords = (text: string): string[] =>
+  Array.from(new Intl.Segmenter(jaJP, { granularity: "word" }).segment(text))
+    .map(({ segment }) => segment)
+    .filter((s) => s.trim().length > 0);
 
 /**
  * Pick a reply topic from comment text: longest grapheme-length word segments;
@@ -6,12 +12,26 @@ const jaJP = new Intl.Locale("ja-JP");
  * Default RNG is Math.random (behavior-preserving).
  */
 export const pickTopic = (text: string, random: () => number = Math.random): string | undefined => {
-  const words = Array.from(new Intl.Segmenter(jaJP, { granularity: "word" }).segment(text))
-    .map(({ segment }) => segment);
+  const words = segmentWords(text);
+  if (words.length === 0) return undefined;
+
   const cands = words.reduce<string[]>((prev, s) => {
     const a = [...s].length;
     const b = [...(prev[0] ?? "")].length;
     return a > b ? [s] : a === b ? [...prev, s] : prev;
-  }, [""]);
-  return cands.at(Math.floor(random() * cands.length));
+  }, []);
+
+  return pickRandomFrom(cands, random);
+};
+
+/**
+ * 乱択: 候補を引数で受け取り、一様に1つ選ぶ。
+ * ゲーム内ニュース起点の発話などで使用。
+ */
+export const pickRandomFrom = <T>(
+  candidates: readonly T[],
+  random: () => number = Math.random,
+): T | undefined => {
+  if (candidates.length === 0) return undefined;
+  return candidates[Math.floor(random() * candidates.length)];
 };


### PR DESCRIPTION
Game-news spontaneous speech now uses pickRandomFrom(segmentWords(...))
instead of longest-word pickTopic, which over-selected long katakana.
Comment replies keep pickTopic unchanged.
